### PR TITLE
fix: add exp claim to device JWT for HiveMQ compatibility

### DIFF
--- a/internal/devicejwt/devicejwt.go
+++ b/internal/devicejwt/devicejwt.go
@@ -35,8 +35,8 @@ func (s *deviceSigner) Sign(deviceID, userID string) (string, error) {
 		"iss":     s.issuer,
 		"sub":     deviceID,
 		"user_id": userID,
-		"iat":     time.Now().Unix(),
-		// No exp — known limitation, see fishhub-oss/fishhub-server#43
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(10 * 365 * 24 * time.Hour).Unix(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("devicejwt: %w", err)

--- a/internal/devicejwt/devicejwt_test.go
+++ b/internal/devicejwt/devicejwt_test.go
@@ -67,8 +67,8 @@ func TestDeviceSigner_Sign(t *testing.T) {
 	if claims["iat"] == nil {
 		t.Error("expected iat claim to be set")
 	}
-	if claims["exp"] != nil {
-		t.Error("expected no exp claim (known limitation, see #43)")
+	if claims["exp"] == nil {
+		t.Error("expected exp claim to be set")
 	}
 	if token.Header["kid"] != "kid-1" {
 		t.Errorf("expected kid=kid-1, got %v", token.Header["kid"])


### PR DESCRIPTION
## Summary

- Add `exp` claim (10 years) to device JWTs issued at activation
- HiveMQ JWT IdP rejects tokens without an expiry claim, causing MQTT authentication to fail with "unknown authentication key or wrong authentication secret"
- Update test to assert `exp` is present

Proper short-lived tokens with refresh are tracked in #43.

## Test plan

- [x] `go test ./...` passes
- [x] Deploy to Railway, re-provision device, verify MQTT connects to HiveMQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)