### PR TITLE
feat: add account domain with GET /api/me endpoint

### DIFF
--- a/db/migrations/006_create_accounts.down.sql
+++ b/db/migrations/006_create_accounts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS accounts;

--- a/db/migrations/006_create_accounts.up.sql
+++ b/db/migrations/006_create_accounts.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE accounts (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL UNIQUE,
+    email      TEXT NOT NULL,
+    name       TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/internal/account/events.go
+++ b/internal/account/events.go
@@ -1,0 +1,24 @@
+package account
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+)
+
+// AccountEventHandler implements auth.UserEventHandler, bridging the auth
+// domain to the account domain without creating a reverse dependency.
+type AccountEventHandler struct {
+	Store AccountStore
+}
+
+func (h *AccountEventHandler) OnUserVerified(ctx context.Context, userID, email, name string) error {
+	if _, err := h.Store.Upsert(ctx, userID, email, name); err != nil {
+		return fmt.Errorf("account event handler: %w", err)
+	}
+	return nil
+}
+
+// compile-time interface check
+var _ auth.UserEventHandler = (*AccountEventHandler)(nil)

--- a/internal/account/handler.go
+++ b/internal/account/handler.go
@@ -1,0 +1,47 @@
+package account
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/go-chi/render"
+)
+
+type MeHandler struct {
+	Store AccountStore
+}
+
+type meResponse struct {
+	ID        string `json:"id"`
+	UserID    string `json:"user_id"`
+	Email     string `json:"email"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+func (h *MeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	account, err := h.Store.FindByUserID(r.Context(), claims.UserID)
+	if err != nil {
+		if errors.Is(err, ErrAccountNotFound) {
+			http.Error(w, "account not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, meResponse{
+		ID:        account.ID,
+		UserID:    account.UserID,
+		Email:     account.Email,
+		Name:      account.Name,
+		CreatedAt: account.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	})
+}

--- a/internal/account/handler_test.go
+++ b/internal/account/handler_test.go
@@ -1,0 +1,92 @@
+package account_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/account"
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+)
+
+type stubAccountStore struct {
+	account account.Account
+	err     error
+}
+
+func (s *stubAccountStore) Upsert(_ context.Context, _, _, _ string) (account.Account, error) {
+	return s.account, s.err
+}
+
+func (s *stubAccountStore) FindByUserID(_ context.Context, _ string) (account.Account, error) {
+	return s.account, s.err
+}
+
+func requestWithClaims(userID string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	ctx := auth.ContextWithClaims(req.Context(), auth.Claims{UserID: userID})
+	return req.WithContext(ctx)
+}
+
+func TestMeHandler(t *testing.T) {
+	validAccount := account.Account{
+		ID:        "acct-uuid",
+		UserID:    "user-uuid",
+		Email:     "alice@example.com",
+		Name:      "Alice",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	t.Run("returns account for authenticated user", func(t *testing.T) {
+		h := &account.MeHandler{Store: &stubAccountStore{account: validAccount}}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, requestWithClaims("user-uuid"))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]string
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp["email"] != "alice@example.com" {
+			t.Errorf("email: got %q, want %q", resp["email"], "alice@example.com")
+		}
+		if resp["name"] != "Alice" {
+			t.Errorf("name: got %q, want %q", resp["name"], "Alice")
+		}
+	})
+
+	t.Run("returns 401 when no claims in context", func(t *testing.T) {
+		h := &account.MeHandler{Store: &stubAccountStore{account: validAccount}}
+		req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns 404 when account not found", func(t *testing.T) {
+		h := &account.MeHandler{Store: &stubAccountStore{err: account.ErrAccountNotFound}}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, requestWithClaims("user-uuid"))
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns 500 on store error", func(t *testing.T) {
+		h := &account.MeHandler{Store: &stubAccountStore{err: errors.New("db error")}}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, requestWithClaims("user-uuid"))
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", w.Code)
+		}
+	})
+}

--- a/internal/account/model.go
+++ b/internal/account/model.go
@@ -1,0 +1,12 @@
+package account
+
+import "time"
+
+type Account struct {
+	ID        string
+	UserID    string
+	Email     string
+	Name      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/account/store.go
+++ b/internal/account/store.go
@@ -1,0 +1,13 @@
+package account
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrAccountNotFound = errors.New("account not found")
+
+type AccountStore interface {
+	Upsert(ctx context.Context, userID, email, name string) (Account, error)
+	FindByUserID(ctx context.Context, userID string) (Account, error)
+}

--- a/internal/account/store_postgres.go
+++ b/internal/account/store_postgres.go
@@ -1,0 +1,49 @@
+package account
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewPostgresStore(db *sql.DB) AccountStore {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) Upsert(ctx context.Context, userID, email, name string) (Account, error) {
+	var a Account
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO accounts (user_id, email, name)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (user_id) DO UPDATE
+		    SET email = EXCLUDED.email,
+		        name  = EXCLUDED.name,
+		        updated_at = now()
+		RETURNING id, user_id, email, name, created_at, updated_at
+	`, userID, email, name).Scan(&a.ID, &a.UserID, &a.Email, &a.Name, &a.CreatedAt, &a.UpdatedAt)
+	if err != nil {
+		return Account{}, fmt.Errorf("upsert account: %w", err)
+	}
+	return a, nil
+}
+
+func (s *postgresStore) FindByUserID(ctx context.Context, userID string) (Account, error) {
+	var a Account
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, email, name, created_at, updated_at
+		FROM accounts
+		WHERE user_id = $1
+	`, userID).Scan(&a.ID, &a.UserID, &a.Email, &a.Name, &a.CreatedAt, &a.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Account{}, ErrAccountNotFound
+		}
+		return Account{}, fmt.Errorf("find account by user id: %w", err)
+	}
+	return a, nil
+}

--- a/internal/account/store_postgres_integration_test.go
+++ b/internal/account/store_postgres_integration_test.go
@@ -1,0 +1,79 @@
+package account_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/account"
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+)
+
+func TestPostgresAccountStore_Integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	userStore := auth.NewPostgresStore(db)
+	store := account.NewPostgresStore(db)
+	ctx := context.Background()
+
+	user, err := userStore.Upsert(ctx, "alice@example.com", "google", "google-sub-alice")
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+
+	t.Run("Upsert creates a new account", func(t *testing.T) {
+		a, err := store.Upsert(ctx, user.ID, "alice@example.com", "Alice")
+		if err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		if a.ID == "" {
+			t.Error("expected non-empty ID")
+		}
+		if a.UserID != user.ID {
+			t.Errorf("user_id: got %q, want %q", a.UserID, user.ID)
+		}
+		if a.Email != "alice@example.com" {
+			t.Errorf("email: got %q, want %q", a.Email, "alice@example.com")
+		}
+		if a.Name != "Alice" {
+			t.Errorf("name: got %q, want %q", a.Name, "Alice")
+		}
+	})
+
+	t.Run("Upsert updates email and name on conflict", func(t *testing.T) {
+		_, err := store.Upsert(ctx, user.ID, "old@example.com", "Old Name")
+		if err != nil {
+			t.Fatalf("initial upsert: %v", err)
+		}
+		updated, err := store.Upsert(ctx, user.ID, "new@example.com", "New Name")
+		if err != nil {
+			t.Fatalf("update upsert: %v", err)
+		}
+		if updated.Email != "new@example.com" {
+			t.Errorf("email: got %q, want %q", updated.Email, "new@example.com")
+		}
+		if updated.Name != "New Name" {
+			t.Errorf("name: got %q, want %q", updated.Name, "New Name")
+		}
+	})
+
+	t.Run("FindByUserID returns the correct account", func(t *testing.T) {
+		_, err := store.Upsert(ctx, user.ID, "alice@example.com", "Alice")
+		if err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		found, err := store.FindByUserID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("find: %v", err)
+		}
+		if found.UserID != user.ID {
+			t.Errorf("user_id: got %q, want %q", found.UserID, user.ID)
+		}
+	})
+
+	t.Run("FindByUserID returns ErrAccountNotFound for unknown user", func(t *testing.T) {
+		_, err := store.FindByUserID(ctx, "00000000-0000-0000-0000-000000000000")
+		if err != account.ErrAccountNotFound {
+			t.Errorf("expected ErrAccountNotFound, got %v", err)
+		}
+	})
+}

--- a/internal/auth/events.go
+++ b/internal/auth/events.go
@@ -1,0 +1,7 @@
+package auth
+
+import "context"
+
+type UserEventHandler interface {
+	OnUserVerified(ctx context.Context, userID, email, name string) error
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -22,6 +22,7 @@ type OIDCConfig struct {
 	Providers    map[string]string
 	Store        UserStore
 	RefreshStore RefreshTokenStore
+	EventHandler UserEventHandler
 	JWTSecret    string
 	JWTTTL       time.Duration
 }
@@ -39,6 +40,7 @@ type oidcService struct {
 	verifiers    map[string]*gooidc.IDTokenVerifier
 	store        UserStore
 	refreshStore RefreshTokenStore
+	eventHandler UserEventHandler
 	jwtSecret    []byte
 	jwtTTL       time.Duration
 }
@@ -63,6 +65,7 @@ func NewOIDCService(ctx context.Context, cfg OIDCConfig) (AuthService, error) {
 		verifiers:    verifiers,
 		store:        cfg.Store,
 		refreshStore: cfg.RefreshStore,
+		eventHandler: cfg.EventHandler,
 		jwtSecret:    []byte(cfg.JWTSecret),
 		jwtTTL:       cfg.JWTTTL,
 	}, nil
@@ -91,12 +94,28 @@ func (s *oidcService) VerifyAndUpsert(ctx context.Context, provider, rawIDToken 
 	var claims struct {
 		Email string `json:"email"`
 		Sub   string `json:"sub"`
+		Name  string `json:"name"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return User{}, fmt.Errorf("extract claims: %w", err)
 	}
 
-	return s.store.Upsert(ctx, claims.Email, provider, claims.Sub)
+	user, err := s.store.Upsert(ctx, claims.Email, provider, claims.Sub)
+	if err != nil {
+		return User{}, err
+	}
+
+	if s.eventHandler != nil {
+		name := claims.Name
+		if name == "" {
+			name = claims.Email
+		}
+		if err := s.eventHandler.OnUserVerified(ctx, user.ID, user.Email, name); err != nil {
+			return User{}, fmt.Errorf("user event handler: %w", err)
+		}
+	}
+
+	return user, nil
 }
 
 func (s *oidcService) IssueSessionJWT(userID string) (string, error) {

--- a/internal/auth/service_events_test.go
+++ b/internal/auth/service_events_test.go
@@ -1,0 +1,167 @@
+package auth
+
+// White-box tests for UserEventHandler dispatch in oidcService.
+// Uses package auth directly so we can construct oidcService without going
+// through the OIDC verifier path.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+)
+
+type stubEventHandler struct {
+	calls []eventCall
+	err   error
+}
+
+type eventCall struct {
+	userID string
+	email  string
+	name   string
+}
+
+func (h *stubEventHandler) OnUserVerified(_ context.Context, userID, email, name string) error {
+	h.calls = append(h.calls, eventCall{userID, email, name})
+	return h.err
+}
+
+// directService builds an oidcService with a pre-wired store and event handler,
+// bypassing OIDC provider setup (no verifiers).
+func directService(store UserStore, handler UserEventHandler) *oidcService {
+	return &oidcService{
+		verifiers:    map[string]*gooidc.IDTokenVerifier{},
+		store:        store,
+		refreshStore: &noopRefreshStore{},
+		eventHandler: handler,
+		jwtSecret:    []byte("secret"),
+		jwtTTL:       time.Hour,
+	}
+}
+
+// noopRefreshStore is a no-op RefreshTokenStore used to satisfy the field.
+type noopRefreshStore struct{}
+
+func (s *noopRefreshStore) Create(_ context.Context, _, _ string, _ time.Time) (RefreshToken, error) {
+	return RefreshToken{}, nil
+}
+func (s *noopRefreshStore) FindByHash(_ context.Context, _ string) (RefreshToken, error) {
+	return RefreshToken{}, ErrTokenNotFound
+}
+func (s *noopRefreshStore) Revoke(_ context.Context, _ string) error { return nil }
+
+// stubInternalUserStore satisfies UserStore for white-box tests.
+type stubInternalUserStore struct {
+	user User
+	err  error
+}
+
+func (s *stubInternalUserStore) Upsert(_ context.Context, email, provider, sub string) (User, error) {
+	if s.err != nil {
+		return User{}, s.err
+	}
+	if s.user.ID != "" {
+		return s.user, nil
+	}
+	return User{ID: "stub-id", Email: email, Provider: provider, ProviderSub: sub}, nil
+}
+
+func (s *stubInternalUserStore) FindByID(_ context.Context, _ string) (User, error) {
+	return s.user, s.err
+}
+
+// upsertDirect calls the internal store + event handler path that VerifyAndUpsert
+// would reach after OIDC verification — lets us test event dispatch without a
+// real OIDC token.
+func upsertDirect(svc *oidcService, ctx context.Context, email, name string) (User, error) {
+	user, err := svc.store.Upsert(ctx, email, "google", "sub-123")
+	if err != nil {
+		return User{}, err
+	}
+	if svc.eventHandler != nil {
+		n := name
+		if n == "" {
+			n = email
+		}
+		if err := svc.eventHandler.OnUserVerified(ctx, user.ID, user.Email, n); err != nil {
+			return User{}, err
+		}
+	}
+	return user, nil
+}
+
+func TestOnUserVerified_CalledAfterSuccessfulUpsert(t *testing.T) {
+	handler := &stubEventHandler{}
+	svc := directService(&stubInternalUserStore{}, handler)
+
+	user, err := upsertDirect(svc, context.Background(), "alice@example.com", "Alice")
+	if err != nil {
+		t.Fatalf("upsertDirect: %v", err)
+	}
+
+	if len(handler.calls) != 1 {
+		t.Fatalf("expected 1 OnUserVerified call, got %d", len(handler.calls))
+	}
+	call := handler.calls[0]
+	if call.userID != user.ID {
+		t.Errorf("userID: got %q, want %q", call.userID, user.ID)
+	}
+	if call.email != "alice@example.com" {
+		t.Errorf("email: got %q, want %q", call.email, "alice@example.com")
+	}
+	if call.name != "Alice" {
+		t.Errorf("name: got %q, want %q", call.name, "Alice")
+	}
+}
+
+func TestOnUserVerified_FallsBackToEmailWhenNameEmpty(t *testing.T) {
+	handler := &stubEventHandler{}
+	svc := directService(&stubInternalUserStore{}, handler)
+
+	_, err := upsertDirect(svc, context.Background(), "bob@example.com", "")
+	if err != nil {
+		t.Fatalf("upsertDirect: %v", err)
+	}
+
+	if len(handler.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(handler.calls))
+	}
+	if handler.calls[0].name != "bob@example.com" {
+		t.Errorf("name fallback: got %q, want %q", handler.calls[0].name, "bob@example.com")
+	}
+}
+
+func TestOnUserVerified_NotCalledWhenUpsertFails(t *testing.T) {
+	handler := &stubEventHandler{}
+	svc := directService(&stubInternalUserStore{err: errors.New("db error")}, handler)
+
+	_, err := upsertDirect(svc, context.Background(), "carol@example.com", "Carol")
+	if err == nil {
+		t.Fatal("expected error from store, got nil")
+	}
+	if len(handler.calls) != 0 {
+		t.Errorf("expected 0 OnUserVerified calls on store error, got %d", len(handler.calls))
+	}
+}
+
+func TestOnUserVerified_ErrorPropagates(t *testing.T) {
+	handler := &stubEventHandler{err: errors.New("event handler error")}
+	svc := directService(&stubInternalUserStore{}, handler)
+
+	_, err := upsertDirect(svc, context.Background(), "dave@example.com", "Dave")
+	if err == nil {
+		t.Fatal("expected error from event handler, got nil")
+	}
+}
+
+func TestOnUserVerified_NotCalledWhenHandlerNil(t *testing.T) {
+	svc := directService(&stubInternalUserStore{}, nil)
+
+	_, err := upsertDirect(svc, context.Background(), "eve@example.com", "Eve")
+	if err != nil {
+		t.Fatalf("expected no error with nil event handler, got %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fishhub-oss/fishhub-server/internal/account"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
@@ -58,12 +59,14 @@ func main() {
 		jwtTTL = time.Duration(h) * time.Hour
 	}
 
+	accountStore := account.NewPostgresStore(db)
 	authSvc, err := auth.NewOIDCService(ctx, auth.OIDCConfig{
 		Providers: map[string]string{
 			"google": os.Getenv("GOOGLE_CLIENT_ID"),
 		},
 		Store:        auth.NewPostgresStore(db),
 		RefreshStore: auth.NewPostgresRefreshTokenStore(db),
+		EventHandler: &account.AccountEventHandler{Store: accountStore},
 		JWTSecret:    os.Getenv("JWT_SECRET"),
 		JWTTTL:       jwtTTL,
 	})
@@ -103,6 +106,7 @@ func main() {
 	})
 	r.Group(func(r chi.Router) {
 		r.Use(platform.SessionAuthenticator(authSvc))
+		r.Get("/api/me", (&account.MeHandler{Store: accountStore}).ServeHTTP)
 		deviceStore := sensors.NewDeviceStore(db)
 		r.Get("/api/devices", (&sensors.DevicesHandler{Store: deviceStore}).List)
 		r.Get("/api/devices/{id}/readings", (&sensors.ReadingsQueryHandler{


### PR DESCRIPTION
## Summary

- `auth.UserEventHandler` interface (`OnUserVerified`) defined in the `auth` package — called after every successful OIDC login; `auth` never imports `account`
- New `internal/account` package: `Account` model, `AccountStore` interface, Postgres implementation, `AccountEventHandler` (implements `auth.UserEventHandler`), `MeHandler`
- Migration 006: `accounts` table with `user_id UNIQUE`, `email`, `name`, `created_at`, `updated_at` — no FK to `users`, decoupled by design
- `GET /api/me` registered in the `SessionAuthenticator` group, returns `{ id, user_id, email, name, created_at }`
- `name` extracted from the OIDC `name` claim, falls back to `email` when absent

## Decoupling model

```
auth.UserEventHandler (interface in auth)
        ▲
        │ implements
account.AccountEventHandler → account.AccountStore → accounts table
```

`main.go` is the only wiring point. Splitting auth into its own service means replacing `AccountEventHandler` with an HTTP/gRPC client — no changes to the `auth` package.

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./...` clean
- [x] `GET /api/me` returns correct profile after login
- [x] `GET /api/me` without session returns 401

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)