### PR TITLE
feat: add Grafana with pre-provisioned datasource and temperature dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ PORT=8080
 INFLUXDB3_HOST=http://localhost:8181
 INFLUXDB3_TOKEN=apiv3_changeme
 INFLUXDB3_DATABASE=readings
+
+# Grafana
+GRAFANA_PASSWORD=admin

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ dev:
 	INFLUX_TOKEN_FILE=$(INFLUX_TOKEN_FILE) docker compose up -d
 	until docker compose exec postgres pg_isready -U fishhub; do sleep 1; done
 	until curl -sf -H "Authorization: Bearer $(INFLUXDB3_TOKEN)" $(INFLUXDB3_HOST)/health > /dev/null; do sleep 1; done
+	until curl -sf http://localhost:3000/api/health > /dev/null; do sleep 1; done
 	go run ./...
 
 influx-setup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,17 @@ services:
     secrets:
       - influxdb-admin-token
 
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      INFLUXDB3_TOKEN: ${INFLUXDB3_TOKEN}
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+
 secrets:
   influxdb-admin-token:
     file: ${INFLUX_TOKEN_FILE}
@@ -34,3 +45,4 @@ secrets:
 volumes:
   postgres_data:
   influxdb_data:
+  grafana_data:

--- a/grafana/provisioning/dashboards/provider.yml
+++ b/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+providers:
+  - name: FishHub
+    folder: FishHub
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana/provisioning/dashboards/temperature.json
+++ b/grafana/provisioning/dashboards/temperature.json
@@ -1,0 +1,160 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fishhub-temperature"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Temperature",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "InfluxDB"
+                      },
+                      "spec": {
+                        "measurement": "sensors",
+                        "orderByTime": "ASC",
+                        "policy": "readings",
+                        "query": "SELECT mean(\"temperature\") FROM \"sensors\" WHERE $timeFilter GROUP BY time($__interval), \"device_id\" fill(none)",
+                        "rawQuery": true,
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": ["temperature"],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "mean"
+                            }
+                          ]
+                        ],
+                        "tags": []
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 10,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": ["fishhub"],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-1h",
+      "to": "now",
+      "autoRefresh": "10s",
+      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Temperature",
+    "variables": []
+  }
+}

--- a/grafana/provisioning/datasources/influxdb.yml
+++ b/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8181
+    jsonData:
+      version: InfluxQL
+      httpMode: GET
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Bearer ${INFLUXDB3_TOKEN}
+    database: readings
+    isDefault: true


### PR DESCRIPTION
## Summary

- Adds `grafana` service to `docker-compose.yml` with a named volume and provisioning mount
- Pre-provisions InfluxDB datasource (InfluxQL over HTTP, Bearer token via `INFLUXDB3_TOKEN`)
- Pre-provisions a temperature time-series dashboard (one line per `device_id`)
- Adds Grafana health check wait to `make dev`
- Documents `GRAFANA_PASSWORD` in `.env.example`

Running `make dev` now brings up Postgres, InfluxDB, and Grafana. Navigating to `http://localhost:3000` shows the FishHub temperature dashboard with live data — no manual setup required.

Closes #5