### PR TITLE
feat: GET /api/devices + CORS middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ INFLUXDB3_DATABASE=readings
 # Grafana
 GRAFANA_PASSWORD=admin
 
+# CORS (comma-separated list of allowed origins)
+CORS_ALLOWED_ORIGINS=http://localhost:3001
+
 # OAuth / session JWT
 GOOGLE_CLIENT_ID=
 JWT_SECRET=change-me-to-a-random-32-plus-byte-secret

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-chi/chi/v5 v5.2.5 // indirect
+	github.com/go-chi/cors v1.2.2 // indirect
 	github.com/go-chi/render v1.0.3 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P
 github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/internal/platform/middleware_test.go
+++ b/internal/platform/middleware_test.go
@@ -34,6 +34,10 @@ func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (sensors.De
 	return s.info, s.err
 }
 
+func (s *stubDeviceStore) ListByUserID(_ context.Context, _ string) ([]sensors.Device, error) {
+	return nil, nil
+}
+
 func TestSessionAuthenticator(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims, ok := auth.ClaimsFromContext(r.Context())

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -7,8 +7,43 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/go-chi/render"
 )
+
+type DeviceResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+type DevicesHandler struct {
+	Store DeviceStore
+}
+
+func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	devices, err := h.Store.ListByUserID(r.Context(), claims.UserID)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]DeviceResponse, len(devices))
+	for i, d := range devices {
+		resp[i] = DeviceResponse{
+			ID:        d.ID,
+			Name:      d.Name,
+			CreatedAt: d.CreatedAt.UTC().Format(time.RFC3339),
+		}
+	}
+	render.JSON(w, r, resp)
+}
 
 type TokenResponse struct {
 	Token    string `json:"token"`

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -85,6 +85,10 @@ func (s *stubReadingWriter) WriteReading(_ context.Context, r sensors.Reading) e
 
 type stubDeviceStore struct{ info sensors.DeviceInfo }
 
+func (s *stubDeviceStore) ListByUserID(_ context.Context, _ string) ([]sensors.Device, error) {
+	return nil, nil
+}
+
 func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (sensors.DeviceInfo, error) {
 	return s.info, nil
 }

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -1,9 +1,19 @@
 package sensors
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+type Device struct {
+	ID        string
+	Name      string
+	CreatedAt time.Time
+}
 
 type DeviceStore interface {
 	LookupByToken(ctx context.Context, token string) (DeviceInfo, error)
+	ListByUserID(ctx context.Context, userID string) ([]Device, error)
 }
 
 type TokenStore interface {

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -17,6 +17,29 @@ func NewDeviceStore(db *sql.DB) DeviceStore {
 	return &postgresDeviceStore{db: db}
 }
 
+func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID string) ([]Device, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, COALESCE(name, ''), created_at
+		FROM devices
+		WHERE user_id = $1
+		ORDER BY created_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list devices: %w", err)
+	}
+	defer rows.Close()
+
+	devices := []Device{}
+	for rows.Next() {
+		var d Device
+		if err := rows.Scan(&d.ID, &d.Name, &d.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan device: %w", err)
+		}
+		devices = append(devices, d)
+	}
+	return devices, rows.Err()
+}
+
 func (s *postgresDeviceStore) LookupByToken(ctx context.Context, token string) (DeviceInfo, error) {
 	var info DeviceInfo
 	err := s.db.QueryRowContext(ctx, `

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -137,4 +137,69 @@ func TestCreateToken_integration(t *testing.T) {
 	})
 }
 
+func TestListByUserID_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewDeviceStore(db)
+	tokens := sensors.NewTokenStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	t.Run("returns devices for the user ordered by created_at DESC", func(t *testing.T) {
+		r1, err := tokens.CreateToken(ctx, userID)
+		if err != nil {
+			t.Fatalf("setup token 1: %v", err)
+		}
+		r2, err := tokens.CreateToken(ctx, userID)
+		if err != nil {
+			t.Fatalf("setup token 2: %v", err)
+		}
+
+		devices, err := store.ListByUserID(ctx, userID)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(devices) < 2 {
+			t.Fatalf("expected at least 2 devices, got %d", len(devices))
+		}
+
+		ids := make([]string, len(devices))
+		for i, d := range devices {
+			ids[i] = d.ID
+		}
+		if !contains(ids, r1.DeviceID) || !contains(ids, r2.DeviceID) {
+			t.Errorf("missing expected device IDs in result")
+		}
+	})
+
+	t.Run("returns empty slice for user with no devices", func(t *testing.T) {
+		// insert a fresh user with no devices
+		var newUserID string
+		err := db.QueryRowContext(ctx, `
+			INSERT INTO users (email, provider, provider_sub)
+			VALUES ('other@example.com', 'google', 'sub-other')
+			RETURNING id
+		`).Scan(&newUserID)
+		if err != nil {
+			t.Fatalf("insert user: %v", err)
+		}
+
+		devices, err := store.ListByUserID(ctx, newUserID)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(devices) != 0 {
+			t.Errorf("expected empty slice, got %d devices", len(devices))
+		}
+	})
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 var _ sensors.TokenStore = sensors.NewTokenStore((*sql.DB)(nil))

--- a/main.go
+++ b/main.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/cors"
 )
 
 func main() {
@@ -77,7 +79,18 @@ func main() {
 		Writer: writer,
 	}
 
+	allowedOrigins := []string{"http://localhost:3001"}
+	if v := os.Getenv("CORS_ALLOWED_ORIGINS"); v != "" {
+		allowedOrigins = strings.Split(v, ",")
+	}
+
 	r := chi.NewRouter()
+	r.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   allowedOrigins,
+		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},
+		AllowCredentials: true,
+	}))
 	r.Get("/health", platform.Health)
 	r.Post("/auth/verify", (&auth.VerifyHandler{Service: authSvc}).ServeHTTP)
 	r.Post("/auth/logout", auth.Logout)
@@ -88,7 +101,7 @@ func main() {
 	})
 	r.Group(func(r chi.Router) {
 		r.Use(platform.SessionAuthenticator(authSvc))
-		// user-facing API routes (web #3, web #4) go here
+		r.Get("/api/devices", (&sensors.DevicesHandler{Store: sensors.NewDeviceStore(db)}).List)
 	})
 
 	port := os.Getenv("PORT")


### PR DESCRIPTION
## Summary

- Adds `Device` struct and `ListByUserID` to `DeviceStore` interface and Postgres implementation (ordered by `created_at DESC`, empty list returns `[]`)
- Adds `DevicesHandler.List` — reads `userID` from session claims, returns JSON array of devices
- Wires `GET /api/devices` into the session-protected route group in `main.go`
- Adds `go-chi/cors` globally with `CORS_ALLOWED_ORIGINS` env var (default `http://localhost:3001`), `AllowCredentials: true` for cookie-based auth
- Integration tests for `ListByUserID`; updated stubs in handler and platform middleware tests

Closes #17
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)