### PR TITLE
feat: remove device_tokens table and legacy token infrastructure

### DIFF
--- a/db/migrations/009_drop_device_tokens.down.sql
+++ b/db/migrations/009_drop_device_tokens.down.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS device_tokens (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id  UUID NOT NULL REFERENCES devices(id),
+    token      TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/db/migrations/009_drop_device_tokens.up.sql
+++ b/db/migrations/009_drop_device_tokens.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS device_tokens;

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -48,31 +48,6 @@ func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, resp)
 }
 
-type TokenResponse struct {
-	Token    string `json:"token"`
-	DeviceID string `json:"device_id"`
-	UserID   string `json:"user_id"`
-}
-
-type TokensHandler struct {
-	Store  TokenStore
-	UserID string
-}
-
-func (h *TokensHandler) Create(w http.ResponseWriter, r *http.Request) {
-	result, err := h.Store.CreateToken(r.Context(), h.UserID)
-	if err != nil {
-		http.Error(w, "failed to create token", http.StatusInternalServerError)
-		return
-	}
-
-	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, TokenResponse{
-		Token:    result.Token,
-		DeviceID: result.DeviceID,
-		UserID:   result.UserID,
-	})
-}
 
 type ReadingsHandler struct {
 	Writer ReadingWriter

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -16,63 +16,6 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-type stubTokenStore struct {
-	result sensors.TokenResult
-	err    error
-}
-
-func (s *stubTokenStore) CreateToken(_ context.Context, userID string) (sensors.TokenResult, error) {
-	return s.result, s.err
-}
-
-func TestTokensHandler_Create_success(t *testing.T) {
-	h := &sensors.TokensHandler{
-		Store: &stubTokenStore{result: sensors.TokenResult{
-			Token:    "abc123",
-			DeviceID: "device-uuid",
-			UserID:   "user-uuid",
-		}},
-		UserID: "user-uuid",
-	}
-
-	req := httptest.NewRequest(http.MethodPost, "/tokens", nil)
-	w := httptest.NewRecorder()
-	h.Create(w, req)
-
-	res := w.Result()
-	if res.StatusCode != http.StatusCreated {
-		t.Fatalf("expected 201, got %d", res.StatusCode)
-	}
-
-	var body sensors.TokenResponse
-	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-		t.Fatalf("decode body: %v", err)
-	}
-	if body.Token != "abc123" {
-		t.Errorf("unexpected token: %s", body.Token)
-	}
-	if body.DeviceID != "device-uuid" {
-		t.Errorf("unexpected device_id: %s", body.DeviceID)
-	}
-	if body.UserID != "user-uuid" {
-		t.Errorf("unexpected user_id: %s", body.UserID)
-	}
-}
-
-func TestTokensHandler_Create_storeError(t *testing.T) {
-	h := &sensors.TokensHandler{
-		Store:  &stubTokenStore{err: errors.New("db down")},
-		UserID: "user-uuid",
-	}
-
-	req := httptest.NewRequest(http.MethodPost, "/tokens", nil)
-	w := httptest.NewRecorder()
-	h.Create(w, req)
-
-	if w.Result().StatusCode != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", w.Result().StatusCode)
-	}
-}
 
 type stubReadingWriter struct {
 	called  bool
@@ -98,9 +41,6 @@ func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensor
 	return nil, nil
 }
 
-func (s *stubDeviceStore) LookupByToken(_ context.Context, _ string) (sensors.DeviceInfo, error) {
-	return s.info, nil
-}
 
 func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sensors.Device, error) {
 	return s.device, s.findErr

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -5,18 +5,11 @@ import (
 	"errors"
 )
 
-var ErrTokenNotFound    = errors.New("token not found")
-var ErrDeviceNotFound   = errors.New("device not found")
-var ErrCodeNotFound     = errors.New("provisioning code not found")
-var ErrCodeAlreadyUsed  = errors.New("provisioning code already used")
+var ErrDeviceNotFound  = errors.New("device not found")
+var ErrCodeNotFound    = errors.New("provisioning code not found")
+var ErrCodeAlreadyUsed = errors.New("provisioning code already used")
 
 type DeviceInfo struct {
-	DeviceID string
-	UserID   string
-}
-
-type TokenResult struct {
-	Token    string
 	DeviceID string
 	UserID   string
 }

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -12,9 +12,6 @@ type Device struct {
 }
 
 type DeviceStore interface {
-	// Deprecated: device auth now uses JWT verification. LookupByToken and the
-	// device_tokens table will be removed in cleanup issue #46.
-	LookupByToken(ctx context.Context, token string) (DeviceInfo, error)
 	// ListByUserID returns devices owned by userID. If status is non-empty, only
 	// devices with that status are returned.
 	ListByUserID(ctx context.Context, userID, status string) ([]Device, error)
@@ -22,10 +19,6 @@ type DeviceStore interface {
 	// PatchDevice updates the name of the device owned by userID.
 	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.
 	PatchDevice(ctx context.Context, deviceID, userID, name string) (Device, error)
-}
-
-type TokenStore interface {
-	CreateToken(ctx context.Context, userID string) (TokenResult, error)
 }
 
 type ProvisioningStore interface {

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -2,9 +2,7 @@ package sensors
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 )
@@ -86,60 +84,3 @@ func (s *postgresDeviceStore) PatchDevice(ctx context.Context, deviceID, userID,
 	return d, nil
 }
 
-func (s *postgresDeviceStore) LookupByToken(ctx context.Context, token string) (DeviceInfo, error) {
-	var info DeviceInfo
-	err := s.db.QueryRowContext(ctx, `
-		SELECT d.id, d.user_id
-		FROM device_tokens dt
-		JOIN devices d ON d.id = dt.device_id
-		WHERE dt.token = $1
-	`, token).Scan(&info.DeviceID, &info.UserID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return DeviceInfo{}, ErrTokenNotFound
-	}
-	if err != nil {
-		return DeviceInfo{}, fmt.Errorf("lookup token: %w", err)
-	}
-	return info, nil
-}
-
-type postgresTokenStore struct {
-	db *sql.DB
-}
-
-func NewTokenStore(db *sql.DB) TokenStore {
-	return &postgresTokenStore{db: db}
-}
-
-func (s *postgresTokenStore) CreateToken(ctx context.Context, userID string) (TokenResult, error) {
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
-		return TokenResult{}, fmt.Errorf("generate token: %w", err)
-	}
-	token := hex.EncodeToString(raw)
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return TokenResult{}, fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	var deviceID string
-	if err := tx.QueryRowContext(ctx, `
-		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
-	`, userID).Scan(&deviceID); err != nil {
-		return TokenResult{}, fmt.Errorf("insert device: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO device_tokens (device_id, token) VALUES ($1, $2)
-	`, deviceID, token); err != nil {
-		return TokenResult{}, fmt.Errorf("insert token: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return TokenResult{}, fmt.Errorf("commit tx: %w", err)
-	}
-
-	return TokenResult{Token: token, DeviceID: deviceID, UserID: userID}, nil
-}

--- a/internal/sensors/store_provisioning_postgres.go
+++ b/internal/sensors/store_provisioning_postgres.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 )
@@ -127,11 +126,3 @@ func generateCode() (string, error) {
 	return string(code), nil
 }
 
-// generateToken produces a 64-char hex Bearer token.
-func generateToken() (string, error) {
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
-		return "", fmt.Errorf("generate token: %w", err)
-	}
-	return hex.EncodeToString(raw), nil
-}

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -2,9 +2,6 @@ package sensors_test
 
 import (
 	"context"
-	"database/sql"
-	"encoding/hex"
-	"errors"
 	"testing"
 
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
@@ -13,145 +10,22 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func TestLookupByToken_integration(t *testing.T) {
-	db := testutil.NewTestDB(t)
-	devices := sensors.NewDeviceStore(db)
-	tokens := sensors.NewTokenStore(db)
-	ctx := context.Background()
-	userID := platform.SeedUserID()
-
-	t.Run("returns device info for valid token", func(t *testing.T) {
-		result, err := tokens.CreateToken(ctx, userID)
-		if err != nil {
-			t.Fatalf("setup: create token: %v", err)
-		}
-
-		info, err := devices.LookupByToken(ctx, result.Token)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if info.DeviceID != result.DeviceID {
-			t.Errorf("expected device_id %s, got %s", result.DeviceID, info.DeviceID)
-		}
-		if info.UserID != userID {
-			t.Errorf("expected user_id %s, got %s", userID, info.UserID)
-		}
-	})
-
-	t.Run("returns ErrTokenNotFound for unknown token", func(t *testing.T) {
-		_, err := devices.LookupByToken(ctx, "0000000000000000000000000000000000000000000000000000000000000000")
-		if !errors.Is(err, sensors.ErrTokenNotFound) {
-			t.Errorf("expected ErrTokenNotFound, got %v", err)
-		}
-	})
-}
-
-func TestCreateToken_integration(t *testing.T) {
-	db := testutil.NewTestDB(t)
-	s := sensors.NewTokenStore(db)
-	userID := platform.SeedUserID()
-	ctx := context.Background()
-
-	t.Run("returns valid token and IDs", func(t *testing.T) {
-		result, err := s.CreateToken(ctx, userID)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if result.UserID != userID {
-			t.Errorf("expected user_id %s, got %s", userID, result.UserID)
-		}
-		if result.DeviceID == "" {
-			t.Error("expected non-empty device_id")
-		}
-		if len(result.Token) != 64 {
-			t.Errorf("expected 64-char token, got %d", len(result.Token))
-		}
-		if _, err := hex.DecodeString(result.Token); err != nil {
-			t.Errorf("token is not valid hex: %v", err)
-		}
-	})
-
-	t.Run("persists device and token to DB", func(t *testing.T) {
-		result, err := s.CreateToken(ctx, userID)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		var deviceUserID string
-		var deviceName *string
-		err = db.QueryRowContext(ctx,
-			`SELECT user_id, name FROM devices WHERE id = $1`, result.DeviceID,
-		).Scan(&deviceUserID, &deviceName)
-		if err != nil {
-			t.Fatalf("device not found in DB: %v", err)
-		}
-		if deviceUserID != userID {
-			t.Errorf("device has wrong user_id: %s", deviceUserID)
-		}
-		if deviceName != nil {
-			t.Errorf("expected name to be NULL, got %s", *deviceName)
-		}
-
-		var storedToken string
-		err = db.QueryRowContext(ctx,
-			`SELECT token FROM device_tokens WHERE device_id = $1`, result.DeviceID,
-		).Scan(&storedToken)
-		if err != nil {
-			t.Fatalf("token not found in DB: %v", err)
-		}
-		if storedToken != result.Token {
-			t.Errorf("stored token mismatch: got %s", storedToken)
-		}
-	})
-
-	t.Run("each call creates a distinct device and token", func(t *testing.T) {
-		r1, err := s.CreateToken(ctx, userID)
-		if err != nil {
-			t.Fatalf("first call error: %v", err)
-		}
-		r2, err := s.CreateToken(ctx, userID)
-		if err != nil {
-			t.Fatalf("second call error: %v", err)
-		}
-		if r1.DeviceID == r2.DeviceID {
-			t.Error("expected distinct device IDs")
-		}
-		if r1.Token == r2.Token {
-			t.Error("expected distinct tokens")
-		}
-	})
-
-	t.Run("invalid userID returns error and nothing is committed", func(t *testing.T) {
-		_, err := s.CreateToken(ctx, "00000000-0000-0000-0000-000000000000")
-		if err == nil {
-			t.Fatal("expected error for unknown user_id, got nil")
-		}
-
-		var count int
-		db.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM devices WHERE user_id = '00000000-0000-0000-0000-000000000000'`,
-		).Scan(&count)
-		if count != 0 {
-			t.Errorf("expected no orphan devices, found %d", count)
-		}
-	})
-}
-
 func TestListByUserID_integration(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	store := sensors.NewDeviceStore(db)
-	tokens := sensors.NewTokenStore(db)
+	provisioning := sensors.NewProvisioningStore(db)
 	ctx := context.Background()
 	userID := platform.SeedUserID()
 
 	t.Run("returns devices for the user ordered by created_at DESC", func(t *testing.T) {
-		r1, err := tokens.CreateToken(ctx, userID)
+		d1, _, err := provisioning.GetOrCreatePending(ctx, userID)
 		if err != nil {
-			t.Fatalf("setup token 1: %v", err)
+			t.Fatalf("setup device 1: %v", err)
 		}
-		r2, err := tokens.CreateToken(ctx, userID)
-		if err != nil {
-			t.Fatalf("setup token 2: %v", err)
+		// create a second device via direct insert so we have two distinct ones
+		var d2 string
+		if err := db.QueryRowContext(ctx, `INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID).Scan(&d2); err != nil {
+			t.Fatalf("setup device 2: %v", err)
 		}
 
 		devices, err := store.ListByUserID(ctx, userID, "")
@@ -166,13 +40,12 @@ func TestListByUserID_integration(t *testing.T) {
 		for i, d := range devices {
 			ids[i] = d.ID
 		}
-		if !contains(ids, r1.DeviceID) || !contains(ids, r2.DeviceID) {
+		if !contains(ids, d1) || !contains(ids, d2) {
 			t.Errorf("missing expected device IDs in result")
 		}
 	})
 
 	t.Run("returns empty slice for user with no devices", func(t *testing.T) {
-		// insert a fresh user with no devices
 		var newUserID string
 		err := db.QueryRowContext(ctx, `
 			INSERT INTO users (email, provider, provider_sub)
@@ -201,5 +74,3 @@ func contains(ss []string, s string) bool {
 	}
 	return false
 }
-
-var _ sensors.TokenStore = sensors.NewTokenStore((*sql.DB)(nil))

--- a/main.go
+++ b/main.go
@@ -94,10 +94,6 @@ func main() {
 		log.Printf("warning: DEVICE_JWT_PRIVATE_KEY not set — token will not be issued at activation")
 	}
 
-	tokens := &sensors.TokensHandler{
-		Store:  sensors.NewTokenStore(db),
-		UserID: platform.SeedUserID(),
-	}
 	readings := &sensors.ReadingsHandler{
 		Writer: influxClient,
 	}
@@ -121,7 +117,6 @@ func main() {
 	provisioningStore := sensors.NewProvisioningStore(db)
 
 	r.Get("/.well-known/jwks.json", (&jwtutil.JWKSHandler{Signer: jwkSigner}).ServeHTTP)
-	r.Post("/tokens", tokens.Create)
 	r.Post("/devices/activate", (&sensors.ActivateHandler{Store: provisioningStore, Signer: deviceSigner}).ServeHTTP)
 	r.Group(func(r chi.Router) {
 		r.Use(platform.DeviceAuthenticator(deviceSigner))


### PR DESCRIPTION
## Summary

- Adds migration 009 to drop the `device_tokens` table
- Removes `LookupByToken`, `TokenStore`, `NewTokenStore`, `TokenResult`, `ErrTokenNotFound` from the sensors package
- Removes `TokensHandler` and the `POST /tokens` route from `main.go`
- Removes the `generateToken` helper from `store_provisioning_postgres.go`
- Rewrites `store_test.go` to use the provisioning flow for device setup instead of the old token factory

Device auth now exclusively uses JWT verification via `DeviceAuthenticator`. No references to `device_tokens` or `LookupByToken` remain.

Closes #46