### PR TITLE
docs: add server documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# fishhub-server — Claude Code Instructions
+
+## What this repo is
+
+Go HTTP backend for FishHub. Receives temperature readings from ESP32 devices, authenticates them via Bearer tokens, and stores data for visualization. See `docs/index.md` for a full overview.
+
+## Read the docs first
+
+**Before making any changes, read the relevant docs:**
+
+| File | When to read |
+|------|-------------|
+| `docs/index.md` | Always — start here |
+| `docs/architecture.md` | Before touching package structure, handlers, or middleware |
+| `docs/api.md` | Before adding or modifying endpoints |
+| `docs/database.md` | Before adding migrations or changing schema |
+| `docs/auth.md` | Before touching token logic or the auth middleware |
+| `docs/development.md` | Before running or testing the server |
+
+## Workflow
+
+1. Before starting any issue, create a plan file in `../planning/` (e.g. `../planning/server-04-influxdb.md`).
+2. Discuss the plan with the user before executing.
+3. Implement only after the user approves.
+4. Never commit directly to `main`. Always create a feature branch, commit there, and open a PR.
+5. After completing an issue, move the corresponding GitHub issue to the Done column on the FishHub PoC project (`org: fishhub-oss`, project ID 1).
+
+## Git conventions
+
+- **Branch naming:** `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `docs/<slug>`
+- **Commit style:** [Conventional Commits](https://www.conventionalcommits.org/)
+  - `feat:` new feature
+  - `fix:` bug fix
+  - `chore:` tooling, config, deps
+  - `refactor:` code change with no behavior change
+  - `docs:` documentation only
+- **PRs:** descriptive but concise — what changed and why. Always use `Closes #<n>` in the PR body.
+
+## GitHub
+
+- Org: `fishhub-oss`
+- Repo: `fishhub-oss/fishhub-server`
+- Project board: https://github.com/orgs/fishhub-oss/projects/1
+- Issues assigned to: `renanmzmendes`
+
+## Architecture principles
+
+- **Dependency injection everywhere**: every dependency (DB, external clients, etc.) must be injected, never instantiated inline.
+- **Depend on interfaces, not concrete types**: define the smallest interface the caller needs; pass it by interface at construction time. This applies to handlers, stores, and any service layer.
+
+## Key conventions
+
+- Router: `chi` v5
+- Database: Postgres (application data) via `golang-migrate` for schema migrations
+- Metrics: InfluxDB (time-series readings)
+- Wire format for sensor readings: **SenML JSON (RFC 8428)**
+- Auth: **Bearer token** (random 32-byte hex), one token per device
+- New stores go in `internal/store/`, new handlers in `internal/handler/`
+- Integration tests use `testutil.NewTestDB(t)` — never mock the database

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-.PHONY: run build
+.PHONY: run build dev
+
+DATABASE_URL ?= postgres://fishhub:fishhub@localhost:5432/fishhub?sslmode=disable
 
 build:
 	go build -o bin/server ./...
 
 run:
-	go run ./...
+	DATABASE_URL=$(DATABASE_URL) go run ./...
+
+dev:
+	docker compose up -d
+	until docker compose exec postgres pg_isready -U fishhub; do sleep 1; done
+	DATABASE_URL=$(DATABASE_URL) go run ./...

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,77 @@
+# API Reference
+
+Base URL: `http://localhost:8080` (development)
+
+---
+
+## GET /health
+
+Health check. No authentication required.
+
+**Response `200`**
+```json
+{"status": "ok"}
+```
+
+---
+
+## POST /tokens
+
+Creates a new device and issues an authentication token for it. The token is what gets hardcoded into the ESP32 firmware (`DEVICE_TOKEN` in `config.h`).
+
+No request body required. The token is always created for the seed user (`admin@fishhub.local`).
+
+**Response `201`**
+```json
+{
+  "token":     "b0a1aba84035c6844d739100e3a93f5911f7ecaf82cbf5bbb33306a1509854a5",
+  "device_id": "a1b2c3d4-...",
+  "user_id":   "00000000-0000-0000-0000-000000000001"
+}
+```
+
+| Field | Description |
+|---|---|
+| `token` | 64-char hex string. Copy this into `config.h` as `DEVICE_TOKEN`. |
+| `device_id` | UUID of the newly created device record. |
+| `user_id` | UUID of the owning user (always the seed user for the PoC). |
+
+**Response `500`** — internal error (DB failure)
+
+---
+
+## POST /readings
+
+Accepts a SenML temperature reading from an authenticated device.
+
+**Headers**
+```
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**Request body** — SenML JSON (RFC 8428)
+```json
+[{
+  "bn": "fishhub/device/",
+  "bt": 1713000000,
+  "e": [{"n": "temperature", "u": "Cel", "v": 23.4}]
+}]
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `bn` | string | Base name (device namespace) |
+| `bt` | int64 | Base time — Unix UTC timestamp of the reading |
+| `e[0].n` | string | Must be `"temperature"` |
+| `e[0].u` | string | Unit — must be `"Cel"` |
+| `e[0].v` | float | Temperature in Celsius |
+
+**Response `201`**
+```json
+{}
+```
+
+**Response `400`** — malformed JSON, missing `bt`, or no `temperature` entry
+
+**Response `401`** — missing or invalid Bearer token

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,80 @@
+# Architecture
+
+## Package layout
+
+```
+fishhub-server/
+├── main.go                  # entry point: wires everything together
+├── db/
+│   └── migrations/          # SQL migration files (golang-migrate format)
+└── internal/
+    ├── auth/                # Bearer token middleware, context helpers
+    ├── db/                  # DB connection, migration runner, seed
+    ├── handler/             # HTTP handlers (health, tokens, readings)
+    ├── senml/               # SenML RFC 8428 parser
+    ├── store/               # Data access layer (Postgres)
+    └── testutil/            # Shared test helpers (test DB via testcontainers)
+```
+
+## Dependency graph
+
+```
+main.go
+ ├── internal/db        — open connection, run migrations, seed user
+ ├── internal/store     — TokenStore, DeviceStore (Postgres implementations)
+ ├── internal/auth      — Authenticator middleware (depends on DeviceStore interface)
+ └── internal/handler   — HTTP handlers (depend on store interfaces)
+      └── internal/senml — SenML parsing (pure, no external deps)
+```
+
+`internal/senml` and `internal/testutil` have no dependencies on other internal packages.
+
+## Design principles
+
+**Dependency injection everywhere.** Handlers receive their stores as struct fields. No package-level singletons.
+
+**Depend on interfaces, not concrete types.** Each handler declares the smallest interface it needs. This is why `TokensHandler` has a `TokenStore` field typed as the interface, not `*postgresTokenStore`. Same for `DeviceStore` in the auth middleware.
+
+**Context-based auth.** The auth middleware stores `DeviceInfo` in the request context via `context.WithValue`. Downstream handlers retrieve it with `auth.DeviceFromContext()` — no need to re-query the DB.
+
+**Transactional safety.** Token creation (device row + token row) is wrapped in a single transaction. A failure at any step rolls back cleanly.
+
+## Request lifecycle
+
+### POST /tokens
+```
+TokensHandler.Create
+  └── TokenStore.CreateToken(userID)
+        ├── crypto/rand → 32 bytes → 64-char hex token
+        ├── INSERT INTO devices (user_id)
+        └── INSERT INTO device_tokens (device_id, token)
+  └── 201 {"token":"...","device_id":"...","user_id":"..."}
+```
+
+### POST /readings
+```
+Authenticator middleware
+  ├── parse "Bearer <token>" from Authorization header
+  ├── DeviceStore.LookupByToken(token)
+  │     └── JOIN device_tokens + devices WHERE token = $1
+  ├── 401 if missing or invalid
+  └── store DeviceInfo in request context
+
+ReadingsHandler.Create
+  ├── auth.DeviceFromContext(ctx) → DeviceInfo
+  ├── senml.Parse(body) → Reading{Temperature, BaseTime}
+  ├── 400 on malformed payload
+  ├── log reading (device_id, temperature, base_time)
+  └── 201 {}
+```
+
+### GET /health
+```
+handler.Health → 200 {"status":"ok"}
+```
+
+## What's not yet implemented
+
+- **InfluxDB persistence** — readings are logged to stdout but not stored (issue #4)
+- **Grafana stack** — Docker Compose doesn't include InfluxDB/Grafana yet (issue #5)
+- **Token security** — tokens stored as plaintext; hashing/JWT under evaluation (issue #6)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,33 @@
+# Authentication
+
+## Token lifecycle
+
+1. **Issue a token** — call `POST /tokens`. The server creates a device record and generates a cryptographically random 64-char hex token (32 bytes from `crypto/rand`).
+2. **Flash the token** — copy the token into the ESP32 firmware's `include/config.h` as `DEVICE_TOKEN`.
+3. **Authenticate requests** — the firmware sends `Authorization: Bearer <token>` on every `POST /readings`.
+
+For the PoC there is no revocation mechanism. Tokens are valid until the device row is deleted from the database.
+
+## Middleware (`internal/auth`)
+
+`auth.Authenticator(devices DeviceStore)` returns a chi-compatible middleware that:
+
+1. Reads the `Authorization` header and extracts the token from `"Bearer <token>"` format
+2. Calls `DeviceStore.LookupByToken(ctx, token)` — a single DB query joining `device_tokens` and `devices`
+3. On success, stores `DeviceInfo{DeviceID, UserID}` in the request context
+4. Returns `401 Unauthorized` if the header is missing, malformed, or the token is unknown
+5. Returns `500` on unexpected DB errors
+
+Downstream handlers retrieve the authenticated device with:
+
+```go
+device, ok := auth.DeviceFromContext(r.Context())
+```
+
+## Token storage
+
+Tokens are currently stored as **plaintext** `CHAR(64)` in the `device_tokens` table. This is acceptable for the PoC on a local network.
+
+Issue #6 evaluates two hardening options:
+- **Option A** — hash at rest (bcrypt/SHA-256): protects against DB leaks, still requires a DB lookup per request
+- **Option B** — JWT with device ID in claims: stateless verification, no DB round-trip, but tokens can't be individually revoked without a denylist

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,68 @@
+# Database
+
+FishHub uses **PostgreSQL** for application data (users, devices, tokens). InfluxDB will be added for time-series metrics (issue #4).
+
+## Schema
+
+```
+users
+├── id          UUID  PK  default gen_random_uuid()
+├── email       TEXT  UNIQUE NOT NULL
+└── created_at  TIMESTAMPTZ  default now()
+
+devices
+├── id          UUID  PK  default gen_random_uuid()
+├── user_id     UUID  FK → users.id  NOT NULL
+├── name        TEXT  (nullable)
+└── created_at  TIMESTAMPTZ  default now()
+
+device_tokens
+├── id          UUID  PK  default gen_random_uuid()
+├── device_id   UUID  FK → devices.id  UNIQUE NOT NULL
+├── token       CHAR(64)  UNIQUE NOT NULL
+└── created_at  TIMESTAMPTZ  default now()
+```
+
+**Relationships:**
+- One user → many devices
+- One device → one token (enforced by UNIQUE on `device_id`)
+
+## Migrations
+
+Migrations live in `db/migrations/` and follow the `golang-migrate` naming convention:
+
+```
+NNN_<description>.up.sql
+NNN_<description>.down.sql
+```
+
+They run automatically on server startup via `db.Migrate()`. The current migrations are:
+
+| # | Description |
+|---|---|
+| 001 | Create `users` table |
+| 002 | Create `devices` table |
+| 003 | Create `device_tokens` table |
+
+To add a new migration, create the next numbered pair of `.up.sql` / `.down.sql` files in `db/migrations/`.
+
+## Seed data
+
+On every startup, `db.SeedUser()` inserts a hardcoded admin user (idempotent — uses `ON CONFLICT DO NOTHING`):
+
+| Field | Value |
+|---|---|
+| `id` | `00000000-0000-0000-0000-000000000001` |
+| `email` | `admin@fishhub.local` |
+
+All tokens created via `POST /tokens` are owned by this user. This is intentional for the PoC — no registration flow is needed.
+
+## Connection
+
+The server reads `DATABASE_URL` from the environment:
+
+```
+DATABASE_URL=postgres://fishhub:fishhub@localhost:5432/fishhub?sslmode=disable
+```
+
+The default in the Makefile matches the credentials in `docker-compose.yml`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,77 @@
+# Development Guide
+
+## Prerequisites
+
+- Go 1.21+
+- Docker (for Postgres and integration tests)
+
+## Running locally
+
+```bash
+make dev
+```
+
+This starts Postgres via Docker Compose, waits until it's ready, then runs the server. The server listens on `:8080` by default.
+
+To use a different port:
+```bash
+PORT=9090 make dev
+```
+
+To use a different database:
+```bash
+make dev DATABASE_URL=postgres://user:pass@host/db?sslmode=disable
+```
+
+## Environment variables
+
+| Variable | Default (Makefile) | Description |
+|---|---|---|
+| `DATABASE_URL` | `postgres://fishhub:fishhub@localhost:5432/fishhub?sslmode=disable` | Postgres connection string |
+| `PORT` | `8080` | HTTP listen port |
+
+InfluxDB env vars will be added when issue #4 is implemented.
+
+## Typical first-run workflow
+
+```bash
+make dev                                      # start everything
+
+curl -s -X POST localhost:8080/tokens | jq    # get a token
+# copy "token" value into firmware's config.h as DEVICE_TOKEN
+# copy your machine's local IP into config.h as SERVER_URL
+
+curl -s localhost:8080/health                 # verify server is up
+```
+
+## Testing
+
+**Unit tests** — use stubs, no Docker required:
+```bash
+go test ./internal/handler/... ./internal/senml/... ./internal/auth/...
+```
+
+**Integration tests** — spin up a real Postgres container via testcontainers:
+```bash
+go test ./internal/store/...
+```
+
+**All tests:**
+```bash
+go test ./...
+```
+
+Integration tests require Docker to be running. Each test gets its own throwaway container with a clean schema — no shared state between tests.
+
+## Adding a new migration
+
+1. Create `db/migrations/NNN_<description>.up.sql` and `NNN_<description>.down.sql`
+2. Migrations run automatically on the next `make dev` / server startup
+
+## Project conventions
+
+- All dependencies injected via struct fields — no package-level state
+- Handlers depend on interfaces, not concrete store types
+- New stores go in `internal/store/`, new handlers in `internal/handler/`
+- Integration tests use `testutil.NewTestDB(t)` to get an isolated DB
+- See [architecture.md](architecture.md) for the full picture

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# fishhub-server — Documentation Index
+
+FishHub backend server: receives temperature readings from ESP32 devices, authenticates them via Bearer tokens, and stores data for visualization.
+
+## Contents
+
+| Document | What it covers |
+|---|---|
+| [architecture.md](architecture.md) | Package layout, data flow, design principles |
+| [api.md](api.md) | HTTP endpoints, request/response formats |
+| [database.md](database.md) | Schema, migrations, seed data |
+| [auth.md](auth.md) | Token lifecycle, auth middleware |
+| [development.md](development.md) | Running locally, environment variables, testing |
+
+## Quick start
+
+```bash
+make dev                          # start Postgres + run server
+curl -s -X POST localhost:8080/tokens | jq   # get a device token
+curl -s localhost:8080/health                # verify server is up
+```
+
+## Tech stack
+
+- **Language:** Go
+- **Router:** chi v5
+- **Database:** PostgreSQL (application data) · InfluxDB (metrics, upcoming)
+- **Migrations:** golang-migrate
+- **Tests:** unit (stubs) + integration (testcontainers)


### PR DESCRIPTION
## What changed

Adds a `docs/` folder with five markdown files covering everything an agent (or human) needs to work on this codebase:

| File | Contents |
|---|---|
| `index.md` | Overview and quick-start |
| `architecture.md` | Package layout, dependency graph, design principles, request lifecycle |
| `api.md` | All endpoints with request/response formats and field descriptions |
| `database.md` | Schema, migrations guide, seed data |
| `auth.md` | Token lifecycle, middleware behaviour, current security tradeoffs |
| `development.md` | Running locally, env vars, testing, conventions |

Also includes the `Makefile` improvements (`dev` target with Postgres readiness check) that were developed alongside this work.