### PR TITLE
docs: update docs/ to reflect current implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,12 @@ dev:
 	until docker compose exec postgres pg_isready -U fishhub; do sleep 1; done
 	until curl -sf -H "Authorization: Bearer $(INFLUXDB3_TOKEN)" $(INFLUXDB3_HOST)/health > /dev/null; do sleep 1; done
 	until curl -sf http://localhost:3000/api/health > /dev/null; do sleep 1; done
-	go run ./...
+	@echo "\n📡 Server IP addresses:"
+	@ipconfig getifaddr en0 2>/dev/null && echo "  (Wi-Fi)" || true
+	@ipconfig getifaddr en1 2>/dev/null && echo "  (Ethernet)" || true
+	@echo ""
+	go run ./... || true
+	docker compose down
 
 influx-setup:
 	docker compose exec influxdb influxdb3 create database \

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,9 +17,9 @@ Health check. No authentication required.
 
 ## POST /tokens
 
-Creates a new device and issues an authentication token for it. The token is what gets hardcoded into the ESP32 firmware (`DEVICE_TOKEN` in `config.h`).
+Creates a new device and issues a Bearer token for it. The token is hardcoded into the ESP32 firmware (`DEVICE_TOKEN` in `config.h`). Always creates the device under the seed user for the PoC.
 
-No request body required. The token is always created for the seed user (`admin@fishhub.local`).
+No request body required.
 
 **Response `201`**
 ```json
@@ -32,11 +32,11 @@ No request body required. The token is always created for the seed user (`admin@
 
 | Field | Description |
 |---|---|
-| `token` | 64-char hex string. Copy this into `config.h` as `DEVICE_TOKEN`. |
+| `token` | 64-char hex string. Copy into firmware `config.h` as `DEVICE_TOKEN`. |
 | `device_id` | UUID of the newly created device record. |
 | `user_id` | UUID of the owning user (always the seed user for the PoC). |
 
-**Response `500`** — internal error (DB failure)
+**Response `500`** — DB failure
 
 ---
 
@@ -46,7 +46,7 @@ Accepts a SenML temperature reading from an authenticated device.
 
 **Headers**
 ```
-Authorization: Bearer <token>
+Authorization: Bearer <device-token>
 Content-Type: application/json
 ```
 
@@ -61,17 +61,166 @@ Content-Type: application/json
 
 | Field | Type | Description |
 |---|---|---|
-| `bn` | string | Base name (device namespace) |
+| `bn` | string | Base name |
 | `bt` | int64 | Base time — Unix UTC timestamp of the reading |
 | `e[0].n` | string | Must be `"temperature"` |
 | `e[0].u` | string | Unit — must be `"Cel"` |
 | `e[0].v` | float | Temperature in Celsius |
 
-**Response `201`**
-```json
-{}
-```
+**Response `201`** — `{}`
 
 **Response `400`** — malformed JSON, missing `bt`, or no `temperature` entry
 
 **Response `401`** — missing or invalid Bearer token
+
+**Response `500`** — InfluxDB write failure
+
+---
+
+## POST /auth/verify
+
+Verifies a Google OIDC ID token and issues a session JWT + refresh token. Called by the web frontend after the OAuth callback.
+
+**Request body**
+```json
+{
+  "provider": "google",
+  "id_token": "<google-id-token>"
+}
+```
+
+**Response `200`**
+```json
+{
+  "token":         "<session-jwt>",
+  "refresh_token": "<64-char-hex-refresh-token>"
+}
+```
+
+**Response `400`** — missing fields
+
+**Response `401`** — invalid ID token
+
+**Response `422`** — unsupported provider
+
+---
+
+## POST /auth/refresh
+
+Rotates a refresh token and issues a new session JWT. Old refresh token is immediately revoked (rotation).
+
+**Request body**
+```json
+{
+  "refresh_token": "<current-refresh-token>"
+}
+```
+
+**Response `200`**
+```json
+{
+  "token":         "<new-session-jwt>",
+  "refresh_token": "<new-refresh-token>"
+}
+```
+
+**Response `401`** — token not found, expired, or already revoked
+
+---
+
+## POST /auth/logout
+
+Revokes the refresh token (best effort) and clears the `session` cookie.
+
+**Request body** (optional)
+```json
+{
+  "refresh_token": "<refresh-token>"
+}
+```
+
+**Response `200`** — `{}`
+
+---
+
+## GET /api/me
+
+Returns the account profile for the signed-in user.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Response `200`**
+```json
+{
+  "id":         "<account-uuid>",
+  "user_id":    "<user-uuid>",
+  "email":      "user@example.com",
+  "name":       "Alice",
+  "created_at": "2024-04-13T12:00:00Z"
+}
+```
+
+**Response `401`** — not authenticated
+
+**Response `404`** — account not found (user exists but no account row yet)
+
+---
+
+## GET /api/devices
+
+Returns all devices belonging to the authenticated user.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Response `200`**
+```json
+[
+  {"id": "...", "name": "", "created_at": "2024-04-13T12:00:00Z"}
+]
+```
+
+---
+
+## GET /api/devices/{id}/readings
+
+Returns temperature readings for a device within a time window.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Query parameters**
+
+| Param | Format | Default | Description |
+|---|---|---|---|
+| `from` | RFC3339 | 24 hours ago | Start of window (inclusive) |
+| `to` | RFC3339 | now | End of window (exclusive) |
+| `window` | string | `"5m"` | InfluxDB aggregation window (passed through to query) |
+
+**Response `200`**
+```json
+{
+  "device_id": "...",
+  "from": "2024-04-12T12:00:00Z",
+  "to":   "2024-04-13T12:00:00Z",
+  "readings": [
+    {"timestamp": "2024-04-12T12:05:00Z", "temperature": 23.4}
+  ]
+}
+```
+
+**Response `400`** — invalid `from` or `to` format
+
+**Response `401`** — not authenticated
+
+**Response `404`** — device not found or not owned by the authenticated user

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,40 +8,58 @@ fishhub-server/
 ├── db/
 │   └── migrations/          # SQL migration files (golang-migrate format)
 └── internal/
-    ├── auth/                # Bearer token middleware, context helpers
-    ├── db/                  # DB connection, migration runner, seed
-    ├── handler/             # HTTP handlers (health, tokens, readings)
-    ├── senml/               # SenML RFC 8428 parser
-    ├── store/               # Data access layer (Postgres)
-    └── testutil/            # Shared test helpers (test DB via testcontainers)
+    ├── sensors/             # domain: device tokens, readings ingestion + query, InfluxDB, SenML
+    │   ├── handler.go               TokensHandler, ReadingsHandler, ReadingsQueryHandler, DevicesHandler
+    │   ├── store.go                 DeviceStore + TokenStore interfaces
+    │   ├── store_postgres.go        Postgres implementations
+    │   ├── influx.go                InfluxClient (ReadingWriter + ReadingQuerier), influxDBClient
+    │   ├── senml.go                 SenML RFC 8428 parser
+    │   └── model.go                 DeviceInfo, TokenResult, Reading, context helpers
+    ├── auth/                # domain: OIDC verification, JWT sessions, refresh token rotation
+    │   ├── handler.go               VerifyHandler, RefreshHandler, LogoutHandler
+    │   ├── service.go               AuthService interface, oidcService implementation
+    │   ├── store.go                 UserStore + RefreshTokenStore interfaces
+    │   ├── store_postgres.go        Postgres implementations
+    │   └── model.go                 User, RefreshToken, error sentinels
+    ├── account/             # domain: account profile (created on first login via event)
+    │   ├── handler.go               MeHandler
+    │   ├── store.go                 AccountStore interface
+    │   ├── store_postgres.go        Postgres implementation
+    │   ├── model.go                 Account struct
+    │   └── events.go                AccountEventHandler (implements auth.UserEventHandler)
+    ├── platform/            # cross-cutting: DB setup, middleware, health
+    │   ├── db.go                    Open(), Migrate(), SeedUser(), SeedUserID()
+    │   └── middleware.go            DeviceAuthenticator(), SessionAuthenticator(), Health()
+    └── testutil/
+        └── db.go                    NewTestDB(t) — starts Postgres container, runs migrations
 ```
 
 ## Dependency graph
 
 ```
 main.go
- ├── internal/db        — open connection, run migrations, seed user
- ├── internal/store     — TokenStore, DeviceStore (Postgres implementations)
- ├── internal/auth      — Authenticator middleware (depends on DeviceStore interface)
- └── internal/handler   — HTTP handlers (depend on store interfaces)
-      └── internal/senml — SenML parsing (pure, no external deps)
+ ├── platform     — DB connection, migrations, seed, middleware
+ ├── sensors      — device tokens, readings ingestion + query (InfluxDB), SenML
+ ├── auth         — OIDC verification, JWT + refresh token issuance
+ └── account      — account profiles, MeHandler
+      └── implements auth.UserEventHandler (called after OIDC verify)
 ```
-
-`internal/senml` and `internal/testutil` have no dependencies on other internal packages.
 
 ## Design principles
 
-**Dependency injection everywhere.** Handlers receive their stores as struct fields. No package-level singletons.
+**Dependency injection everywhere.** Handlers receive dependencies as struct fields — no package-level singletons.
 
-**Depend on interfaces, not concrete types.** Each handler declares the smallest interface it needs. This is why `TokensHandler` has a `TokenStore` field typed as the interface, not `*postgresTokenStore`. Same for `DeviceStore` in the auth middleware.
+**Depend on interfaces, not concrete types.** Each handler declares the smallest interface it needs (e.g. `TokenStore`, `DeviceStore`, `ReadingWriter`, `AuthService`). `main.go` is the only wiring point.
 
-**Context-based auth.** The auth middleware stores `DeviceInfo` in the request context via `context.WithValue`. Downstream handlers retrieve it with `auth.DeviceFromContext()` — no need to re-query the DB.
+**Domain packages never import each other.** `sensors`, `auth`, and `account` are fully isolated. Cross-domain dependencies use interfaces (e.g. `auth.UserEventHandler` is satisfied by `account.AccountEventHandler`).
 
-**Transactional safety.** Token creation (device row + token row) is wrapped in a single transaction. A failure at any step rolls back cleanly.
+**`platform` may be imported by any domain.** It has no domain knowledge — only DB setup and middleware.
+
+**Context-based auth.** Device auth middleware stores `DeviceInfo` in the request context. Session auth middleware stores `auth.Claims`. Downstream handlers retrieve them without re-querying the DB.
 
 ## Request lifecycle
 
-### POST /tokens
+### POST /tokens (no auth)
 ```
 TokensHandler.Create
   └── TokenStore.CreateToken(userID)
@@ -51,30 +69,42 @@ TokensHandler.Create
   └── 201 {"token":"...","device_id":"...","user_id":"..."}
 ```
 
-### POST /readings
+### POST /readings (device Bearer token)
 ```
-Authenticator middleware
+DeviceAuthenticator middleware
   ├── parse "Bearer <token>" from Authorization header
-  ├── DeviceStore.LookupByToken(token)
-  │     └── JOIN device_tokens + devices WHERE token = $1
-  ├── 401 if missing or invalid
-  └── store DeviceInfo in request context
+  ├── DeviceStore.LookupByToken(token) → JOIN device_tokens + devices
+  ├── 401 if missing/invalid
+  └── store DeviceInfo{DeviceID, UserID} in context
 
 ReadingsHandler.Create
-  ├── auth.DeviceFromContext(ctx) → DeviceInfo
-  ├── senml.Parse(body) → Reading{Temperature, BaseTime}
+  ├── DeviceFromContext(ctx)
+  ├── ParseSenML(body) → Reading{Measurements, BaseTime}
   ├── 400 on malformed payload
-  ├── log reading (device_id, temperature, base_time)
-  └── 201 {}
+  └── InfluxClient.WriteReading(ctx, Reading) → InfluxDB 3 Core
 ```
 
-### GET /health
+### GET /api/devices and /api/devices/{id}/readings (session JWT)
 ```
-handler.Health → 200 {"status":"ok"}
+SessionAuthenticator middleware
+  ├── read "Bearer <token>" header OR "session" cookie
+  ├── AuthService.ValidateSessionJWT(token) → userID
+  ├── 401 if missing/invalid
+  └── store Claims{UserID} in context
+
+DevicesHandler.List / ReadingsQueryHandler.List
+  ├── ClaimsFromContext(ctx)
+  ├── DeviceStore.ListByUserID / FindByIDAndUserID
+  └── InfluxClient.QueryReadings (for readings endpoint)
 ```
 
-## What's not yet implemented
-
-- **InfluxDB persistence** — readings are logged to stdout but not stored (issue #4)
-- **Grafana stack** — Docker Compose doesn't include InfluxDB/Grafana yet (issue #5)
-- **Token security** — tokens stored as plaintext; hashing/JWT under evaluation (issue #6)
+### POST /auth/verify → session issuance
+```
+VerifyHandler
+  ├── AuthService.VerifyAndUpsert(provider, idToken)
+  │     ├── OIDC ID token verification (go-oidc)
+  │     ├── UserStore.Upsert(email, provider, sub)
+  │     └── UserEventHandler.OnUserVerified → AccountStore.Upsert
+  ├── AuthService.IssueSessionJWT(userID) → signed HS256 JWT
+  └── AuthService.IssueRefreshToken(ctx, userID) → stored hash, return raw
+```

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,33 +1,104 @@
 # Authentication
 
-## Token lifecycle
+FishHub has two separate authentication paths: **device Bearer tokens** (ESP32 → server) and **user session JWTs** (browser → server via the web frontend).
 
-1. **Issue a token** — call `POST /tokens`. The server creates a device record and generates a cryptographically random 64-char hex token (32 bytes from `crypto/rand`).
-2. **Flash the token** — copy the token into the ESP32 firmware's `include/config.h` as `DEVICE_TOKEN`.
-3. **Authenticate requests** — the firmware sends `Authorization: Bearer <token>` on every `POST /readings`.
+---
 
-For the PoC there is no revocation mechanism. Tokens are valid until the device row is deleted from the database.
+## Device Bearer tokens
 
-## Middleware (`internal/auth`)
+### Token lifecycle
 
-`auth.Authenticator(devices DeviceStore)` returns a chi-compatible middleware that:
+1. **Issue** — call `POST /tokens`. The server creates a device row and generates a cryptographically random 64-char hex token (32 bytes from `crypto/rand`).
+2. **Flash** — copy the token into the ESP32 firmware's `include/config.h` as `DEVICE_TOKEN`.
+3. **Authenticate** — the firmware sends `Authorization: Bearer <token>` on every `POST /readings`.
 
-1. Reads the `Authorization` header and extracts the token from `"Bearer <token>"` format
-2. Calls `DeviceStore.LookupByToken(ctx, token)` — a single DB query joining `device_tokens` and `devices`
-3. On success, stores `DeviceInfo{DeviceID, UserID}` in the request context
-4. Returns `401 Unauthorized` if the header is missing, malformed, or the token is unknown
-5. Returns `500` on unexpected DB errors
+For the PoC there is no revocation. Tokens are valid until the `devices` row is deleted.
 
-Downstream handlers retrieve the authenticated device with:
+### `DeviceAuthenticator` middleware (`internal/platform/middleware.go`)
 
+`platform.DeviceAuthenticator(devices sensors.DeviceStore)` returns a chi middleware that:
+
+1. Reads `Authorization` header, extracts token from `"Bearer <token>"` format
+2. Calls `DeviceStore.LookupByToken(ctx, token)` — a JOIN of `device_tokens + devices`
+3. On success, stores `sensors.DeviceInfo{DeviceID, UserID}` in the request context via `sensors.DeviceContextKey`
+4. Returns `401` if header is missing, malformed, or token unknown
+5. Returns `500` on unexpected DB error
+
+Downstream handlers retrieve it with:
 ```go
-device, ok := auth.DeviceFromContext(r.Context())
+device, ok := sensors.DeviceFromContext(r.Context())
 ```
 
-## Token storage
+### Token storage
 
-Tokens are currently stored as **plaintext** `CHAR(64)` in the `device_tokens` table. This is acceptable for the PoC on a local network.
+Tokens are stored as **plaintext** `CHAR(64)` in `device_tokens`. Acceptable for local-network PoC. Issue #6 evaluates hashing or JWT alternatives.
 
-Issue #6 evaluates two hardening options:
-- **Option A** — hash at rest (bcrypt/SHA-256): protects against DB leaks, still requires a DB lookup per request
-- **Option B** — JWT with device ID in claims: stateless verification, no DB round-trip, but tokens can't be individually revoked without a denylist
+---
+
+## User session auth (OIDC + JWT)
+
+### Flow overview
+
+```
+Browser                    Next.js (fishhub-web)       fishhub-server
+  |                               |                          |
+  |-- click "Sign in with Google" |                          |
+  |-- GET /api/auth/login/google  |                          |
+  |<-- redirect to Google OAuth   |                          |
+  |                               |                          |
+  |-- Google redirect callback    |                          |
+  |-- GET /api/auth/callback/google?code=...                 |
+  |                  |-- exchange code → id_token            |
+  |                  |-- POST /auth/verify {provider, id_token}
+  |                  |                         |-- OIDC verify
+  |                  |                         |-- DB upsert user
+  |                  |                         |-- create/update account
+  |                  |                         |-- issue session JWT + refresh token
+  |                  |<-- {token, refresh_token}             |
+  |                  |-- set httpOnly cookies: session, refresh_token
+  |<-- redirect /devices          |                          |
+```
+
+### `AuthService` (`internal/auth/service.go`)
+
+Interface:
+```go
+type AuthService interface {
+    VerifyAndUpsert(ctx, provider, idToken string) (User, error)
+    IssueSessionJWT(userID string) (string, error)
+    ValidateSessionJWT(token string) (string, error)
+    IssueRefreshToken(ctx, userID string) (string, error)
+    RotateRefreshToken(ctx, rawToken string) (newRawToken, sessionJWT string, err error)
+    RevokeRefreshToken(ctx, rawToken string) error
+}
+```
+
+Implemented by `oidcService`. Configured via `auth.NewOIDCService(ctx, OIDCConfig{...})` in `main.go`.
+
+**`VerifyAndUpsert`** — verifies the ID token with the OIDC provider (go-oidc library), upserts the user row, then calls `UserEventHandler.OnUserVerified` (implemented by `account.AccountEventHandler`, which upserts the account row with name/email from ID token claims).
+
+**Session JWT** — HS256, signed with `JWT_SECRET`. Claims: `sub` (user UUID), `iat`, `exp`. Default TTL: 24h (configurable via `JWT_TTL_HOURS`).
+
+**Refresh tokens** — 64-char raw hex token; stored as SHA-256 hash in `refresh_tokens`. TTL: 30 days. Rotation: every `RotateRefreshToken` call revokes the old token and issues a new one.
+
+### `SessionAuthenticator` middleware (`internal/platform/middleware.go`)
+
+`platform.SessionAuthenticator(svc auth.AuthService)` returns a chi middleware that:
+
+1. Reads `Authorization: Bearer <token>` header, or falls back to the `session` cookie
+2. Calls `AuthService.ValidateSessionJWT(token)` → `userID`
+3. On success, stores `auth.Claims{UserID}` in context via `auth.ContextWithClaims`
+4. Returns `401` if token is absent or invalid
+
+Downstream handlers retrieve it with:
+```go
+claims, ok := auth.ClaimsFromContext(r.Context())
+```
+
+### Refresh token rotation (web frontend)
+
+The web frontend's `apiFetch` wrapper automatically retries on `401` by calling `POST /api/auth/refresh` (a Next.js API route), which calls `POST /auth/refresh` on the server. The server rotates the refresh token and issues a new session JWT; the Next.js route updates the `session` cookie.
+
+### Providers
+
+Currently only `"google"` is supported. The OIDC issuer is `https://accounts.google.com`. Configured via `GOOGLE_CLIENT_ID` in the environment.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,21 +1,34 @@
 # Database
 
-FishHub uses **PostgreSQL** for application data (users, devices, tokens). InfluxDB will be added for time-series metrics (issue #4).
+FishHub uses **PostgreSQL** for application data (users, devices, tokens, accounts, refresh tokens) and **InfluxDB 3 Core** for time-series sensor readings.
 
 ## Schema
 
+### `users`
 ```
 users
-├── id          UUID  PK  default gen_random_uuid()
-├── email       TEXT  UNIQUE NOT NULL
-└── created_at  TIMESTAMPTZ  default now()
+├── id           UUID  PK  default gen_random_uuid()
+├── email        TEXT  UNIQUE NOT NULL
+├── provider     TEXT  NOT NULL  default 'local'
+├── provider_sub TEXT  NOT NULL  default ''
+└── created_at   TIMESTAMPTZ  default now()
 
+UNIQUE (provider, provider_sub)
+```
+
+Stores one row per identity. The `provider`/`provider_sub` pair identifies the OAuth account (e.g. `provider='google'`, `provider_sub='<google-sub-claim>'`). The seed user has `provider='local'`.
+
+### `devices`
+```
 devices
 ├── id          UUID  PK  default gen_random_uuid()
 ├── user_id     UUID  FK → users.id  NOT NULL
 ├── name        TEXT  (nullable)
 └── created_at  TIMESTAMPTZ  default now()
+```
 
+### `device_tokens`
+```
 device_tokens
 ├── id          UUID  PK  default gen_random_uuid()
 ├── device_id   UUID  FK → devices.id  UNIQUE NOT NULL
@@ -23,39 +36,78 @@ device_tokens
 └── created_at  TIMESTAMPTZ  default now()
 ```
 
-**Relationships:**
-- One user → many devices
-- One device → one token (enforced by UNIQUE on `device_id`)
+One token per device (enforced by UNIQUE on `device_id`). Tokens are stored as plaintext 64-char hex strings.
+
+### `refresh_tokens`
+```
+refresh_tokens
+├── id          UUID  PK  default gen_random_uuid()
+├── user_id     UUID  FK → users.id ON DELETE CASCADE  NOT NULL
+├── token_hash  CHAR(64)  UNIQUE NOT NULL
+├── expires_at  TIMESTAMPTZ  NOT NULL
+├── revoked_at  TIMESTAMPTZ  (nullable)
+└── created_at  TIMESTAMPTZ  default now()
+
+INDEX refresh_tokens_user_id_idx ON (user_id)
+```
+
+Stores the SHA-256 hash of the raw refresh token (never the raw token). Rotated on every use — old token is revoked, new token is issued.
+
+### `accounts`
+```
+accounts
+├── id          UUID  PK  default gen_random_uuid()
+├── user_id     UUID  UNIQUE NOT NULL
+├── email       TEXT  NOT NULL
+├── name        TEXT  NOT NULL  default ''
+└── created_at  TIMESTAMPTZ  NOT NULL  default now()
+└── updated_at  TIMESTAMPTZ  NOT NULL  default now()
+```
+
+Created/updated automatically via `account.AccountEventHandler.OnUserVerified` on every successful OIDC login. Stores the display name from the ID token claims.
+
+## Relationships
+
+```
+users ──< devices ──< device_tokens
+users ──< refresh_tokens
+users ──  accounts  (1:1 via user_id UNIQUE)
+```
 
 ## Migrations
 
-Migrations live in `db/migrations/` and follow the `golang-migrate` naming convention:
+Migrations live in `db/migrations/` and use the `golang-migrate` naming convention:
 
 ```
 NNN_<description>.up.sql
 NNN_<description>.down.sql
 ```
 
-They run automatically on server startup via `db.Migrate()`. The current migrations are:
+They run automatically on server startup via `platform.Migrate()`. Current migrations:
 
 | # | Description |
 |---|---|
 | 001 | Create `users` table |
 | 002 | Create `devices` table |
 | 003 | Create `device_tokens` table |
+| 004 | Add `provider` + `provider_sub` columns to `users` |
+| 005 | Create `refresh_tokens` table |
+| 006 | Create `accounts` table |
 
-To add a new migration, create the next numbered pair of `.up.sql` / `.down.sql` files in `db/migrations/`.
+To add a migration, create the next numbered `.up.sql` / `.down.sql` pair in `db/migrations/`. Migrations run on the next server startup.
 
 ## Seed data
 
-On every startup, `db.SeedUser()` inserts a hardcoded admin user (idempotent — uses `ON CONFLICT DO NOTHING`):
+`platform.SeedUser()` runs on every startup and inserts a hardcoded device-owner user (idempotent — `ON CONFLICT DO NOTHING`):
 
 | Field | Value |
 |---|---|
 | `id` | `00000000-0000-0000-0000-000000000001` |
 | `email` | `admin@fishhub.local` |
+| `provider` | `local` |
+| `provider_sub` | `seed` |
 
-All tokens created via `POST /tokens` are owned by this user. This is intentional for the PoC — no registration flow is needed.
+Tokens created via `POST /tokens` are always owned by this user. No registration flow needed for the device side of the PoC.
 
 ## Connection
 
@@ -66,3 +118,18 @@ DATABASE_URL=postgres://fishhub:fishhub@localhost:5432/fishhub?sslmode=disable
 ```
 
 The default in the Makefile matches the credentials in `docker-compose.yml`.
+
+## InfluxDB
+
+Time-series readings are written to InfluxDB 3 Core. The `sensors` measurement uses these tags and fields:
+
+| Tag | Value |
+|---|---|
+| `device_id` | UUID of the device |
+| `user_id` | UUID of the owning user |
+
+| Field | Value |
+|---|---|
+| `temperature` | float (Celsius) |
+
+The server writes one point per `POST /readings` request and queries via raw SQL in `ReadingsQueryHandler`. Connection is configured via environment variables (see [development.md](development.md)).

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Go 1.21+
-- Docker (for Postgres and integration tests)
+- Docker (for Postgres, InfluxDB 3 Core, Grafana, and integration tests)
 
 ## Running locally
 
@@ -11,49 +11,65 @@
 make dev
 ```
 
-This starts Postgres via Docker Compose, waits until it's ready, then runs the server. The server listens on `:8080` by default.
+This starts Postgres, InfluxDB 3 Core, and Grafana via Docker Compose, waits until all are healthy, then runs the server. The server listens on `:8080` by default.
+
+The Makefile also prints the machine's local IP addresses (useful for configuring the firmware's `SERVER_URL`).
 
 To use a different port:
 ```bash
 PORT=9090 make dev
 ```
 
-To use a different database:
-```bash
-make dev DATABASE_URL=postgres://user:pass@host/db?sslmode=disable
-```
-
 ## Environment variables
 
-| Variable | Default (Makefile) | Description |
+| Variable | Default (Makefile / `.env`) | Description |
 |---|---|---|
 | `DATABASE_URL` | `postgres://fishhub:fishhub@localhost:5432/fishhub?sslmode=disable` | Postgres connection string |
 | `PORT` | `8080` | HTTP listen port |
+| `INFLUXDB3_HOST` | — | InfluxDB 3 Core host URL (e.g. `http://localhost:8086`) |
+| `INFLUXDB3_TOKEN` | — | InfluxDB admin token |
+| `INFLUXDB3_DATABASE` | — | InfluxDB database name |
+| `GOOGLE_CLIENT_ID` | — | Google OAuth client ID (OIDC verification) |
+| `JWT_SECRET` | — | Secret for signing HS256 session JWTs |
+| `JWT_TTL_HOURS` | `24` | Session JWT validity in hours |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:3001` | Comma-separated list of allowed CORS origins |
 
-InfluxDB env vars will be added when issue #4 is implemented.
+The Makefile sources `.env` automatically via `-include .env`.
 
-## Typical first-run workflow
+If `INFLUXDB3_HOST`, `INFLUXDB3_TOKEN`, and `INFLUXDB3_DATABASE` are all set, the server connects to InfluxDB on startup. If any are missing, the server logs a warning and runs without InfluxDB — readings are accepted and logged but not persisted.
+
+## First-run workflow
 
 ```bash
 make dev                                      # start everything
 
-curl -s -X POST localhost:8080/tokens | jq    # get a token
-# copy "token" value into firmware's config.h as DEVICE_TOKEN
-# copy your machine's local IP into config.h as SERVER_URL
+curl -s -X POST localhost:8080/tokens | jq    # get a device token
+# copy "token" into firmware's config.h as DEVICE_TOKEN
+# copy the printed IP into config.h as SERVER_URL
 
 curl -s localhost:8080/health                 # verify server is up
 ```
 
-## Testing
+## InfluxDB setup
 
-**Unit tests** — use stubs, no Docker required:
+After `make dev`, create the InfluxDB database (first time only):
+
 ```bash
-go test ./internal/handler/... ./internal/senml/... ./internal/auth/...
+make influx-setup
 ```
 
-**Integration tests** — spin up a real Postgres container via testcontainers:
+This runs `influxdb3 create database` inside the InfluxDB container using the configured token and database name from `.env`.
+
+## Testing
+
+**Unit tests** (stubs, no Docker required):
 ```bash
-go test ./internal/store/...
+go test ./internal/auth/... ./internal/sensors/... ./internal/platform/...
+```
+
+**Integration tests** (spin up a real Postgres container via testcontainers, Docker required):
+```bash
+go test ./internal/account/... ./internal/auth/... ./internal/sensors/...
 ```
 
 **All tests:**
@@ -61,17 +77,17 @@ go test ./internal/store/...
 go test ./...
 ```
 
-Integration tests require Docker to be running. Each test gets its own throwaway container with a clean schema — no shared state between tests.
+Integration tests use `testutil.NewTestDB(t)` — each test gets a throwaway Postgres container with a clean schema. No shared state between tests.
 
 ## Adding a new migration
 
 1. Create `db/migrations/NNN_<description>.up.sql` and `NNN_<description>.down.sql`
-2. Migrations run automatically on the next `make dev` / server startup
+2. Migrations run automatically on the next server startup
 
 ## Project conventions
 
 - All dependencies injected via struct fields — no package-level state
 - Handlers depend on interfaces, not concrete store types
-- New stores go in `internal/store/`, new handlers in `internal/handler/`
-- Integration tests use `testutil.NewTestDB(t)` to get an isolated DB
-- See [architecture.md](architecture.md) for the full picture
+- Domain packages (`sensors`, `auth`, `account`) never import each other
+- Integration tests use `testutil.NewTestDB(t)` — never mock the database
+- See [architecture.md](architecture.md) for the full package picture

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # fishhub-server — Documentation Index
 
-FishHub backend server: receives temperature readings from ESP32 devices, authenticates them via Bearer tokens, and stores data for visualization.
+FishHub backend server: receives temperature readings from ESP32 devices, authenticates them via Bearer tokens, stores data in InfluxDB, and serves a JSON API for the web frontend.
 
 ## Contents
 
@@ -9,13 +9,13 @@ FishHub backend server: receives temperature readings from ESP32 devices, authen
 | [architecture.md](architecture.md) | Package layout, data flow, design principles |
 | [api.md](api.md) | HTTP endpoints, request/response formats |
 | [database.md](database.md) | Schema, migrations, seed data |
-| [auth.md](auth.md) | Token lifecycle, auth middleware |
+| [auth.md](auth.md) | Device token lifecycle, OIDC/JWT session auth, middleware |
 | [development.md](development.md) | Running locally, environment variables, testing |
 
 ## Quick start
 
 ```bash
-make dev                          # start Postgres + run server
+make dev                          # start Postgres + InfluxDB + Grafana, then run server
 curl -s -X POST localhost:8080/tokens | jq   # get a device token
 curl -s localhost:8080/health                # verify server is up
 ```
@@ -24,6 +24,7 @@ curl -s localhost:8080/health                # verify server is up
 
 - **Language:** Go
 - **Router:** chi v5
-- **Database:** PostgreSQL (application data) · InfluxDB (metrics, upcoming)
+- **Database:** PostgreSQL (application data) · InfluxDB 3 Core (time-series readings)
 - **Migrations:** golang-migrate
+- **Auth:** Google OIDC → JWT session + refresh token rotation; device Bearer tokens
 - **Tests:** unit (stubs) + integration (testcontainers)


### PR DESCRIPTION
Audits and rewrites all six doc files to match the current codebase, which has grown significantly since the docs were originally written:

**`index.md`** — updated tech stack (InfluxDB now live, OIDC auth added)

**`architecture.md`** — complete rewrite of package layout (`sensors`, `auth`, `account`, `platform`), updated dependency graph, full request lifecycle diagrams for all endpoint groups, OIDC verify flow

**`api.md`** — adds all missing endpoints: `POST /auth/verify`, `POST /auth/refresh`, `POST /auth/logout`, `GET /api/me`, `GET /api/devices`, `GET /api/devices/{id}/readings`; updates `/readings` to document InfluxDB 500 error

**`database.md`** — adds migrations 004–006 (`provider` columns on `users`, `refresh_tokens` table, `accounts` table), documents InfluxDB measurement schema with tags/fields

**`auth.md`** — full rewrite covering both auth paths: device Bearer tokens and OIDC/JWT session auth with refresh token rotation; documents `DeviceAuthenticator` and `SessionAuthenticator` middleware accurately

**`development.md`** — adds all env vars (InfluxDB, Google, JWT, CORS), `make influx-setup` step, updated test commands matching actual package paths

Closes #30