### PR TITLE
docs: update docs to reflect PATCH /api/devices/:id

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,13 +5,20 @@
 ```
 fishhub-server/
 ├── main.go                  # entry point: wires everything together
+├── railway.toml             # Railway deployment config (build + start commands, health check)
 ├── db/
 │   └── migrations/          # SQL migration files (golang-migrate format)
 └── internal/
     ├── sensors/             # domain: device tokens, readings ingestion + query, InfluxDB, SenML
-    │   ├── handler.go               TokensHandler, ReadingsHandler, ReadingsQueryHandler, DevicesHandler
-    │   ├── store.go                 DeviceStore + TokenStore interfaces
-    │   ├── store_postgres.go        Postgres implementations
+    │   ├── handler.go               TokensHandler, ReadingsHandler, ReadingsQueryHandler,
+    │   │                            DevicesHandler, ProvisionHandler, ActivateHandler,
+    │   │                            PatchDeviceHandler
+    │   ├── store.go                 DeviceStore, TokenStore, ProvisioningStore interfaces
+    │   │                            + error sentinels (ErrCodeNotFound, ErrCodeAlreadyUsed,
+    │   │                            ErrDeviceNotFound, ErrTokenNotFound)
+    │   ├── store_postgres.go        DeviceStore + TokenStore Postgres impls (incl. PatchDevice)
+    │   ├── store_provisioning_postgres.go  ProvisioningStore Postgres impl
+    │   │                            (GetOrCreatePending, ClaimCode, Activate)
     │   ├── influx.go                InfluxClient (ReadingWriter + ReadingQuerier), influxDBClient
     │   ├── senml.go                 SenML RFC 8428 parser
     │   └── model.go                 DeviceInfo, TokenResult, Reading, context helpers
@@ -94,8 +101,52 @@ SessionAuthenticator middleware
 
 DevicesHandler.List / ReadingsQueryHandler.List
   ├── ClaimsFromContext(ctx)
-  ├── DeviceStore.ListByUserID / FindByIDAndUserID
+  ├── DeviceStore.ListByUserID (accepts optional ?status filter) / FindByIDAndUserID
   └── InfluxClient.QueryReadings (for readings endpoint)
+```
+
+### POST /api/devices/provision → device pairing (session JWT)
+```
+SessionAuthenticator middleware
+  └── store Claims{UserID} in context
+
+ProvisionHandler
+  ├── ClaimsFromContext(ctx)
+  └── ProvisioningStore.GetOrCreatePending(ctx, userID)
+        ├── atomic upsert: INSERT INTO devices WHERE NOT EXISTS pending for user
+        ├── INSERT INTO provisioning_codes (code CHAR(6), device_id) ON CONFLICT DO NOTHING
+        └── return (code, device_id)
+  └── 201 {"code":"...","device_id":"..."}
+```
+
+### POST /devices/activate → firmware token issuance (no auth)
+```
+ActivateHandler
+  ├── decode body {code}
+  ├── 400 if code missing
+  ├── ProvisioningStore.ClaimCode(ctx, code)
+  │     ├── UPDATE provisioning_codes SET used_at=now() WHERE code=? AND used_at IS NULL
+  │     ├── 404 (ErrCodeNotFound) if no row matched
+  │     └── 409 (ErrCodeAlreadyUsed) if row exists but used_at already set
+  ├── crypto/rand → 32 bytes → 64-char hex Bearer token
+  └── ProvisioningStore.Activate(ctx, deviceID, token)
+        ├── INSERT INTO device_tokens (device_id, token)
+        └── UPDATE devices SET status='active' WHERE id=deviceID
+  └── 201 {"token":"...","device_id":"..."}
+```
+
+### PATCH /api/devices/{id} → rename device (session JWT)
+```
+SessionAuthenticator middleware
+  └── store Claims{UserID} in context
+
+PatchDeviceHandler
+  ├── ClaimsFromContext(ctx)
+  ├── decode body {name}; 400 if empty
+  ├── DeviceStore.PatchDevice(ctx, deviceID, userID, name)
+  │     ├── UPDATE devices SET name=? WHERE id=? AND user_id=?
+  │     └── 404 (ErrDeviceNotFound) if no row matched
+  └── 200 {"id":"...","name":"...","created_at":"..."}
 ```
 
 ### POST /auth/verify → session issuance
@@ -107,4 +158,5 @@ VerifyHandler
   │     └── UserEventHandler.OnUserVerified → AccountStore.Upsert
   ├── AuthService.IssueSessionJWT(userID) → signed HS256 JWT
   └── AuthService.IssueRefreshToken(ctx, userID) → stored hash, return raw
+  └── 200 {"token":"<jwt>","refresh_token":"<64-char-hex>"}
 ```

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -8,11 +8,17 @@ FishHub has two separate authentication paths: **device Bearer tokens** (ESP32 �
 
 ### Token lifecycle
 
-1. **Issue** — call `POST /tokens`. The server creates a device row and generates a cryptographically random 64-char hex token (32 bytes from `crypto/rand`).
-2. **Flash** — copy the token into the ESP32 firmware's `include/config.h` as `DEVICE_TOKEN`.
-3. **Authenticate** — the firmware sends `Authorization: Bearer <token>` on every `POST /readings`.
+There are two paths for a device to obtain a Bearer token:
 
-For the PoC there is no revocation. Tokens are valid until the `devices` row is deleted.
+**Legacy / seed path** — `POST /tokens`. The server creates a device row and generates a cryptographically random 64-char hex token (32 bytes from `crypto/rand`). Copy the token into the ESP32 firmware's `include/config.h` as `DEVICE_TOKEN`. Used for the initial PoC setup.
+
+**Provisioning path** (production flow):
+1. Web user calls `POST /api/devices/provision` (session JWT required) — receives a 6-char pairing `code` and a `device_id`.
+2. User enters the code on the device captive portal (or transmits it via QR code).
+3. ESP32 calls `POST /devices/activate` with `{ "code": "..." }` (no auth). The server claims the code atomically, generates a 64-char hex Bearer token, activates the device, and returns `{ token, device_id }`.
+4. The firmware stores the token in NVS and sends `Authorization: Bearer <token>` on every `POST /readings`.
+
+For the PoC there is no revocation. Tokens are valid until the `device_tokens` row is deleted.
 
 ### `DeviceAuthenticator` middleware (`internal/platform/middleware.go`)
 
@@ -54,10 +60,12 @@ Browser                    Next.js (fishhub-web)       fishhub-server
   |                  |                         |-- DB upsert user
   |                  |                         |-- create/update account
   |                  |                         |-- issue session JWT + refresh token
-  |                  |<-- {token, refresh_token}             |
-  |                  |-- set httpOnly cookies: session, refresh_token
+  |                  |<-- 200 {token, refresh_token}         |
+  |                  |-- store JWT in localStorage; set httpOnly cookie: session
   |<-- redirect /devices          |                          |
 ```
+
+`POST /auth/verify` returns `{ "token": "<session-jwt>", "refresh_token": "<64-char-hex>" }` as JSON (status 200). The Next.js callback handler stores the JWT in `localStorage` for client-side API calls and also sets a `session` httpOnly cookie so SSR pages can read it.
 
 ### `AuthService` (`internal/auth/service.go`)
 
@@ -97,7 +105,7 @@ claims, ok := auth.ClaimsFromContext(r.Context())
 
 ### Refresh token rotation (web frontend)
 
-The web frontend's `apiFetch` wrapper automatically retries on `401` by calling `POST /api/auth/refresh` (a Next.js API route), which calls `POST /auth/refresh` on the server. The server rotates the refresh token and issues a new session JWT; the Next.js route updates the `session` cookie.
+The web frontend's `apiFetch` wrapper automatically retries on `401` by calling `POST /api/auth/refresh` (a Next.js API route), which calls `POST /auth/refresh` on the server. The server rotates the refresh token and issues a new `{ token, refresh_token }` pair; the Next.js route updates `localStorage` and the `session` cookie with the new JWT.
 
 ### Providers
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -24,8 +24,11 @@ devices
 ├── id          UUID  PK  default gen_random_uuid()
 ├── user_id     UUID  FK → users.id  NOT NULL
 ├── name        TEXT  (nullable)
+├── status      TEXT  NOT NULL  default 'pending'  -- 'pending' | 'active'
 └── created_at  TIMESTAMPTZ  default now()
 ```
+
+A device starts as `pending` when created via `POST /api/devices/provision`. It transitions to `active` when the ESP32 claims the pairing code via `POST /devices/activate`.
 
 ### `device_tokens`
 ```
@@ -37,6 +40,18 @@ device_tokens
 ```
 
 One token per device (enforced by UNIQUE on `device_id`). Tokens are stored as plaintext 64-char hex strings.
+
+### `provisioning_codes`
+```
+provisioning_codes
+├── id         UUID  PK  default gen_random_uuid()
+├── code       CHAR(6)  UNIQUE NOT NULL
+├── device_id  UUID  FK → devices.id  NOT NULL
+├── used_at    TIMESTAMPTZ  (nullable)
+└── created_at TIMESTAMPTZ  default now()
+```
+
+Created alongside the pending device in `POST /api/devices/provision`. The `code` is a 6-character alphanumeric string displayed to the user (e.g. as a QR code) so they can enter it on the device captive portal. `used_at` is set atomically by `ProvisioningStore.ClaimCode` — the `WHERE used_at IS NULL` guard makes the claim race-safe. Once claimed the device is activated and the code cannot be reused.
 
 ### `refresh_tokens`
 ```
@@ -70,6 +85,7 @@ Created/updated automatically via `account.AccountEventHandler.OnUserVerified` o
 
 ```
 users ──< devices ──< device_tokens
+               └──< provisioning_codes
 users ──< refresh_tokens
 users ──  accounts  (1:1 via user_id UNIQUE)
 ```
@@ -93,6 +109,8 @@ They run automatically on server startup via `platform.Migrate()`. Current migra
 | 004 | Add `provider` + `provider_sub` columns to `users` |
 | 005 | Create `refresh_tokens` table |
 | 006 | Create `accounts` table |
+| 007 | Add `status` column to `devices` table (`pending` \| `active`, default `pending`) |
+| 008 | Create `provisioning_codes` table |
 
 To add a migration, create the next numbered `.up.sql` / `.down.sql` pair in `db/migrations/`. Migrations run on the next server startup.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,4 @@ curl -s localhost:8080/health                # verify server is up
 - **Migrations:** golang-migrate
 - **Auth:** Google OIDC → JWT session + refresh token rotation; device Bearer tokens
 - **Tests:** unit (stubs) + integration (testcontainers)
+- **Deployment:** Railway (`railway.toml` — builds Go binary with `go build`, starts server, health-checks `/health`; binds to `PORT` env var)


### PR DESCRIPTION
Updates server docs to reflect:
- New `PATCH /api/devices/{id}` endpoint for renaming devices
- `PatchDevice` on `DeviceStore` interface and Postgres implementation
- Updated API reference with request/response format and error codes
- Provisioning flow documented (pending device → activation → active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)