### PR TITLE
feat: add POST /readings endpoint with Bearer token auth

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/fishhub-oss/fishhub-server/internal/store"
+)
+
+type contextKey string
+
+const deviceContextKey contextKey = "device"
+
+func Authenticator(devices store.DeviceStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := bearerToken(r)
+			if token == "" {
+				http.Error(w, "missing or malformed authorization header", http.StatusUnauthorized)
+				return
+			}
+
+			info, err := devices.LookupByToken(r.Context(), token)
+			if errors.Is(err, store.ErrTokenNotFound) {
+				http.Error(w, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			if err != nil {
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), deviceContextKey, info)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func DeviceFromContext(ctx context.Context) (store.DeviceInfo, bool) {
+	info, ok := ctx.Value(deviceContextKey).(store.DeviceInfo)
+	return info, ok
+}
+
+func bearerToken(r *http.Request) string {
+	header := r.Header.Get("Authorization")
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,88 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/store"
+)
+
+type stubDeviceStore struct {
+	info store.DeviceInfo
+	err  error
+}
+
+func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (store.DeviceInfo, error) {
+	return s.info, s.err
+}
+
+func TestAuthenticator(t *testing.T) {
+	validInfo := store.DeviceInfo{DeviceID: "device-uuid", UserID: "user-uuid"}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info, ok := auth.DeviceFromContext(r.Context())
+		if !ok {
+			http.Error(w, "no device in context", http.StatusInternalServerError)
+			return
+		}
+		if info.DeviceID != validInfo.DeviceID {
+			http.Error(w, "wrong device", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("valid token passes through with device in context", func(t *testing.T) {
+		mw := auth.Authenticator(&stubDeviceStore{info: validInfo})
+		req := httptest.NewRequest(http.MethodPost, "/readings", nil)
+		req.Header.Set("Authorization", "Bearer validtoken")
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing authorization header returns 401", func(t *testing.T) {
+		mw := auth.Authenticator(&stubDeviceStore{info: validInfo})
+		req := httptest.NewRequest(http.MethodPost, "/readings", nil)
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid token returns 401", func(t *testing.T) {
+		mw := auth.Authenticator(&stubDeviceStore{err: store.ErrTokenNotFound})
+		req := httptest.NewRequest(http.MethodPost, "/readings", nil)
+		req.Header.Set("Authorization", "Bearer badtoken")
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("malformed authorization header returns 401", func(t *testing.T) {
+		mw := auth.Authenticator(&stubDeviceStore{info: validInfo})
+		req := httptest.NewRequest(http.MethodPost, "/readings", nil)
+		req.Header.Set("Authorization", "notbearer token")
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+}

--- a/internal/handler/readings.go
+++ b/internal/handler/readings.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/senml"
+	"github.com/go-chi/render"
+)
+
+type ReadingsHandler struct{}
+
+func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
+	device, ok := auth.DeviceFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	reading, err := senml.Parse(body)
+	if err != nil {
+		if errors.Is(err, senml.ErrEmptyPayload) ||
+			errors.Is(err, senml.ErrMissingBaseTime) ||
+			errors.Is(err, senml.ErrMissingTemperature) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("reading: device_id=%s temperature=%.2f bt=%d",
+		device.DeviceID, reading.Temperature, reading.BaseTime)
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, map[string]string{})
+}

--- a/internal/handler/readings_test.go
+++ b/internal/handler/readings_test.go
@@ -1,0 +1,103 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/handler"
+	"github.com/fishhub-oss/fishhub-server/internal/store"
+)
+
+func requestWithDevice(method, target, body string, device store.DeviceInfo) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), contextKey("device"), device)
+	// inject via the exported helper path so we don't duplicate the key
+	_ = ctx
+	// use auth package to inject properly via a minimal middleware
+	return req
+}
+
+func withDevice(r *http.Request, info store.DeviceInfo) *http.Request {
+	type stubDS struct{ info store.DeviceInfo }
+	// Build context directly using the same key auth uses, via a one-shot middleware
+	called := false
+	var enriched *http.Request
+	mw := auth.Authenticator(&deviceStoreStub{info: info})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enriched = r
+		called = true
+	})
+	r.Header.Set("Authorization", "Bearer anytoken")
+	w := httptest.NewRecorder()
+	mw(inner).ServeHTTP(w, r)
+	if !called {
+		panic("middleware did not call next")
+	}
+	return enriched
+}
+
+type deviceStoreStub struct{ info store.DeviceInfo }
+
+func (s *deviceStoreStub) LookupByToken(_ context.Context, _ string) (store.DeviceInfo, error) {
+	return s.info, nil
+}
+
+type contextKey string
+
+const validSenML = `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4}]}]`
+
+func TestReadingsHandler_Create(t *testing.T) {
+	h := &handler.ReadingsHandler{}
+	device := store.DeviceInfo{DeviceID: "device-uuid", UserID: "user-uuid"}
+
+	t.Run("valid payload returns 201", func(t *testing.T) {
+		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML)), device)
+		w := httptest.NewRecorder()
+		h.Create(w, req)
+		if w.Code != http.StatusCreated {
+			t.Errorf("expected 201, got %d", w.Code)
+		}
+	})
+
+	t.Run("malformed JSON returns 400", func(t *testing.T) {
+		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(`not json`)), device)
+		w := httptest.NewRecorder()
+		h.Create(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing base time returns 400", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","e":[{"n":"temperature","u":"Cel","v":23.4}]}]`
+		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(body)), device)
+		w := httptest.NewRecorder()
+		h.Create(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing temperature returns 400", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"humidity","u":"%RH","v":55}]}]`
+		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(body)), device)
+		w := httptest.NewRecorder()
+		h.Create(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("no device in context returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML))
+		w := httptest.NewRecorder()
+		h.Create(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+}

--- a/internal/senml/senml.go
+++ b/internal/senml/senml.go
@@ -1,0 +1,52 @@
+package senml
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrEmptyPayload       = errors.New("payload must contain at least one record")
+	ErrMissingBaseTime    = errors.New("missing or zero base time (bt)")
+	ErrMissingTemperature = errors.New("no temperature entry found in payload")
+)
+
+type Entry struct {
+	Name  string  `json:"n"`
+	Unit  string  `json:"u"`
+	Value float64 `json:"v"`
+}
+
+type Record struct {
+	BaseName string  `json:"bn"`
+	BaseTime int64   `json:"bt"`
+	Entries  []Entry `json:"e"`
+}
+
+type Reading struct {
+	Temperature float64
+	BaseTime    int64
+}
+
+func Parse(body []byte) (Reading, error) {
+	var records []Record
+	if err := json.Unmarshal(body, &records); err != nil {
+		return Reading{}, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if len(records) == 0 {
+		return Reading{}, ErrEmptyPayload
+	}
+
+	rec := records[0]
+	if rec.BaseTime == 0 {
+		return Reading{}, ErrMissingBaseTime
+	}
+
+	for _, e := range rec.Entries {
+		if e.Name == "temperature" {
+			return Reading{Temperature: e.Value, BaseTime: rec.BaseTime}, nil
+		}
+	}
+	return Reading{}, ErrMissingTemperature
+}

--- a/internal/senml/senml_test.go
+++ b/internal/senml/senml_test.go
@@ -1,0 +1,60 @@
+package senml_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/senml"
+)
+
+func TestParse(t *testing.T) {
+	valid := `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4}]}]`
+
+	t.Run("valid payload", func(t *testing.T) {
+		r, err := senml.Parse([]byte(valid))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if r.Temperature != 23.4 {
+			t.Errorf("expected 23.4, got %v", r.Temperature)
+		}
+		if r.BaseTime != 1713000000 {
+			t.Errorf("expected bt 1713000000, got %v", r.BaseTime)
+		}
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, err := senml.Parse([]byte(`not json`))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		_, err := senml.Parse([]byte(`[]`))
+		if !errors.Is(err, senml.ErrEmptyPayload) {
+			t.Errorf("expected ErrEmptyPayload, got %v", err)
+		}
+	})
+
+	t.Run("missing base time", func(t *testing.T) {
+		_, err := senml.Parse([]byte(`[{"bn":"fishhub/device/","e":[{"n":"temperature","u":"Cel","v":23.4}]}]`))
+		if !errors.Is(err, senml.ErrMissingBaseTime) {
+			t.Errorf("expected ErrMissingBaseTime, got %v", err)
+		}
+	})
+
+	t.Run("missing temperature entry", func(t *testing.T) {
+		_, err := senml.Parse([]byte(`[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"humidity","u":"%RH","v":55}]}]`))
+		if !errors.Is(err, senml.ErrMissingTemperature) {
+			t.Errorf("expected ErrMissingTemperature, got %v", err)
+		}
+	})
+
+	t.Run("empty entries", func(t *testing.T) {
+		_, err := senml.Parse([]byte(`[{"bn":"fishhub/device/","bt":1713000000,"e":[]}]`))
+		if !errors.Is(err, senml.ErrMissingTemperature) {
+			t.Errorf("expected ErrMissingTemperature, got %v", err)
+		}
+	})
+}

--- a/internal/store/devices.go
+++ b/internal/store/devices.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+var ErrTokenNotFound = errors.New("token not found")
+
+type DeviceInfo struct {
+	DeviceID string
+	UserID   string
+}
+
+type DeviceStore interface {
+	LookupByToken(ctx context.Context, token string) (DeviceInfo, error)
+}
+
+type postgresDeviceStore struct {
+	db *sql.DB
+}
+
+func NewDeviceStore(db *sql.DB) DeviceStore {
+	return &postgresDeviceStore{db: db}
+}
+
+func (s *postgresDeviceStore) LookupByToken(ctx context.Context, token string) (DeviceInfo, error) {
+	var info DeviceInfo
+	err := s.db.QueryRowContext(ctx, `
+		SELECT d.id, d.user_id
+		FROM device_tokens dt
+		JOIN devices d ON d.id = dt.device_id
+		WHERE dt.token = $1
+	`, token).Scan(&info.DeviceID, &info.UserID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return DeviceInfo{}, ErrTokenNotFound
+	}
+	if err != nil {
+		return DeviceInfo{}, fmt.Errorf("lookup token: %w", err)
+	}
+	return info, nil
+}

--- a/internal/store/devices_integration_test.go
+++ b/internal/store/devices_integration_test.go
@@ -1,0 +1,45 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appdb "github.com/fishhub-oss/fishhub-server/internal/db"
+	"github.com/fishhub-oss/fishhub-server/internal/store"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+	_ "github.com/lib/pq"
+)
+
+func TestLookupByToken_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	devices := store.NewDeviceStore(db)
+	tokens := store.NewTokenStore(db)
+	ctx := context.Background()
+	userID := appdb.SeedUserID()
+
+	t.Run("returns device info for valid token", func(t *testing.T) {
+		result, err := tokens.CreateToken(ctx, userID)
+		if err != nil {
+			t.Fatalf("setup: create token: %v", err)
+		}
+
+		info, err := devices.LookupByToken(ctx, result.Token)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.DeviceID != result.DeviceID {
+			t.Errorf("expected device_id %s, got %s", result.DeviceID, info.DeviceID)
+		}
+		if info.UserID != userID {
+			t.Errorf("expected user_id %s, got %s", userID, info.UserID)
+		}
+	})
+
+	t.Run("returns ErrTokenNotFound for unknown token", func(t *testing.T) {
+		_, err := devices.LookupByToken(ctx, "0000000000000000000000000000000000000000000000000000000000000000")
+		if !errors.Is(err, store.ErrTokenNotFound) {
+			t.Errorf("expected ErrTokenNotFound, got %v", err)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	appdb "github.com/fishhub-oss/fishhub-server/internal/db"
 	"github.com/fishhub-oss/fishhub-server/internal/handler"
 	"github.com/fishhub-oss/fishhub-server/internal/store"
@@ -33,10 +34,15 @@ func main() {
 		Store:  store.NewTokenStore(db),
 		UserID: appdb.SeedUserID(),
 	}
+	readings := &handler.ReadingsHandler{}
 
 	r := chi.NewRouter()
 	r.Get("/health", handler.Health)
 	r.Post("/tokens", tokens.Create)
+	r.Group(func(r chi.Router) {
+		r.Use(auth.Authenticator(store.NewDeviceStore(db)))
+		r.Post("/readings", readings.Create)
+	})
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
Closes #3.

## What changed

Implements the core ingest endpoint the ESP32 will POST to on each wake cycle.

**`internal/senml`** — SenML RFC 8428 parser. Validates presence of `bt` and a `temperature` entry, returns typed sentinel errors for 400 cases.

**`internal/store/devices.go`** — `DeviceStore` interface + `LookupByToken` query (joins `device_tokens` → `devices`). Returns `ErrTokenNotFound` for unknown tokens.

**`internal/auth/middleware.go`** — chi middleware that extracts the Bearer token, validates it via `DeviceStore`, and injects `DeviceInfo` into the request context.

**`internal/handler/readings.go`** — reads `DeviceInfo` from context, parses SenML body, logs the reading to stdout, returns 201.

## Testing
```sh
# create a token first
TOKEN=$(curl -s -X POST http://localhost:8080/tokens | jq -r .token)

# post a reading
curl -s -X POST http://localhost:8080/readings \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4}]}]'
```