### PR TITLE
feat: add device provisioning flow

### DIFF
--- a/db/migrations/007_add_device_status.down.sql
+++ b/db/migrations/007_add_device_status.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX devices_user_id_status_idx;
+DROP INDEX devices_status_idx;
+ALTER TABLE devices DROP COLUMN status;

--- a/db/migrations/007_add_device_status.up.sql
+++ b/db/migrations/007_add_device_status.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE devices
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'active'));
+
+CREATE INDEX devices_status_idx ON devices (status);
+CREATE INDEX devices_user_id_status_idx ON devices (user_id, status);

--- a/db/migrations/008_create_provisioning_codes.down.sql
+++ b/db/migrations/008_create_provisioning_codes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE provisioning_codes;

--- a/db/migrations/008_create_provisioning_codes.up.sql
+++ b/db/migrations/008_create_provisioning_codes.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE provisioning_codes (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code       CHAR(6) NOT NULL UNIQUE,
+    device_id  UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,15 +170,88 @@ Cookie: session=<session-jwt>
 
 ---
 
-## GET /api/devices
+## POST /api/devices/provision
 
-Returns all devices belonging to the authenticated user.
+Creates (or returns the existing) pending device for the authenticated user, along with a 6-character pairing code. Idempotent — repeated calls return the same pending device and code until the device is activated.
 
 **Headers** (one of):
 ```
 Authorization: Bearer <session-jwt>
 Cookie: session=<session-jwt>
 ```
+
+No request body required.
+
+**Response `201`**
+```json
+{
+  "code":      "A1B2C3",
+  "device_id": "a1b2c3d4-..."
+}
+```
+
+| Field | Description |
+|---|---|
+| `code` | 6-char alphanumeric pairing code. Display this to the user (e.g. QR code or text) so they can enter it on the device captive portal. |
+| `device_id` | UUID of the pending device. |
+
+**Response `401`** — not authenticated
+
+**Response `500`** — DB failure
+
+---
+
+## POST /devices/activate
+
+Called by the ESP32 after the user enters the pairing code on the captive portal. No session auth required — the code itself is the credential. Marks the device active and issues a Bearer token.
+
+No auth header required.
+
+**Request body**
+```json
+{
+  "code": "A1B2C3"
+}
+```
+
+**Response `201`**
+```json
+{
+  "token":     "b0a1aba84035c6844d739100e3a93f5911f7ecaf82cbf5bbb33306a1509854a5",
+  "device_id": "a1b2c3d4-..."
+}
+```
+
+| Field | Description |
+|---|---|
+| `token` | 64-char hex Bearer token. The device stores this in NVS and uses it for all subsequent `/readings` calls. |
+| `device_id` | UUID of the now-active device. |
+
+**Response `400`** — missing or empty `code`
+
+**Response `404`** — code not found
+
+**Response `409`** — code already used
+
+**Response `500`** — DB or token-generation failure
+
+---
+
+## GET /api/devices
+
+Returns devices belonging to the authenticated user. Pass `?status=active` (recommended) to exclude pending devices.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Query parameters**
+
+| Param | Values | Default | Description |
+|---|---|---|---|
+| `status` | `active`, `pending`, _(empty)_ | _(empty)_ | Filter by device status. Omit to return all devices. |
 
 **Response `200`**
 ```json

--- a/internal/platform/middleware_test.go
+++ b/internal/platform/middleware_test.go
@@ -39,7 +39,7 @@ func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (sensors.De
 	return s.info, s.err
 }
 
-func (s *stubDeviceStore) ListByUserID(_ context.Context, _ string) ([]sensors.Device, error) {
+func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensors.Device, error) {
 	return nil, nil
 }
 

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -29,7 +29,8 @@ func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := h.Store.ListByUserID(r.Context(), claims.UserID)
+	status := r.URL.Query().Get("status")
+	devices, err := h.Store.ListByUserID(r.Context(), claims.UserID, status)
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
@@ -211,4 +212,81 @@ func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	render.Status(r, http.StatusCreated)
 	render.JSON(w, r, map[string]string{})
+}
+
+// ProvisionHandler handles POST /devices/provision (session auth).
+type ProvisionHandler struct {
+	Store ProvisioningStore
+}
+
+type provisionResponse struct {
+	Code     string `json:"code"`
+	DeviceID string `json:"device_id"`
+}
+
+func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	deviceID, code, err := h.Store.GetOrCreatePending(r.Context(), claims.UserID)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, provisionResponse{Code: code, DeviceID: deviceID})
+}
+
+// ActivateHandler handles POST /devices/activate (no auth — called by the device).
+type ActivateHandler struct {
+	Store ProvisioningStore
+}
+
+type activateRequest struct {
+	Code string `json:"code"`
+}
+
+type activateResponse struct {
+	Token    string `json:"token"`
+	DeviceID string `json:"device_id"`
+}
+
+func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req activateRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil || req.Code == "" {
+		http.Error(w, "code is required", http.StatusBadRequest)
+		return
+	}
+
+	deviceID, err := h.Store.ClaimCode(r.Context(), req.Code)
+	if err != nil {
+		if errors.Is(err, ErrCodeNotFound) {
+			http.Error(w, "provisioning code not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrCodeAlreadyUsed) {
+			http.Error(w, "provisioning code already used", http.StatusConflict)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	token, err := generateToken()
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.Store.Activate(r.Context(), deviceID, token); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, activateResponse{Token: token, DeviceID: deviceID})
 }

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -92,7 +92,7 @@ type stubDeviceStore struct {
 	findErr      error
 }
 
-func (s *stubDeviceStore) ListByUserID(_ context.Context, _ string) ([]sensors.Device, error) {
+func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensors.Device, error) {
 	return nil, nil
 }
 
@@ -333,6 +333,156 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 		}
 		if body.From == "" || body.To == "" {
 			t.Error("expected from/to to be set to defaults")
+		}
+	})
+}
+
+// --- ProvisionHandler ---
+
+type stubProvisioningStore struct {
+	deviceID string
+	code     string
+	getErr   error
+
+	claimedDeviceID string
+	claimErr        error
+
+	activateErr error
+}
+
+func (s *stubProvisioningStore) GetOrCreatePending(_ context.Context, _ string) (string, string, error) {
+	return s.deviceID, s.code, s.getErr
+}
+
+func (s *stubProvisioningStore) ClaimCode(_ context.Context, _ string) (string, error) {
+	return s.claimedDeviceID, s.claimErr
+}
+
+func (s *stubProvisioningStore) Activate(_ context.Context, _, _ string) error {
+	return s.activateErr
+}
+
+func TestProvisionHandler(t *testing.T) {
+	t.Run("returns 201 with code and device_id", func(t *testing.T) {
+		h := &sensors.ProvisionHandler{
+			Store: &stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"},
+		}
+		req := withClaims(httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil), "user-uuid")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d", rec.Code)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["code"] != "ABC123" {
+			t.Errorf("expected code ABC123, got %s", body["code"])
+		}
+		if body["device_id"] != "dev-uuid" {
+			t.Errorf("expected device_id dev-uuid, got %s", body["device_id"])
+		}
+	})
+
+	t.Run("missing claims returns 401", func(t *testing.T) {
+		h := &sensors.ProvisionHandler{Store: &stubProvisioningStore{}}
+		req := httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("store error returns 500", func(t *testing.T) {
+		h := &sensors.ProvisionHandler{
+			Store: &stubProvisioningStore{getErr: errors.New("db down")},
+		}
+		req := withClaims(httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil), "user-uuid")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+}
+
+// --- ActivateHandler ---
+
+func TestActivateHandler(t *testing.T) {
+	validBody := `{"code":"ABC123"}`
+
+	t.Run("returns 201 with token and device_id", func(t *testing.T) {
+		h := &sensors.ActivateHandler{
+			Store: &stubProvisioningStore{claimedDeviceID: "dev-uuid"},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d", rec.Code)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["device_id"] != "dev-uuid" {
+			t.Errorf("expected device_id dev-uuid, got %s", body["device_id"])
+		}
+		if len(body["token"]) != 64 {
+			t.Errorf("expected 64-char token, got %d chars", len(body["token"]))
+		}
+	})
+
+	t.Run("missing code returns 400", func(t *testing.T) {
+		h := &sensors.ActivateHandler{Store: &stubProvisioningStore{}}
+		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(`{}`))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("unknown code returns 404", func(t *testing.T) {
+		h := &sensors.ActivateHandler{
+			Store: &stubProvisioningStore{claimErr: sensors.ErrCodeNotFound},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("already used code returns 409", func(t *testing.T) {
+		h := &sensors.ActivateHandler{
+			Store: &stubProvisioningStore{claimErr: sensors.ErrCodeAlreadyUsed},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusConflict {
+			t.Errorf("expected 409, got %d", rec.Code)
+		}
+	})
+
+	t.Run("activate error returns 500", func(t *testing.T) {
+		h := &sensors.ActivateHandler{
+			Store: &stubProvisioningStore{
+				claimedDeviceID: "dev-uuid",
+				activateErr:     errors.New("db down"),
+			},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
 		}
 	})
 }

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 )
 
-var ErrTokenNotFound = errors.New("token not found")
-var ErrDeviceNotFound = errors.New("device not found")
+var ErrTokenNotFound    = errors.New("token not found")
+var ErrDeviceNotFound   = errors.New("device not found")
+var ErrCodeNotFound     = errors.New("provisioning code not found")
+var ErrCodeAlreadyUsed  = errors.New("provisioning code already used")
 
 type DeviceInfo struct {
 	DeviceID string

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -13,10 +13,23 @@ type Device struct {
 
 type DeviceStore interface {
 	LookupByToken(ctx context.Context, token string) (DeviceInfo, error)
-	ListByUserID(ctx context.Context, userID string) ([]Device, error)
+	// ListByUserID returns devices owned by userID. If status is non-empty, only
+	// devices with that status are returned.
+	ListByUserID(ctx context.Context, userID, status string) ([]Device, error)
 	FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error)
 }
 
 type TokenStore interface {
 	CreateToken(ctx context.Context, userID string) (TokenResult, error)
+}
+
+type ProvisioningStore interface {
+	// GetOrCreatePending returns the existing pending device + code for the user,
+	// or creates both atomically if none exists.
+	GetOrCreatePending(ctx context.Context, userID string) (deviceID, code string, err error)
+	// ClaimCode marks the code as used and returns the associated device ID.
+	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
+	ClaimCode(ctx context.Context, code string) (deviceID string, err error)
+	// Activate writes the Bearer token into device_tokens and sets the device status to active.
+	Activate(ctx context.Context, deviceID, token string) error
 }

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -17,13 +17,26 @@ func NewDeviceStore(db *sql.DB) DeviceStore {
 	return &postgresDeviceStore{db: db}
 }
 
-func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID string) ([]Device, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, COALESCE(name, ''), created_at
-		FROM devices
-		WHERE user_id = $1
-		ORDER BY created_at DESC
-	`, userID)
+func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID, status string) ([]Device, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if status != "" {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, COALESCE(name, ''), created_at
+			FROM devices
+			WHERE user_id = $1 AND status = $2
+			ORDER BY created_at DESC
+		`, userID, status)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, COALESCE(name, ''), created_at
+			FROM devices
+			WHERE user_id = $1
+			ORDER BY created_at DESC
+		`, userID)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("list devices: %w", err)
 	}

--- a/internal/sensors/store_provisioning_integration_test.go
+++ b/internal/sensors/store_provisioning_integration_test.go
@@ -1,0 +1,198 @@
+package sensors_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/platform"
+	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+)
+
+func TestGetOrCreatePending_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewProvisioningStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	t.Run("creates a pending device and code on first call", func(t *testing.T) {
+		deviceID, code, err := store.GetOrCreatePending(ctx, userID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deviceID == "" {
+			t.Error("expected non-empty device_id")
+		}
+		if len(code) != 6 {
+			t.Errorf("expected 6-char code, got %q", code)
+		}
+	})
+
+	t.Run("second call returns same device and code", func(t *testing.T) {
+		var uid string
+		if err := db.QueryRowContext(ctx, `
+			INSERT INTO users (email, provider, provider_sub)
+			VALUES ('idempotent@test.com', 'test', 'sub-idempotent')
+			RETURNING id`,
+		).Scan(&uid); err != nil {
+			t.Fatalf("insert user: %v", err)
+		}
+
+		deviceID1, code1, err := store.GetOrCreatePending(ctx, uid)
+		if err != nil {
+			t.Fatalf("first call: %v", err)
+		}
+		deviceID2, code2, err := store.GetOrCreatePending(ctx, uid)
+		if err != nil {
+			t.Fatalf("second call: %v", err)
+		}
+		if deviceID1 != deviceID2 {
+			t.Errorf("expected same device_id, got %s and %s", deviceID1, deviceID2)
+		}
+		if code1 != code2 {
+			t.Errorf("expected same code, got %s and %s", code1, code2)
+		}
+	})
+}
+
+func TestClaimCode_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewProvisioningStore(db)
+	ctx := context.Background()
+
+	insertUser := func(t *testing.T, suffix string) string {
+		t.Helper()
+		var uid string
+		if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+			INSERT INTO users (email, provider, provider_sub)
+			VALUES ('claim-%s@test.com', 'test', 'sub-claim-%s')
+			RETURNING id`, suffix, suffix),
+		).Scan(&uid); err != nil {
+			t.Fatalf("insert user: %v", err)
+		}
+		return uid
+	}
+
+	t.Run("claims code and returns device_id", func(t *testing.T) {
+		userID := insertUser(t, "a")
+		deviceID, code, err := store.GetOrCreatePending(ctx, userID)
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		claimedDeviceID, err := store.ClaimCode(ctx, code)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if claimedDeviceID != deviceID {
+			t.Errorf("expected device_id %s, got %s", deviceID, claimedDeviceID)
+		}
+	})
+
+	t.Run("claiming same code twice returns ErrCodeAlreadyUsed", func(t *testing.T) {
+		userID := insertUser(t, "b")
+		_, code, err := store.GetOrCreatePending(ctx, userID)
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		if _, err := store.ClaimCode(ctx, code); err != nil {
+			t.Fatalf("first claim: %v", err)
+		}
+
+		_, err = store.ClaimCode(ctx, code)
+		if !errors.Is(err, sensors.ErrCodeAlreadyUsed) {
+			t.Errorf("expected ErrCodeAlreadyUsed, got %v", err)
+		}
+	})
+
+	t.Run("unknown code returns ErrCodeNotFound", func(t *testing.T) {
+		_, err := store.ClaimCode(ctx, "XXXXXX")
+		if !errors.Is(err, sensors.ErrCodeNotFound) {
+			t.Errorf("expected ErrCodeNotFound, got %v", err)
+		}
+	})
+}
+
+func TestActivate_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewProvisioningStore(db)
+	deviceStore := sensors.NewDeviceStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	t.Run("sets device status to active and stores token", func(t *testing.T) {
+		deviceID, code, err := store.GetOrCreatePending(ctx, userID)
+		if err != nil {
+			t.Fatalf("setup provision: %v", err)
+		}
+		if _, err := store.ClaimCode(ctx, code); err != nil {
+			t.Fatalf("setup claim: %v", err)
+		}
+
+		token := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+		if err := store.Activate(ctx, deviceID, token); err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+
+		info, err := deviceStore.LookupByToken(ctx, token)
+		if err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+		if info.DeviceID != deviceID {
+			t.Errorf("expected device_id %s, got %s", deviceID, info.DeviceID)
+		}
+	})
+
+	t.Run("active device appears in ListByUserID with status filter", func(t *testing.T) {
+		var uid string
+		if err := db.QueryRowContext(ctx, `
+			INSERT INTO users (email, provider, provider_sub)
+			VALUES ('activate-list@test.com', 'test', 'sub-activate-list')
+			RETURNING id`,
+		).Scan(&uid); err != nil {
+			t.Fatalf("insert user: %v", err)
+		}
+
+		deviceID, code, err := store.GetOrCreatePending(ctx, uid)
+		if err != nil {
+			t.Fatalf("setup provision: %v", err)
+		}
+		if _, err := store.ClaimCode(ctx, code); err != nil {
+			t.Fatalf("setup claim: %v", err)
+		}
+		token := "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+		if err := store.Activate(ctx, deviceID, token); err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+
+		active, err := deviceStore.ListByUserID(ctx, uid, "active")
+		if err != nil {
+			t.Fatalf("list active: %v", err)
+		}
+		found := false
+		for _, d := range active {
+			if d.ID == deviceID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected activated device %s in active list", deviceID)
+		}
+
+		_, _, err = store.GetOrCreatePending(ctx, uid)
+		if err != nil {
+			t.Fatalf("create pending: %v", err)
+		}
+		active2, err := deviceStore.ListByUserID(ctx, uid, "active")
+		if err != nil {
+			t.Fatalf("list active after pending: %v", err)
+		}
+		if len(active2) != len(active) {
+			t.Errorf("pending device leaked into active list (before: %d, after: %d)", len(active), len(active2))
+		}
+	})
+}

--- a/internal/sensors/store_provisioning_postgres.go
+++ b/internal/sensors/store_provisioning_postgres.go
@@ -1,0 +1,152 @@
+package sensors
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+const provisioningCodeCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+type postgresProvisioningStore struct {
+	db *sql.DB
+}
+
+func NewProvisioningStore(db *sql.DB) ProvisioningStore {
+	return &postgresProvisioningStore{db: db}
+}
+
+func (s *postgresProvisioningStore) GetOrCreatePending(ctx context.Context, userID string) (string, string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var deviceID, code string
+	err = tx.QueryRowContext(ctx, `
+		SELECT d.id, pc.code
+		FROM devices d
+		JOIN provisioning_codes pc ON pc.device_id = d.id
+		WHERE d.user_id = $1 AND d.status = 'pending'
+		LIMIT 1
+		FOR UPDATE
+	`, userID).Scan(&deviceID, &code)
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", "", fmt.Errorf("lookup pending device: %w", err)
+	}
+
+	if err == nil {
+		// existing pending device — return as-is
+		if err := tx.Commit(); err != nil {
+			return "", "", fmt.Errorf("commit tx: %w", err)
+		}
+		return deviceID, code, nil
+	}
+
+	// no pending device — create one
+	if err := tx.QueryRowContext(ctx, `
+		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
+	`, userID).Scan(&deviceID); err != nil {
+		return "", "", fmt.Errorf("insert device: %w", err)
+	}
+
+	code, err = generateCode()
+	if err != nil {
+		return "", "", err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO provisioning_codes (code, device_id) VALUES ($1, $2)
+	`, code, deviceID); err != nil {
+		return "", "", fmt.Errorf("insert provisioning code: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", "", fmt.Errorf("commit tx: %w", err)
+	}
+	return deviceID, code, nil
+}
+
+func (s *postgresProvisioningStore) ClaimCode(ctx context.Context, code string) (string, error) {
+	// check existence and used state before attempting update
+	var usedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, `
+		SELECT used_at FROM provisioning_codes WHERE code = $1
+	`, code).Scan(&usedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrCodeNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("lookup code: %w", err)
+	}
+	if usedAt.Valid {
+		return "", ErrCodeAlreadyUsed
+	}
+
+	var deviceID string
+	err = s.db.QueryRowContext(ctx, `
+		UPDATE provisioning_codes
+		SET used_at = now()
+		WHERE code = $1 AND used_at IS NULL
+		RETURNING device_id
+	`, code).Scan(&deviceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		// raced — another request claimed it between our SELECT and UPDATE
+		return "", ErrCodeAlreadyUsed
+	}
+	if err != nil {
+		return "", fmt.Errorf("claim code: %w", err)
+	}
+	return deviceID, nil
+}
+
+func (s *postgresProvisioningStore) Activate(ctx context.Context, deviceID, token string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO device_tokens (device_id, token) VALUES ($1, $2)
+	`, deviceID, token); err != nil {
+		return fmt.Errorf("insert device token: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE devices SET status = 'active' WHERE id = $1
+	`, deviceID); err != nil {
+		return fmt.Errorf("activate device: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+func generateCode() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate code: %w", err)
+	}
+	code := make([]byte, 6)
+	for i, v := range b {
+		code[i] = provisioningCodeCharset[int(v)%len(provisioningCodeCharset)]
+	}
+	return string(code), nil
+}
+
+// generateToken produces a 64-char hex Bearer token.
+func generateToken() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -154,7 +154,7 @@ func TestListByUserID_integration(t *testing.T) {
 			t.Fatalf("setup token 2: %v", err)
 		}
 
-		devices, err := store.ListByUserID(ctx, userID)
+		devices, err := store.ListByUserID(ctx, userID, "")
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}
@@ -183,7 +183,7 @@ func TestListByUserID_integration(t *testing.T) {
 			t.Fatalf("insert user: %v", err)
 		}
 
-		devices, err := store.ListByUserID(ctx, newUserID)
+		devices, err := store.ListByUserID(ctx, newUserID, "")
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -99,7 +99,10 @@ func main() {
 	r.Post("/auth/verify", (&auth.VerifyHandler{Service: authSvc}).ServeHTTP)
 	r.Post("/auth/refresh", (&auth.RefreshHandler{Service: authSvc}).ServeHTTP)
 	r.Post("/auth/logout", (&auth.LogoutHandler{Service: authSvc}).ServeHTTP)
+	provisioningStore := sensors.NewProvisioningStore(db)
+
 	r.Post("/tokens", tokens.Create)
+	r.Post("/devices/activate", (&sensors.ActivateHandler{Store: provisioningStore}).ServeHTTP)
 	r.Group(func(r chi.Router) {
 		r.Use(platform.DeviceAuthenticator(sensors.NewDeviceStore(db)))
 		r.Post("/readings", readings.Create)
@@ -108,6 +111,7 @@ func main() {
 		r.Use(platform.SessionAuthenticator(authSvc))
 		r.Get("/api/me", (&account.MeHandler{Store: accountStore}).ServeHTTP)
 		deviceStore := sensors.NewDeviceStore(db)
+		r.Post("/api/devices/provision", (&sensors.ProvisionHandler{Store: provisioningStore}).ServeHTTP)
 		r.Get("/api/devices", (&sensors.DevicesHandler{Store: deviceStore}).List)
 		r.Get("/api/devices/{id}/readings", (&sensors.ReadingsQueryHandler{
 			Querier: influxClient,

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "./fishhub-server"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"

--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,9 @@
 [build]
 builder = "nixpacks"
+buildCommand = "go build -o /app/fishhub-server ."
 
 [deploy]
-startCommand = "./fishhub-server"
+startCommand = "/app/fishhub-server"
 healthcheckPath = "/health"
 healthcheckTimeout = 30
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## Summary

- Adds `devices.status` column (`pending`/`active`) with two indexes; new `provisioning_codes` table (migrations 007–008)
- `ProvisioningStore` with three operations: `GetOrCreatePending` (idempotent — reuses existing pending device+code), `ClaimCode` (single-use guard), `Activate` (issues bearer token, marks device active)
- `POST /api/devices/provision` (session auth) — web app calls this to get the pairing code to show the user
- `POST /devices/activate` (no auth) — ESP32 calls this with the code to get its bearer token
- `GET /api/devices?status=active` filter so pending devices don't appear in the device list

## Test plan

- [x] Unit tests for `ProvisionHandler` and `ActivateHandler` (success + all error paths)
- [x] Integration tests for `GetOrCreatePending`, `ClaimCode`, `Activate` (idempotency, single-use, not-found, status filter)
- [x] `go test ./...` — all packages green

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)