### PR TITLE
feat: implement refresh token flow

### DIFF
--- a/db/migrations/005_create_refresh_tokens.down.sql
+++ b/db/migrations/005_create_refresh_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS refresh_tokens;

--- a/db/migrations/005_create_refresh_tokens.up.sql
+++ b/db/migrations/005_create_refresh_tokens.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE refresh_tokens (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash   CHAR(64) NOT NULL UNIQUE,
+    expires_at   TIMESTAMPTZ NOT NULL,
+    revoked_at   TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX refresh_tokens_user_id_idx ON refresh_tokens (user_id);

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -48,9 +48,82 @@ func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.JSON(w, r, map[string]string{"token": sessionToken})
+	refreshToken, err := h.Service.IssueRefreshToken(r.Context(), user.ID)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, map[string]string{
+		"token":         sessionToken,
+		"refresh_token": refreshToken,
+	})
 }
 
+type RefreshHandler struct {
+	Service AuthService
+}
+
+type refreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req refreshRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.RefreshToken == "" {
+		http.Error(w, "refresh_token is required", http.StatusBadRequest)
+		return
+	}
+
+	newRaw, sessionJWT, err := h.Service.RotateRefreshToken(r.Context(), req.RefreshToken)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrTokenRevoked) {
+			http.Error(w, "invalid or expired refresh token", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, map[string]string{
+		"token":         sessionJWT,
+		"refresh_token": newRaw,
+	})
+}
+
+type LogoutHandler struct {
+	Service AuthService
+}
+
+type logoutRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+func (h *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req logoutRequest
+	// best-effort decode — missing body or missing field is fine
+	json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+
+	if req.RefreshToken != "" {
+		// ignore revocation errors; the cookie is cleared regardless
+		h.Service.RevokeRefreshToken(r.Context(), req.RefreshToken) //nolint:errcheck
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    "",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Path:     "/",
+	})
+	render.JSON(w, r, map[string]string{})
+}
+
+// Logout is kept for backwards compatibility with existing routes that use it as a plain handler func.
 func Logout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -12,12 +12,18 @@ import (
 )
 
 type stubAuthService struct {
-	user     auth.User
-	upsertErr error
-	jwtToken string
-	jwtErr   error
+	user           auth.User
+	upsertErr      error
+	jwtToken       string
+	jwtErr         error
 	validateUserID string
 	validateErr    error
+	refreshRaw     string
+	refreshErr     error
+	newRaw         string
+	newJWT         string
+	rotateErr      error
+	revokeErr      error
 }
 
 func (s *stubAuthService) VerifyAndUpsert(_ context.Context, _, _ string) (auth.User, error) {
@@ -29,14 +35,24 @@ func (s *stubAuthService) IssueSessionJWT(_ string) (string, error) {
 func (s *stubAuthService) ValidateSessionJWT(_ string) (string, error) {
 	return s.validateUserID, s.validateErr
 }
+func (s *stubAuthService) IssueRefreshToken(_ context.Context, _ string) (string, error) {
+	return s.refreshRaw, s.refreshErr
+}
+func (s *stubAuthService) RotateRefreshToken(_ context.Context, _ string) (string, string, error) {
+	return s.newRaw, s.newJWT, s.rotateErr
+}
+func (s *stubAuthService) RevokeRefreshToken(_ context.Context, _ string) error {
+	return s.revokeErr
+}
 
 func TestVerifyHandler(t *testing.T) {
 	validUser := auth.User{ID: "user-uuid"}
 
-	t.Run("valid request returns 200 with token", func(t *testing.T) {
+	t.Run("valid request returns token and refresh_token", func(t *testing.T) {
 		h := &auth.VerifyHandler{Service: &stubAuthService{
-			user:     validUser,
-			jwtToken: "signed.jwt.token",
+			user:       validUser,
+			jwtToken:   "signed.jwt.token",
+			refreshRaw: "raw-refresh-token",
 		}}
 		body, _ := json.Marshal(map[string]string{"provider": "google", "id_token": "raw-id-token"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
@@ -51,6 +67,9 @@ func TestVerifyHandler(t *testing.T) {
 		if resp["token"] != "signed.jwt.token" {
 			t.Errorf("token: got %q, want %q", resp["token"], "signed.jwt.token")
 		}
+		if resp["refresh_token"] != "raw-refresh-token" {
+			t.Errorf("refresh_token: got %q, want %q", resp["refresh_token"], "raw-refresh-token")
+		}
 	})
 
 	t.Run("missing id_token returns 400", func(t *testing.T) {
@@ -59,7 +78,6 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
@@ -71,7 +89,6 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
@@ -83,7 +100,6 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-
 		if w.Code != http.StatusUnprocessableEntity {
 			t.Errorf("expected 422, got %d", w.Code)
 		}
@@ -95,7 +111,6 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-
 		if w.Code != http.StatusUnauthorized {
 			t.Errorf("expected 401, got %d", w.Code)
 		}
@@ -106,9 +121,107 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader([]byte("not json")))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestRefreshHandler(t *testing.T) {
+	t.Run("valid refresh token returns new token pair", func(t *testing.T) {
+		h := &auth.RefreshHandler{Service: &stubAuthService{
+			newRaw: "new-raw-token",
+			newJWT: "new.jwt.token",
+		}}
+		body, _ := json.Marshal(map[string]string{"refresh_token": "old-raw-token"})
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]string
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp["token"] != "new.jwt.token" {
+			t.Errorf("token: got %q, want %q", resp["token"], "new.jwt.token")
+		}
+		if resp["refresh_token"] != "new-raw-token" {
+			t.Errorf("refresh_token: got %q, want %q", resp["refresh_token"], "new-raw-token")
+		}
+	})
+
+	t.Run("missing refresh_token returns 400", func(t *testing.T) {
+		h := &auth.RefreshHandler{Service: &stubAuthService{}}
+		body, _ := json.Marshal(map[string]string{})
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("malformed JSON returns 400", func(t *testing.T) {
+		h := &auth.RefreshHandler{Service: &stubAuthService{}}
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader([]byte("not json")))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"not found returns 401", auth.ErrTokenNotFound},
+		{"expired returns 401", auth.ErrTokenExpired},
+		{"revoked returns 401", auth.ErrTokenRevoked},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &auth.RefreshHandler{Service: &stubAuthService{rotateErr: tc.err}}
+			body, _ := json.Marshal(map[string]string{"refresh_token": "some-token"})
+			req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("expected 401, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestLogoutHandler(t *testing.T) {
+	t.Run("clears session cookie", func(t *testing.T) {
+		h := &auth.LogoutHandler{Service: &stubAuthService{}}
+		body, _ := json.Marshal(map[string]string{"refresh_token": "some-token"})
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		var found bool
+		for _, c := range w.Result().Cookies() {
+			if c.Name == "session" && c.MaxAge < 0 {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected session cookie with MaxAge < 0 to clear it")
+		}
+	})
+
+	t.Run("works without body", func(t *testing.T) {
+		h := &auth.LogoutHandler{Service: &stubAuthService{}}
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
 		}
 	})
 }
@@ -122,9 +235,8 @@ func TestLogout(t *testing.T) {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
 
-	cookie := w.Result().Cookies()
 	var found bool
-	for _, c := range cookie {
+	for _, c := range w.Result().Cookies() {
 		if c.Name == "session" && c.MaxAge < 0 {
 			found = true
 		}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -2,6 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -11,31 +14,35 @@ import (
 )
 
 var ErrUnsupportedProvider = errors.New("unsupported provider")
-var ErrInvalidIDToken = errors.New("invalid id token")
+var ErrInvalidIDToken      = errors.New("invalid id token")
+
+const refreshTokenTTL = 30 * 24 * time.Hour
 
 type OIDCConfig struct {
-	// Providers maps provider name (e.g. "google") to its client ID.
-	Providers map[string]string
-	Store     UserStore
-	JWTSecret string
-	JWTTTL    time.Duration
+	Providers    map[string]string
+	Store        UserStore
+	RefreshStore RefreshTokenStore
+	JWTSecret    string
+	JWTTTL       time.Duration
 }
 
 type AuthService interface {
 	VerifyAndUpsert(ctx context.Context, provider, idToken string) (User, error)
 	IssueSessionJWT(userID string) (string, error)
 	ValidateSessionJWT(token string) (string, error)
+	IssueRefreshToken(ctx context.Context, userID string) (string, error)
+	RotateRefreshToken(ctx context.Context, rawToken string) (newRawToken, sessionJWT string, err error)
+	RevokeRefreshToken(ctx context.Context, rawToken string) error
 }
 
 type oidcService struct {
-	verifiers map[string]*gooidc.IDTokenVerifier
-	store     UserStore
-	jwtSecret []byte
-	jwtTTL    time.Duration
+	verifiers    map[string]*gooidc.IDTokenVerifier
+	store        UserStore
+	refreshStore RefreshTokenStore
+	jwtSecret    []byte
+	jwtTTL       time.Duration
 }
 
-// NewOIDCService builds verifiers for each configured provider eagerly.
-// Providers whose client ID is empty are silently skipped.
 func NewOIDCService(ctx context.Context, cfg OIDCConfig) (AuthService, error) {
 	verifiers := make(map[string]*gooidc.IDTokenVerifier, len(cfg.Providers))
 	for name, clientID := range cfg.Providers {
@@ -53,10 +60,11 @@ func NewOIDCService(ctx context.Context, cfg OIDCConfig) (AuthService, error) {
 		verifiers[name] = provider.Verifier(&gooidc.Config{ClientID: clientID})
 	}
 	return &oidcService{
-		verifiers: verifiers,
-		store:     cfg.Store,
-		jwtSecret: []byte(cfg.JWTSecret),
-		jwtTTL:    cfg.JWTTTL,
+		verifiers:    verifiers,
+		store:        cfg.Store,
+		refreshStore: cfg.RefreshStore,
+		jwtSecret:    []byte(cfg.JWTSecret),
+		jwtTTL:       cfg.JWTTTL,
 	}, nil
 }
 
@@ -125,4 +133,74 @@ func (s *oidcService) ValidateSessionJWT(raw string) (string, error) {
 		return "", errors.New("missing sub claim")
 	}
 	return sub, nil
+}
+
+func (s *oidcService) IssueRefreshToken(ctx context.Context, userID string) (string, error) {
+	raw, hash, err := generateRefreshToken()
+	if err != nil {
+		return "", err
+	}
+	_, err = s.refreshStore.Create(ctx, userID, hash, time.Now().Add(refreshTokenTTL))
+	if err != nil {
+		return "", fmt.Errorf("store refresh token: %w", err)
+	}
+	return raw, nil
+}
+
+func (s *oidcService) RotateRefreshToken(ctx context.Context, rawToken string) (string, string, error) {
+	hash := hashToken(rawToken)
+	rt, err := s.refreshStore.FindByHash(ctx, hash)
+	if err != nil {
+		return "", "", err
+	}
+	if rt.RevokedAt != nil {
+		return "", "", ErrTokenRevoked
+	}
+	if time.Now().After(rt.ExpiresAt) {
+		return "", "", ErrTokenExpired
+	}
+
+	if err := s.refreshStore.Revoke(ctx, rt.ID); err != nil {
+		return "", "", fmt.Errorf("revoke old refresh token: %w", err)
+	}
+
+	newRaw, newHash, err := generateRefreshToken()
+	if err != nil {
+		return "", "", err
+	}
+	_, err = s.refreshStore.Create(ctx, rt.UserID, newHash, time.Now().Add(refreshTokenTTL))
+	if err != nil {
+		return "", "", fmt.Errorf("store new refresh token: %w", err)
+	}
+
+	sessionJWT, err := s.IssueSessionJWT(rt.UserID)
+	if err != nil {
+		return "", "", err
+	}
+
+	return newRaw, sessionJWT, nil
+}
+
+func (s *oidcService) RevokeRefreshToken(ctx context.Context, rawToken string) error {
+	hash := hashToken(rawToken)
+	rt, err := s.refreshStore.FindByHash(ctx, hash)
+	if err != nil {
+		return err
+	}
+	return s.refreshStore.Revoke(ctx, rt.ID)
+}
+
+func generateRefreshToken() (raw, hash string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generate refresh token: %w", err)
+	}
+	raw = hex.EncodeToString(b)
+	hash = hashToken(raw)
+	return raw, hash, nil
+}
+
+func hashToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,10 +14,11 @@ import (
 func jwtOnlyService(t *testing.T, secret string, ttl time.Duration) auth.AuthService {
 	t.Helper()
 	svc, err := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
-		Providers: map[string]string{},
-		Store:     &stubUserStore{},
-		JWTSecret: secret,
-		JWTTTL:    ttl,
+		Providers:    map[string]string{},
+		Store:        &stubUserStore{},
+		RefreshStore: &stubRefreshTokenStore{},
+		JWTSecret:    secret,
+		JWTTTL:       ttl,
 	})
 	if err != nil {
 		t.Fatalf("NewOIDCService: %v", err)
@@ -82,6 +84,106 @@ func TestVerifyAndUpsert_UnsupportedProvider(t *testing.T) {
 	}
 }
 
+func TestIssueRefreshToken(t *testing.T) {
+	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+
+	raw, err := svc.IssueRefreshToken(context.Background(), "user-uuid-123")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken: %v", err)
+	}
+	if raw == "" {
+		t.Fatal("expected non-empty raw token")
+	}
+	if len(raw) != 64 {
+		t.Errorf("expected 64-char hex token, got len %d", len(raw))
+	}
+}
+
+func TestRotateRefreshToken(t *testing.T) {
+	store := &stubRefreshTokenStore{}
+	svc, err := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
+		Providers:    map[string]string{},
+		Store:        &stubUserStore{},
+		RefreshStore: store,
+		JWTSecret:    "test-secret-32-bytes-long-enough!",
+		JWTTTL:       time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCService: %v", err)
+	}
+
+	raw, err := svc.IssueRefreshToken(context.Background(), "user-uuid-123")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken: %v", err)
+	}
+
+	newRaw, jwt, err := svc.RotateRefreshToken(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("RotateRefreshToken: %v", err)
+	}
+	if newRaw == "" || newRaw == raw {
+		t.Error("expected a different non-empty new raw token")
+	}
+	if jwt == "" {
+		t.Error("expected non-empty session JWT")
+	}
+}
+
+func TestRotateRefreshToken_Revoked(t *testing.T) {
+	store := &stubRefreshTokenStore{}
+	svc, _ := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
+		Providers:    map[string]string{},
+		Store:        &stubUserStore{},
+		RefreshStore: store,
+		JWTSecret:    "test-secret-32-bytes-long-enough!",
+		JWTTTL:       time.Hour,
+	})
+
+	raw, _ := svc.IssueRefreshToken(context.Background(), "user-uuid-123")
+	svc.RevokeRefreshToken(context.Background(), raw)
+
+	_, _, err := svc.RotateRefreshToken(context.Background(), raw)
+	if err != auth.ErrTokenRevoked {
+		t.Errorf("expected ErrTokenRevoked, got %v", err)
+	}
+}
+
+func TestRotateRefreshToken_Expired(t *testing.T) {
+	store := &stubRefreshTokenStore{ttl: -time.Second}
+	svc, _ := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
+		Providers:    map[string]string{},
+		Store:        &stubUserStore{},
+		RefreshStore: store,
+		JWTSecret:    "test-secret-32-bytes-long-enough!",
+		JWTTTL:       time.Hour,
+	})
+
+	raw, _ := svc.IssueRefreshToken(context.Background(), "user-uuid-123")
+
+	_, _, err := svc.RotateRefreshToken(context.Background(), raw)
+	if err != auth.ErrTokenExpired {
+		t.Errorf("expected ErrTokenExpired, got %v", err)
+	}
+}
+
+func TestRotateRefreshToken_NotFound(t *testing.T) {
+	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+
+	_, _, err := svc.RotateRefreshToken(context.Background(), "nonexistent-token")
+	if err != auth.ErrTokenNotFound {
+		t.Errorf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestRevokeRefreshToken_NotFound(t *testing.T) {
+	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+
+	err := svc.RevokeRefreshToken(context.Background(), "nonexistent-token")
+	if err != auth.ErrTokenNotFound {
+		t.Errorf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
 // stubUserStore satisfies UserStore for unit tests.
 type stubUserStore struct {
 	user auth.User
@@ -97,4 +199,53 @@ func (s *stubUserStore) Upsert(_ context.Context, email, provider, sub string) (
 
 func (s *stubUserStore) FindByID(_ context.Context, id string) (auth.User, error) {
 	return s.user, s.err
+}
+
+// stubRefreshTokenStore is an in-memory RefreshTokenStore for unit tests.
+type stubRefreshTokenStore struct {
+	tokens map[string]auth.RefreshToken // keyed by token_hash
+	nextID int
+	ttl    time.Duration // override TTL; zero means use the value passed to Create
+}
+
+func (s *stubRefreshTokenStore) Create(_ context.Context, userID, tokenHash string, expiresAt time.Time) (auth.RefreshToken, error) {
+	if s.tokens == nil {
+		s.tokens = map[string]auth.RefreshToken{}
+	}
+	s.nextID++
+	if s.ttl != 0 {
+		expiresAt = time.Now().Add(s.ttl)
+	}
+	rt := auth.RefreshToken{
+		ID:        fmt.Sprintf("stub-%d", s.nextID),
+		UserID:    userID,
+		TokenHash: tokenHash,
+		ExpiresAt: expiresAt,
+		CreatedAt: time.Now(),
+	}
+	s.tokens[tokenHash] = rt
+	return rt, nil
+}
+
+func (s *stubRefreshTokenStore) FindByHash(_ context.Context, tokenHash string) (auth.RefreshToken, error) {
+	if s.tokens == nil {
+		return auth.RefreshToken{}, auth.ErrTokenNotFound
+	}
+	rt, ok := s.tokens[tokenHash]
+	if !ok {
+		return auth.RefreshToken{}, auth.ErrTokenNotFound
+	}
+	return rt, nil
+}
+
+func (s *stubRefreshTokenStore) Revoke(_ context.Context, id string) error {
+	for hash, rt := range s.tokens {
+		if rt.ID == id {
+			now := time.Now()
+			rt.RevokedAt = &now
+			s.tokens[hash] = rt
+			return nil
+		}
+	}
+	return auth.ErrTokenNotFound
 }

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -3,11 +3,30 @@ package auth
 import (
 	"context"
 	"errors"
+	"time"
 )
 
-var ErrUserNotFound = errors.New("user not found")
+var ErrUserNotFound  = errors.New("user not found")
+var ErrTokenNotFound = errors.New("refresh token not found")
+var ErrTokenExpired  = errors.New("refresh token expired")
+var ErrTokenRevoked  = errors.New("refresh token revoked")
 
 type UserStore interface {
 	Upsert(ctx context.Context, email, provider, providerSub string) (User, error)
 	FindByID(ctx context.Context, id string) (User, error)
+}
+
+type RefreshToken struct {
+	ID        string
+	UserID    string
+	TokenHash string
+	ExpiresAt time.Time
+	RevokedAt *time.Time
+	CreatedAt time.Time
+}
+
+type RefreshTokenStore interface {
+	Create(ctx context.Context, userID, tokenHash string, expiresAt time.Time) (RefreshToken, error)
+	FindByHash(ctx context.Context, tokenHash string) (RefreshToken, error)
+	Revoke(ctx context.Context, id string) error
 }

--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 )
 
 type postgresStore struct {
@@ -44,4 +45,62 @@ func (s *postgresStore) FindByID(ctx context.Context, id string) (User, error) {
 		return User{}, fmt.Errorf("find user by id: %w", err)
 	}
 	return u, nil
+}
+
+type postgresRefreshTokenStore struct {
+	db *sql.DB
+}
+
+func NewPostgresRefreshTokenStore(db *sql.DB) RefreshTokenStore {
+	return &postgresRefreshTokenStore{db: db}
+}
+
+func (s *postgresRefreshTokenStore) Create(ctx context.Context, userID, tokenHash string, expiresAt time.Time) (RefreshToken, error) {
+	var rt RefreshToken
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
+		VALUES ($1, $2, $3)
+		RETURNING id, user_id, token_hash, expires_at, revoked_at, created_at
+	`, userID, tokenHash, expiresAt).Scan(
+		&rt.ID, &rt.UserID, &rt.TokenHash, &rt.ExpiresAt, &rt.RevokedAt, &rt.CreatedAt,
+	)
+	if err != nil {
+		return RefreshToken{}, fmt.Errorf("create refresh token: %w", err)
+	}
+	return rt, nil
+}
+
+func (s *postgresRefreshTokenStore) FindByHash(ctx context.Context, tokenHash string) (RefreshToken, error) {
+	var rt RefreshToken
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, token_hash, expires_at, revoked_at, created_at
+		FROM refresh_tokens
+		WHERE token_hash = $1
+	`, tokenHash).Scan(
+		&rt.ID, &rt.UserID, &rt.TokenHash, &rt.ExpiresAt, &rt.RevokedAt, &rt.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RefreshToken{}, ErrTokenNotFound
+		}
+		return RefreshToken{}, fmt.Errorf("find refresh token by hash: %w", err)
+	}
+	return rt, nil
+}
+
+func (s *postgresRefreshTokenStore) Revoke(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE refresh_tokens SET revoked_at = now() WHERE id = $1 AND revoked_at IS NULL
+	`, id)
+	if err != nil {
+		return fmt.Errorf("revoke refresh token: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("revoke refresh token rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrTokenNotFound
+	}
+	return nil
 }

--- a/internal/auth/store_postgres_integration_test.go
+++ b/internal/auth/store_postgres_integration_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/testutil"
@@ -81,6 +82,76 @@ func TestPostgresStore_Integration(t *testing.T) {
 		_, err := store.FindByID(ctx, "00000000-0000-0000-0000-000000000000")
 		if err != auth.ErrUserNotFound {
 			t.Errorf("expected ErrUserNotFound, got %v", err)
+		}
+	})
+}
+
+func TestPostgresRefreshTokenStore_Integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	userStore := auth.NewPostgresStore(db)
+	rtStore := auth.NewPostgresRefreshTokenStore(db)
+	ctx := context.Background()
+
+	// create a user to satisfy the FK constraint
+	user, err := userStore.Upsert(ctx, "refresh@example.com", "google", "google-sub-refresh")
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+
+	t.Run("Create and FindByHash round-trip", func(t *testing.T) {
+		rt, err := rtStore.Create(ctx, user.ID, "deadbeef01", time.Now().Add(30*24*time.Hour))
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if rt.ID == "" {
+			t.Error("expected non-empty ID")
+		}
+		if rt.RevokedAt != nil {
+			t.Error("expected RevokedAt to be nil")
+		}
+
+		found, err := rtStore.FindByHash(ctx, "deadbeef01")
+		if err != nil {
+			t.Fatalf("find: %v", err)
+		}
+		if found.ID != rt.ID {
+			t.Errorf("ID mismatch: got %q, want %q", found.ID, rt.ID)
+		}
+		if found.UserID != user.ID {
+			t.Errorf("UserID mismatch: got %q, want %q", found.UserID, user.ID)
+		}
+	})
+
+	t.Run("FindByHash returns ErrTokenNotFound for unknown hash", func(t *testing.T) {
+		_, err := rtStore.FindByHash(ctx, "nonexistent-hash")
+		if err != auth.ErrTokenNotFound {
+			t.Errorf("expected ErrTokenNotFound, got %v", err)
+		}
+	})
+
+	t.Run("Revoke sets revoked_at", func(t *testing.T) {
+		rt, err := rtStore.Create(ctx, user.ID, "deadbeef02", time.Now().Add(30*24*time.Hour))
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+
+		if err := rtStore.Revoke(ctx, rt.ID); err != nil {
+			t.Fatalf("revoke: %v", err)
+		}
+
+		found, err := rtStore.FindByHash(ctx, "deadbeef02")
+		if err != nil {
+			t.Fatalf("find after revoke: %v", err)
+		}
+		if found.RevokedAt == nil {
+			t.Error("expected RevokedAt to be set after revoke")
+		}
+	})
+
+	t.Run("Revoke returns ErrTokenNotFound for unknown id", func(t *testing.T) {
+		err := rtStore.Revoke(ctx, "00000000-0000-0000-0000-000000000000")
+		if err != auth.ErrTokenNotFound {
+			t.Errorf("expected ErrTokenNotFound, got %v", err)
 		}
 	})
 }

--- a/internal/platform/middleware_test.go
+++ b/internal/platform/middleware_test.go
@@ -20,10 +20,15 @@ type stubAuthService struct {
 func (s *stubAuthService) VerifyAndUpsert(_ context.Context, _, _ string) (auth.User, error) {
 	return auth.User{}, nil
 }
-func (s *stubAuthService) IssueSessionJWT(_ string) (string, error) { return "", nil }
-func (s *stubAuthService) ValidateSessionJWT(_ string) (string, error) {
-	return s.userID, s.err
+func (s *stubAuthService) IssueSessionJWT(_ string) (string, error)   { return "", nil }
+func (s *stubAuthService) ValidateSessionJWT(_ string) (string, error) { return s.userID, s.err }
+func (s *stubAuthService) IssueRefreshToken(_ context.Context, _ string) (string, error) {
+	return "", nil
 }
+func (s *stubAuthService) RotateRefreshToken(_ context.Context, _ string) (string, string, error) {
+	return "", "", nil
+}
+func (s *stubAuthService) RevokeRefreshToken(_ context.Context, _ string) error { return nil }
 
 type stubDeviceStore struct {
 	info sensors.DeviceInfo

--- a/main.go
+++ b/main.go
@@ -62,9 +62,10 @@ func main() {
 		Providers: map[string]string{
 			"google": os.Getenv("GOOGLE_CLIENT_ID"),
 		},
-		Store:     auth.NewPostgresStore(db),
-		JWTSecret: os.Getenv("JWT_SECRET"),
-		JWTTTL:    jwtTTL,
+		Store:        auth.NewPostgresStore(db),
+		RefreshStore: auth.NewPostgresRefreshTokenStore(db),
+		JWTSecret:    os.Getenv("JWT_SECRET"),
+		JWTTTL:       jwtTTL,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "auth init: %v\n", err)
@@ -93,7 +94,8 @@ func main() {
 	}))
 	r.Get("/health", platform.Health)
 	r.Post("/auth/verify", (&auth.VerifyHandler{Service: authSvc}).ServeHTTP)
-	r.Post("/auth/logout", auth.Logout)
+	r.Post("/auth/refresh", (&auth.RefreshHandler{Service: authSvc}).ServeHTTP)
+	r.Post("/auth/logout", (&auth.LogoutHandler{Service: authSvc}).ServeHTTP)
 	r.Post("/tokens", tokens.Create)
 	r.Group(func(r chi.Router) {
 		r.Use(platform.DeviceAuthenticator(sensors.NewDeviceStore(db)))


### PR DESCRIPTION
## Summary

- Adds a `refresh_tokens` table (migration 005) storing SHA-256 hashes of 30-day opaque tokens
- `RefreshTokenStore` interface + Postgres implementation
- `AuthService` extended with `IssueRefreshToken`, `RotateRefreshToken`, `RevokeRefreshToken`
- `POST /auth/verify` now returns `{ token, refresh_token }`
- New `POST /auth/refresh` endpoint rotates the token pair
- `POST /auth/logout` promoted to `LogoutHandler`; revokes the refresh token server-side
- Unit + handler + integration tests for all new code

## Test plan

- [ ] `go test ./internal/auth/...` passes (unit + integration)
- [ ] `go build ./...` clean
- [ ] `POST /auth/verify` returns both `token` and `refresh_token`
- [ ] `POST /auth/refresh` with valid token returns new pair; expired/revoked/unknown returns 401
- [ ] `POST /auth/logout` with `refresh_token` in body revokes it; cookie cleared

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)