### PR TITLE
feat: users table provider columns + auth domain package

### DIFF
--- a/db/migrations/004_add_provider_to_users.down.sql
+++ b/db/migrations/004_add_provider_to_users.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+    DROP CONSTRAINT users_provider_sub_unique,
+    DROP COLUMN provider,
+    DROP COLUMN provider_sub;

--- a/db/migrations/004_add_provider_to_users.up.sql
+++ b/db/migrations/004_add_provider_to_users.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN provider     TEXT NOT NULL DEFAULT 'local',
+    ADD COLUMN provider_sub TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE users
+    ADD CONSTRAINT users_provider_sub_unique UNIQUE (provider, provider_sub);

--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -1,0 +1,11 @@
+package auth
+
+import "time"
+
+type User struct {
+	ID          string
+	Email       string
+	Provider    string
+	ProviderSub string
+	CreatedAt   time.Time
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,13 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrUserNotFound = errors.New("user not found")
+
+type UserStore interface {
+	Upsert(ctx context.Context, email, provider, providerSub string) (User, error)
+	FindByID(ctx context.Context, id string) (User, error)
+}

--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewPostgresStore(db *sql.DB) UserStore {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) Upsert(ctx context.Context, email, provider, providerSub string) (User, error) {
+	var u User
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO users (email, provider, provider_sub)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (provider, provider_sub) DO UPDATE
+		    SET email = EXCLUDED.email
+		RETURNING id, email, provider, provider_sub, created_at
+	`, email, provider, providerSub).Scan(&u.ID, &u.Email, &u.Provider, &u.ProviderSub, &u.CreatedAt)
+	if err != nil {
+		return User{}, fmt.Errorf("upsert user: %w", err)
+	}
+	return u, nil
+}
+
+func (s *postgresStore) FindByID(ctx context.Context, id string) (User, error) {
+	var u User
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, email, provider, provider_sub, created_at
+		FROM users
+		WHERE id = $1
+	`, id).Scan(&u.ID, &u.Email, &u.Provider, &u.ProviderSub, &u.CreatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("find user by id: %w", err)
+	}
+	return u, nil
+}

--- a/internal/auth/store_postgres_integration_test.go
+++ b/internal/auth/store_postgres_integration_test.go
@@ -1,0 +1,86 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+)
+
+func TestPostgresStore_Integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := auth.NewPostgresStore(db)
+	ctx := context.Background()
+
+	t.Run("Upsert creates a new user", func(t *testing.T) {
+		u, err := store.Upsert(ctx, "alice@example.com", "google", "google-sub-alice")
+		if err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		if u.ID == "" {
+			t.Error("expected non-empty ID")
+		}
+		if u.Email != "alice@example.com" {
+			t.Errorf("email: got %q, want %q", u.Email, "alice@example.com")
+		}
+		if u.Provider != "google" {
+			t.Errorf("provider: got %q, want %q", u.Provider, "google")
+		}
+		if u.ProviderSub != "google-sub-alice" {
+			t.Errorf("provider_sub: got %q, want %q", u.ProviderSub, "google-sub-alice")
+		}
+	})
+
+	t.Run("Upsert is idempotent", func(t *testing.T) {
+		first, err := store.Upsert(ctx, "bob@example.com", "google", "google-sub-bob")
+		if err != nil {
+			t.Fatalf("first upsert: %v", err)
+		}
+		second, err := store.Upsert(ctx, "bob@example.com", "google", "google-sub-bob")
+		if err != nil {
+			t.Fatalf("second upsert: %v", err)
+		}
+		if first.ID != second.ID {
+			t.Errorf("expected same ID on second upsert: got %q and %q", first.ID, second.ID)
+		}
+	})
+
+	t.Run("Upsert updates email on conflict", func(t *testing.T) {
+		_, err := store.Upsert(ctx, "old@example.com", "google", "google-sub-carol")
+		if err != nil {
+			t.Fatalf("initial upsert: %v", err)
+		}
+		updated, err := store.Upsert(ctx, "new@example.com", "google", "google-sub-carol")
+		if err != nil {
+			t.Fatalf("update upsert: %v", err)
+		}
+		if updated.Email != "new@example.com" {
+			t.Errorf("email after update: got %q, want %q", updated.Email, "new@example.com")
+		}
+	})
+
+	t.Run("FindByID returns the correct user", func(t *testing.T) {
+		created, err := store.Upsert(ctx, "dave@example.com", "github", "github-sub-dave")
+		if err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		found, err := store.FindByID(ctx, created.ID)
+		if err != nil {
+			t.Fatalf("find: %v", err)
+		}
+		if found.ID != created.ID {
+			t.Errorf("ID mismatch: got %q, want %q", found.ID, created.ID)
+		}
+		if found.Email != created.Email {
+			t.Errorf("email mismatch: got %q, want %q", found.Email, created.Email)
+		}
+	})
+
+	t.Run("FindByID returns ErrUserNotFound for unknown ID", func(t *testing.T) {
+		_, err := store.FindByID(ctx, "00000000-0000-0000-0000-000000000000")
+		if err != auth.ErrUserNotFound {
+			t.Errorf("expected ErrUserNotFound, got %v", err)
+		}
+	})
+}

--- a/internal/platform/db.go
+++ b/internal/platform/db.go
@@ -47,8 +47,8 @@ func Migrate(db *sql.DB, migrationsPath string) error {
 
 func SeedUser(db *sql.DB) error {
 	_, err := db.Exec(`
-		INSERT INTO users (id, email)
-		VALUES ($1, $2)
+		INSERT INTO users (id, email, provider, provider_sub)
+		VALUES ($1, $2, 'local', 'seed')
 		ON CONFLICT (id) DO NOTHING
 	`, seedUserID, seedUserEmail)
 	return err


### PR DESCRIPTION
## Summary

- Migration `004` adds `provider` and `provider_sub` columns to `users` table with a `UNIQUE (provider, provider_sub)` constraint — no CHECK constraint on provider values so new providers can be added without a migration
- Updates `platform.SeedUser` to explicitly insert `provider='local'`, `provider_sub='seed'`
- New `internal/auth/` domain package: `User` model, `UserStore` interface (`Upsert` + `FindByID`), Postgres implementation, and integration tests (all green)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)