### PR TITLE
feat: add PATCH /api/devices/:id to update device name

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -262,6 +262,38 @@ Cookie: session=<session-jwt>
 
 ---
 
+## PATCH /api/devices/{id}
+
+Updates the name of a device owned by the authenticated user.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Request body**
+```json
+{
+  "name": "Tank A"
+}
+```
+
+**Response `200`**
+```json
+{"id": "...", "name": "Tank A", "created_at": "2024-04-13T12:00:00Z"}
+```
+
+**Response `400`** — missing or empty `name`
+
+**Response `401`** — not authenticated
+
+**Response `404`** — device not found or not owned by the authenticated user
+
+**Response `500`** — DB failure
+
+---
+
 ## GET /api/devices/{id}/readings
 
 Returns temperature readings for a device within a time window.

--- a/internal/platform/middleware_test.go
+++ b/internal/platform/middleware_test.go
@@ -43,6 +43,10 @@ func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensor
 	return nil, nil
 }
 
+func (s *stubDeviceStore) PatchDevice(_ context.Context, _, _, _ string) (sensors.Device, error) {
+	return sensors.Device{}, nil
+}
+
 func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sensors.Device, error) {
 	return sensors.Device{}, nil
 }

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -214,6 +214,46 @@ func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, map[string]string{})
 }
 
+// PatchDeviceHandler handles PATCH /api/devices/{id} (session auth).
+type PatchDeviceHandler struct {
+	Store DeviceStore
+}
+
+type patchDeviceRequest struct {
+	Name string `json:"name"`
+}
+
+func (h *PatchDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req patchDeviceRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil || req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	device, err := h.Store.PatchDevice(r.Context(), deviceID, claims.UserID, req.Name)
+	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, DeviceResponse{
+		ID:        device.ID,
+		Name:      device.Name,
+		CreatedAt: device.CreatedAt.UTC().Format(time.RFC3339),
+	})
+}
+
 // ProvisionHandler handles POST /devices/provision (session auth).
 type ProvisionHandler struct {
 	Store ProvisioningStore

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -87,9 +87,11 @@ func (s *stubReadingWriter) WriteReading(_ context.Context, r sensors.Reading) e
 }
 
 type stubDeviceStore struct {
-	info         sensors.DeviceInfo
-	device       sensors.Device
-	findErr      error
+	info        sensors.DeviceInfo
+	device      sensors.Device
+	findErr     error
+	patchDevice sensors.Device
+	patchErr    error
 }
 
 func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensors.Device, error) {
@@ -102,6 +104,10 @@ func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (sensors.De
 
 func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sensors.Device, error) {
 	return s.device, s.findErr
+}
+
+func (s *stubDeviceStore) PatchDevice(_ context.Context, _, _, _ string) (sensors.Device, error) {
+	return s.patchDevice, s.patchErr
 }
 
 type stubReadingQuerier struct {
@@ -333,6 +339,78 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 		}
 		if body.From == "" || body.To == "" {
 			t.Error("expected from/to to be set to defaults")
+		}
+	})
+}
+
+// --- PatchDeviceHandler ---
+
+func TestPatchDeviceHandler(t *testing.T) {
+	ts := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	makeReq := func(deviceID, body string) *http.Request {
+		req := httptest.NewRequest(http.MethodPatch, "/api/devices/"+deviceID, strings.NewReader(body))
+		req = withClaims(req, "user-uuid")
+		req = withChiParam(req, "id", deviceID)
+		return req
+	}
+
+	t.Run("valid name returns 200 with updated device", func(t *testing.T) {
+		updated := sensors.Device{ID: "dev-1", Name: "Tank A", CreatedAt: ts}
+		h := &sensors.PatchDeviceHandler{Store: &stubDeviceStore{patchDevice: updated}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-1", `{"name":"Tank A"}`))
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var body sensors.DeviceResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.Name != "Tank A" {
+			t.Errorf("expected name 'Tank A', got %q", body.Name)
+		}
+		if body.ID != "dev-1" {
+			t.Errorf("expected id 'dev-1', got %q", body.ID)
+		}
+	})
+
+	t.Run("empty name returns 400", func(t *testing.T) {
+		h := &sensors.PatchDeviceHandler{Store: &stubDeviceStore{}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-1", `{"name":""}`))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("device not found returns 404", func(t *testing.T) {
+		h := &sensors.PatchDeviceHandler{Store: &stubDeviceStore{patchErr: sensors.ErrDeviceNotFound}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-x", `{"name":"Tank A"}`))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("store error returns 500", func(t *testing.T) {
+		h := &sensors.PatchDeviceHandler{Store: &stubDeviceStore{patchErr: errors.New("db down")}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-1", `{"name":"Tank A"}`))
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+
+	t.Run("missing claims returns 401", func(t *testing.T) {
+		h := &sensors.PatchDeviceHandler{Store: &stubDeviceStore{}}
+		req := httptest.NewRequest(http.MethodPatch, "/api/devices/dev-1", strings.NewReader(`{"name":"Tank A"}`))
+		req = withChiParam(req, "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
 		}
 	})
 }

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -17,6 +17,9 @@ type DeviceStore interface {
 	// devices with that status are returned.
 	ListByUserID(ctx context.Context, userID, status string) ([]Device, error)
 	FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error)
+	// PatchDevice updates the name of the device owned by userID.
+	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.
+	PatchDevice(ctx context.Context, deviceID, userID, name string) (Device, error)
 }
 
 type TokenStore interface {

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -69,6 +69,23 @@ func (s *postgresDeviceStore) FindByIDAndUserID(ctx context.Context, deviceID, u
 	return d, nil
 }
 
+func (s *postgresDeviceStore) PatchDevice(ctx context.Context, deviceID, userID, name string) (Device, error) {
+	var d Device
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE devices
+		SET name = $1
+		WHERE id = $2 AND user_id = $3
+		RETURNING id, COALESCE(name, ''), created_at
+	`, name, deviceID, userID).Scan(&d.ID, &d.Name, &d.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Device{}, ErrDeviceNotFound
+	}
+	if err != nil {
+		return Device{}, fmt.Errorf("patch device: %w", err)
+	}
+	return d, nil
+}
+
 func (s *postgresDeviceStore) LookupByToken(ctx context.Context, token string) (DeviceInfo, error) {
 	var info DeviceInfo
 	err := s.db.QueryRowContext(ctx, `

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   allowedOrigins,
-		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "PATCH", "OPTIONS"},
 		AllowedHeaders:   []string{"Content-Type", "Authorization"},
 		AllowCredentials: true,
 	}))
@@ -113,6 +113,7 @@ func main() {
 		deviceStore := sensors.NewDeviceStore(db)
 		r.Post("/api/devices/provision", (&sensors.ProvisionHandler{Store: provisioningStore}).ServeHTTP)
 		r.Get("/api/devices", (&sensors.DevicesHandler{Store: deviceStore}).List)
+		r.Patch("/api/devices/{id}", (&sensors.PatchDeviceHandler{Store: deviceStore}).ServeHTTP)
 		r.Get("/api/devices/{id}/readings", (&sensors.ReadingsQueryHandler{
 			Querier: influxClient,
 			Devices: deviceStore,


### PR DESCRIPTION
## Summary

- Adds `PatchDevice(ctx, deviceID, userID, name)` to `DeviceStore` interface and Postgres implementation using `UPDATE ... RETURNING`
- Adds `PatchDeviceHandler` that returns the updated device as JSON (`200`) on success
- Returns `400` for empty name, `404` if device not found or not owned by the user
- Adds PATCH to CORS allowed methods
- Unit tests covering all cases
- Documents `PATCH /api/devices/{id}` in `docs/api.md`

## Test plan

- [ ] `go test ./internal/sensors/ -run TestPatchDeviceHandler` passes
- [ ] `go build ./...` clean

Closes #35