### PR TITLE
feat: update SenML parser to flat RFC 8428 sibling records

### DIFF
--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -64,8 +64,8 @@ func withDevice(r *http.Request, info sensors.DeviceInfo) *http.Request {
 	return r.WithContext(ctx)
 }
 
-const validSenML = `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4}]}]`
-const multiSenML = `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4},{"n":"ph","u":"pH","v":7.2}]}]`
+const validSenML = `[{"bn":"fishhub/device/","bt":1713000000},{"n":"temperature","u":"Cel","v":23.4}]`
+const multiSenML = `[{"bn":"fishhub/device/","bt":1713000000},{"n":"temperature","u":"Cel","v":23.4},{"n":"ph","u":"pH","v":7.2}]`
 
 func TestReadingsHandler_Create(t *testing.T) {
 	device := sensors.DeviceInfo{DeviceID: "device-uuid", UserID: "user-uuid"}
@@ -140,7 +140,7 @@ func TestReadingsHandler_Create(t *testing.T) {
 
 	t.Run("missing base time returns 400", func(t *testing.T) {
 		h := &sensors.ReadingsHandler{}
-		body := `[{"bn":"fishhub/device/","e":[{"n":"temperature","v":23.4}]}]`
+		body := `[{"bn":"fishhub/device/"},{"n":"temperature","v":23.4}]`
 		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(body)), device)
 		rec := httptest.NewRecorder()
 		h.Create(rec, req)

--- a/internal/sensors/senml.go
+++ b/internal/sensors/senml.go
@@ -12,17 +12,13 @@ var (
 	ErrEmptyEntries    = errors.New("payload must contain at least one entry")
 )
 
-type senmlEntry struct {
+type senmlRecord struct {
+	BaseName  string   `json:"bn"`
+	BaseTime  int64    `json:"bt"`
 	Name      string   `json:"n"`
 	Unit      string   `json:"u"`
 	Value     *float64 `json:"v"`
 	BoolValue *bool    `json:"vb"`
-}
-
-type senmlRecord struct {
-	BaseName string       `json:"bn"`
-	BaseTime int64        `json:"bt"`
-	Entries  []senmlEntry `json:"e"`
 }
 
 type Measurement struct {
@@ -41,25 +37,25 @@ func ParseSenML(body []byte) (SenMLReading, error) {
 	if err := json.Unmarshal(body, &records); err != nil {
 		return SenMLReading{}, fmt.Errorf("invalid JSON: %w", err)
 	}
-	if len(records) == 0 {
+	if len(records) < 2 {
 		return SenMLReading{}, ErrEmptyPayload
 	}
 
-	rec := records[0]
-	if rec.BaseTime == 0 {
+	base := records[0]
+	if base.BaseTime == 0 {
 		return SenMLReading{}, ErrMissingBaseTime
 	}
 
 	var measurements []Measurement
-	for _, e := range rec.Entries {
-		if e.Name == "" {
+	for _, r := range records[1:] {
+		if r.Name == "" {
 			continue
 		}
 		switch {
-		case e.Value != nil:
-			measurements = append(measurements, Measurement{Name: e.Name, Unit: e.Unit, Value: *e.Value})
-		case e.BoolValue != nil:
-			measurements = append(measurements, Measurement{Name: e.Name, Unit: e.Unit, Value: *e.BoolValue})
+		case r.Value != nil:
+			measurements = append(measurements, Measurement{Name: r.Name, Unit: r.Unit, Value: *r.Value})
+		case r.BoolValue != nil:
+			measurements = append(measurements, Measurement{Name: r.Name, Unit: r.Unit, Value: *r.BoolValue})
 		}
 	}
 
@@ -67,5 +63,5 @@ func ParseSenML(body []byte) (SenMLReading, error) {
 		return SenMLReading{}, ErrEmptyEntries
 	}
 
-	return SenMLReading{BaseTime: rec.BaseTime, Measurements: measurements}, nil
+	return SenMLReading{BaseTime: base.BaseTime, Measurements: measurements}, nil
 }

--- a/internal/sensors/senml_test.go
+++ b/internal/sensors/senml_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestParseSenML(t *testing.T) {
-	t.Run("single float entry", func(t *testing.T) {
-		body := `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4}]}]`
+	t.Run("single float measurement", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"temperature","u":"Cel","v":25.3}]`
 		r, err := sensors.ParseSenML([]byte(body))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if r.BaseTime != 1713000000 {
-			t.Errorf("expected bt 1713000000, got %v", r.BaseTime)
+		if r.BaseTime != 1745000000 {
+			t.Errorf("expected bt 1745000000, got %v", r.BaseTime)
 		}
 		if len(r.Measurements) != 1 {
 			t.Fatalf("expected 1 measurement, got %d", len(r.Measurements))
@@ -24,13 +24,16 @@ func TestParseSenML(t *testing.T) {
 		if m.Name != "temperature" {
 			t.Errorf("expected name 'temperature', got %q", m.Name)
 		}
-		if v, ok := m.Value.(float64); !ok || v != 23.4 {
-			t.Errorf("expected value 23.4, got %v", m.Value)
+		if v, ok := m.Value.(float64); !ok || v != 25.3 {
+			t.Errorf("expected value 25.3, got %v", m.Value)
+		}
+		if m.Unit != "Cel" {
+			t.Errorf("expected unit 'Cel', got %q", m.Unit)
 		}
 	})
 
-	t.Run("multi-sensor payload", func(t *testing.T) {
-		body := `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"temperature","u":"Cel","v":23.4},{"n":"ph","u":"pH","v":7.2}]}]`
+	t.Run("multi-peripheral pack: float + bool", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"temperature","u":"Cel","v":25.3},{"n":"relay/state","vb":true}]`
 		r, err := sensors.ParseSenML([]byte(body))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -41,13 +44,17 @@ func TestParseSenML(t *testing.T) {
 		if r.Measurements[0].Name != "temperature" {
 			t.Errorf("expected first measurement 'temperature', got %q", r.Measurements[0].Name)
 		}
-		if r.Measurements[1].Name != "ph" {
-			t.Errorf("expected second measurement 'ph', got %q", r.Measurements[1].Name)
+		if r.Measurements[1].Name != "relay/state" {
+			t.Errorf("expected second measurement 'relay/state', got %q", r.Measurements[1].Name)
+		}
+		v, ok := r.Measurements[1].Value.(bool)
+		if !ok || !v {
+			t.Errorf("expected bool true, got %v", r.Measurements[1].Value)
 		}
 	})
 
-	t.Run("boolean entry", func(t *testing.T) {
-		body := `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"door_open","vb":true}]}]`
+	t.Run("boolean-only pack", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"relay/state","vb":false}]`
 		r, err := sensors.ParseSenML([]byte(body))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -56,19 +63,22 @@ func TestParseSenML(t *testing.T) {
 			t.Fatalf("expected 1 measurement, got %d", len(r.Measurements))
 		}
 		v, ok := r.Measurements[0].Value.(bool)
-		if !ok || !v {
-			t.Errorf("expected bool true, got %v", r.Measurements[0].Value)
+		if !ok || v {
+			t.Errorf("expected bool false, got %v", r.Measurements[0].Value)
 		}
 	})
 
-	t.Run("entries with unknown value type are skipped", func(t *testing.T) {
-		body := `[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"label","vs":"hello"},{"n":"temperature","v":23.4}]}]`
+	t.Run("records with unknown value type are skipped", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"label","vs":"hello"},{"n":"temperature","v":25.3}]`
 		r, err := sensors.ParseSenML([]byte(body))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(r.Measurements) != 1 {
 			t.Fatalf("expected 1 measurement (label skipped), got %d", len(r.Measurements))
+		}
+		if r.Measurements[0].Name != "temperature" {
+			t.Errorf("expected 'temperature', got %q", r.Measurements[0].Name)
 		}
 	})
 
@@ -86,22 +96,29 @@ func TestParseSenML(t *testing.T) {
 		}
 	})
 
+	t.Run("single-element array (only base record)", func(t *testing.T) {
+		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1745000000}]`))
+		if !errors.Is(err, sensors.ErrEmptyPayload) {
+			t.Errorf("expected ErrEmptyPayload, got %v", err)
+		}
+	})
+
 	t.Run("missing base time", func(t *testing.T) {
-		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","e":[{"n":"temperature","v":23.4}]}]`))
+		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/"},{"n":"temperature","v":25.3}]`))
 		if !errors.Is(err, sensors.ErrMissingBaseTime) {
 			t.Errorf("expected ErrMissingBaseTime, got %v", err)
 		}
 	})
 
-	t.Run("empty entries", func(t *testing.T) {
-		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1713000000,"e":[]}]`))
-		if !errors.Is(err, sensors.ErrEmptyEntries) {
-			t.Errorf("expected ErrEmptyEntries, got %v", err)
+	t.Run("measurement record before base record", func(t *testing.T) {
+		_, err := sensors.ParseSenML([]byte(`[{"n":"temperature","v":25.3},{"bn":"fishhub/device/","bt":1745000000}]`))
+		if !errors.Is(err, sensors.ErrMissingBaseTime) {
+			t.Errorf("expected ErrMissingBaseTime, got %v", err)
 		}
 	})
 
-	t.Run("all entries have no supported value type", func(t *testing.T) {
-		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1713000000,"e":[{"n":"label","vs":"hello"}]}]`))
+	t.Run("all measurement records have no supported value type", func(t *testing.T) {
+		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1745000000},{"n":"label","vs":"hello"}]`))
 		if !errors.Is(err, sensors.ErrEmptyEntries) {
 			t.Errorf("expected ErrEmptyEntries, got %v", err)
 		}


### PR DESCRIPTION
## Summary

- Replaces the legacy `"e"` entries array with flat RFC 8428 sibling records
- `records[0]` is the base record (`bn`, `bt`); `records[1:]` are individual measurements
- Requires at least 2 records — a single-element array (base only) now returns `ErrEmptyPayload`
- Supports `v` (float64) and `vb` (bool) value types; unknown types are skipped
- Updates handler test payloads to the new format

Coordinated with fishhub-oss/fishhub-firmware#29 (firmware-side format switch).

Closes #40