### PR TITLE
feat: session middleware (cookie + Bearer token)

### DIFF
--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -1,6 +1,9 @@
 package auth
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type User struct {
 	ID          string
@@ -8,4 +11,21 @@ type User struct {
 	Provider    string
 	ProviderSub string
 	CreatedAt   time.Time
+}
+
+type Claims struct {
+	UserID string
+}
+
+type contextKey string
+
+const claimsContextKey contextKey = "claims"
+
+func ClaimsFromContext(ctx context.Context) (Claims, bool) {
+	c, ok := ctx.Value(claimsContextKey).(Claims)
+	return c, ok
+}
+
+func ContextWithClaims(ctx context.Context, c Claims) context.Context {
+	return context.WithValue(ctx, claimsContextKey, c)
 }

--- a/internal/platform/middleware.go
+++ b/internal/platform/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 	"github.com/go-chi/render"
 )
@@ -41,6 +42,32 @@ func bearerToken(r *http.Request) string {
 		return ""
 	}
 	return strings.TrimSpace(parts[1])
+}
+
+func SessionAuthenticator(svc auth.AuthService) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := bearerToken(r)
+			if token == "" {
+				if cookie, err := r.Cookie("session"); err == nil {
+					token = cookie.Value
+				}
+			}
+			if token == "" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			userID, err := svc.ValidateSessionJWT(token)
+			if err != nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			ctx := auth.ContextWithClaims(r.Context(), auth.Claims{UserID: userID})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 type HealthResponse struct {

--- a/internal/platform/middleware_test.go
+++ b/internal/platform/middleware_test.go
@@ -2,13 +2,28 @@ package platform_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 )
+
+type stubAuthService struct {
+	userID string
+	err    error
+}
+
+func (s *stubAuthService) VerifyAndUpsert(_ context.Context, _, _ string) (auth.User, error) {
+	return auth.User{}, nil
+}
+func (s *stubAuthService) IssueSessionJWT(_ string) (string, error) { return "", nil }
+func (s *stubAuthService) ValidateSessionJWT(_ string) (string, error) {
+	return s.userID, s.err
+}
 
 type stubDeviceStore struct {
 	info sensors.DeviceInfo
@@ -17,6 +32,83 @@ type stubDeviceStore struct {
 
 func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (sensors.DeviceInfo, error) {
 	return s.info, s.err
+}
+
+func TestSessionAuthenticator(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := auth.ClaimsFromContext(r.Context())
+		if !ok || claims.UserID == "" {
+			http.Error(w, "no claims in context", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("valid JWT via cookie passes through with claims in context", func(t *testing.T) {
+		mw := platform.SessionAuthenticator(&stubAuthService{userID: "user-uuid"})
+		req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+		req.AddCookie(&http.Cookie{Name: "session", Value: "valid.jwt.token"})
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("valid JWT via Bearer header passes through with claims in context", func(t *testing.T) {
+		mw := platform.SessionAuthenticator(&stubAuthService{userID: "user-uuid"})
+		req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+		req.Header.Set("Authorization", "Bearer valid.jwt.token")
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("Bearer header takes precedence over cookie", func(t *testing.T) {
+		// cookie has invalid token, header has valid — should pass
+		mw := platform.SessionAuthenticator(&stubAuthService{userID: "user-uuid"})
+		req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+		req.Header.Set("Authorization", "Bearer valid.jwt.token")
+		req.AddCookie(&http.Cookie{Name: "session", Value: "ignored.cookie"})
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing cookie and no header returns 401", func(t *testing.T) {
+		mw := platform.SessionAuthenticator(&stubAuthService{userID: "user-uuid"})
+		req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid JWT returns 401", func(t *testing.T) {
+		mw := platform.SessionAuthenticator(&stubAuthService{err: errors.New("invalid token")})
+		req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+		req.AddCookie(&http.Cookie{Name: "session", Value: "bad.jwt.token"})
+		w := httptest.NewRecorder()
+
+		mw(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
 }
 
 func TestDeviceAuthenticator(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -86,6 +86,10 @@ func main() {
 		r.Use(platform.DeviceAuthenticator(sensors.NewDeviceStore(db)))
 		r.Post("/readings", readings.Create)
 	})
+	r.Group(func(r chi.Router) {
+		r.Use(platform.SessionAuthenticator(authSvc))
+		// user-facing API routes (web #3, web #4) go here
+	})
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
## Summary

- `internal/auth/model.go` — adds `Claims{UserID}`, context key, `ClaimsFromContext`, and `ContextWithClaims` helpers
- `internal/platform/middleware.go` — adds `SessionAuthenticator`: checks `Authorization: Bearer` header first, falls back to `session` httpOnly cookie; returns 401 if missing or invalid
- `main.go` — wires an empty protected route group with `SessionAuthenticator` applied, ready for web #3/#4 endpoints
- 5 unit tests covering all paths (cookie, Bearer, precedence, missing, invalid)

Both modes use the same JWT and `ValidateSessionJWT` — fully stateless, no DB calls per request.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)