### PR TITLE
feat: provision HiveMQ MQTT credentials at device activation

### DIFF
--- a/db/migrations/010_add_mqtt_credentials.down.sql
+++ b/db/migrations/010_add_mqtt_credentials.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE devices DROP COLUMN mqtt_username;
+ALTER TABLE devices DROP COLUMN mqtt_password;

--- a/db/migrations/010_add_mqtt_credentials.up.sql
+++ b/db/migrations/010_add_mqtt_credentials.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE devices ADD COLUMN mqtt_username TEXT;
+ALTER TABLE devices ADD COLUMN mqtt_password TEXT;

--- a/internal/hivemq/client.go
+++ b/internal/hivemq/client.go
@@ -1,0 +1,92 @@
+package hivemq
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Client provisions and removes per-device MQTT credentials in HiveMQ Cloud.
+type Client interface {
+	ProvisionDevice(ctx context.Context, username, password string) error
+	DeleteDevice(ctx context.Context, username string) error
+}
+
+type apiClient struct {
+	baseURL      string
+	apiToken     string
+	deviceRoleID string
+	http         *http.Client
+}
+
+// NewAPIClient returns a Client that calls the HiveMQ Cloud REST API.
+func NewAPIClient(baseURL, apiToken, deviceRoleID string) Client {
+	return &apiClient{
+		baseURL:      baseURL,
+		apiToken:     apiToken,
+		deviceRoleID: deviceRoleID,
+		http:         &http.Client{},
+	}
+}
+
+func (c *apiClient) ProvisionDevice(ctx context.Context, username, password string) error {
+	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+	if err := c.do(ctx, http.MethodPost, "/mqtt/credentials", body); err != nil {
+		return fmt.Errorf("hivemq: create credential: %w", err)
+	}
+
+	attachURL := fmt.Sprintf("/user/%s/roles/%s/attach", username, c.deviceRoleID)
+	if err := c.do(ctx, http.MethodPost, attachURL, nil); err != nil {
+		// Roll back — delete the credential we just created
+		_ = c.do(ctx, http.MethodDelete, "/mqtt/credentials/"+username, nil)
+		return fmt.Errorf("hivemq: attach role: %w", err)
+	}
+
+	return nil
+}
+
+func (c *apiClient) DeleteDevice(ctx context.Context, username string) error {
+	detachURL := fmt.Sprintf("/user/%s/roles/%s/attach", username, c.deviceRoleID)
+	if err := c.do(ctx, http.MethodDelete, detachURL, nil); err != nil {
+		return fmt.Errorf("hivemq: detach role: %w", err)
+	}
+	if err := c.do(ctx, http.MethodDelete, "/mqtt/credentials/"+username, nil); err != nil {
+		return fmt.Errorf("hivemq: delete credential: %w", err)
+	}
+	return nil
+}
+
+func (c *apiClient) do(ctx context.Context, method, path string, body []byte) error {
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(body))
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	}
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// noopClient is returned when HIVEMQ_API_BASE_URL is not configured.
+type noopClient struct{}
+
+func NewNoOp() Client                                                          { return &noopClient{} }
+func (n *noopClient) ProvisionDevice(_ context.Context, _, _ string) error    { return nil }
+func (n *noopClient) DeleteDevice(_ context.Context, _ string) error          { return nil }

--- a/internal/hivemq/client_test.go
+++ b/internal/hivemq/client_test.go
@@ -1,0 +1,104 @@
+package hivemq_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
+)
+
+func TestProvisionDevice(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("calls credentials then role-attach", func(t *testing.T) {
+		var calls []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, r.Method+" "+r.URL.Path)
+			w.WriteHeader(http.StatusCreated)
+		}))
+		defer srv.Close()
+
+		c := hivemq.NewAPIClient(srv.URL, "token", "role-id")
+		if err := c.ProvisionDevice(ctx, "dev-1", "pass"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+		}
+		if calls[0] != "POST /mqtt/credentials" {
+			t.Errorf("expected first call POST /mqtt/credentials, got %s", calls[0])
+		}
+		if calls[1] != "POST /user/dev-1/roles/role-id/attach" {
+			t.Errorf("expected second call POST /user/dev-1/roles/role-id/attach, got %s", calls[1])
+		}
+	})
+
+	t.Run("rolls back credential when role-attach fails", func(t *testing.T) {
+		var calls []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, r.Method+" "+r.URL.Path)
+			if r.Method == http.MethodPost && r.URL.Path != "/mqtt/credentials" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		}))
+		defer srv.Close()
+
+		c := hivemq.NewAPIClient(srv.URL, "token", "role-id")
+		if err := c.ProvisionDevice(ctx, "dev-1", "pass"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		// Should have: create credential, fail attach, delete credential (rollback)
+		if len(calls) != 3 {
+			t.Fatalf("expected 3 calls (create, attach, rollback), got %d: %v", len(calls), calls)
+		}
+		if calls[2] != "DELETE /mqtt/credentials/dev-1" {
+			t.Errorf("expected rollback DELETE /mqtt/credentials/dev-1, got %s", calls[2])
+		}
+	})
+}
+
+func TestDeleteDevice(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("calls detach then delete credential", func(t *testing.T) {
+		var calls []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, r.Method+" "+r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		c := hivemq.NewAPIClient(srv.URL, "token", "role-id")
+		if err := c.DeleteDevice(ctx, "dev-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+		}
+		if calls[0] != "DELETE /user/dev-1/roles/role-id/attach" {
+			t.Errorf("expected first call DELETE /user/dev-1/roles/role-id/attach, got %s", calls[0])
+		}
+		if calls[1] != "DELETE /mqtt/credentials/dev-1" {
+			t.Errorf("expected second call DELETE /mqtt/credentials/dev-1, got %s", calls[1])
+		}
+	})
+}
+
+func TestNoOpClient(t *testing.T) {
+	ctx := context.Background()
+	c := hivemq.NewNoOp()
+
+	if err := c.ProvisionDevice(ctx, "dev-1", "pass"); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if err := c.DeleteDevice(ctx, "dev-1"); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -1,6 +1,8 @@
 package sensors
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"io"
 	"log"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
+	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
@@ -259,8 +262,11 @@ func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // ActivateHandler handles POST /devices/activate (no auth — called by the device).
 type ActivateHandler struct {
-	Store  ProvisioningStore
-	Signer devicejwt.Signer
+	Store    ProvisioningStore
+	Signer   devicejwt.Signer
+	HiveMQ   hivemq.Client
+	MQTTHost string
+	MQTTPort int
 }
 
 type activateRequest struct {
@@ -268,8 +274,12 @@ type activateRequest struct {
 }
 
 type activateResponse struct {
-	Token    string `json:"token"`
-	DeviceID string `json:"device_id"`
+	Token        string `json:"token"`
+	DeviceID     string `json:"device_id"`
+	MQTTUsername string `json:"mqtt_username,omitempty"`
+	MQTTPassword string `json:"mqtt_password,omitempty"`
+	MQTTHost     string `json:"mqtt_host,omitempty"`
+	MQTTPort     int    `json:"mqtt_port,omitempty"`
 }
 
 func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -293,7 +303,22 @@ func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Store.Activate(r.Context(), deviceID); err != nil {
+	mqttUsername := deviceID
+	mqttPasswordBytes := make([]byte, 32)
+	if _, err := rand.Read(mqttPasswordBytes); err != nil {
+		log.Printf("generate mqtt password error: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	mqttPassword := hex.EncodeToString(mqttPasswordBytes)
+
+	if err := h.HiveMQ.ProvisionDevice(r.Context(), mqttUsername, mqttPassword); err != nil {
+		log.Printf("hivemq provision error: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.Store.Activate(r.Context(), deviceID, mqttUsername, mqttPassword); err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -306,5 +331,12 @@ func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, activateResponse{Token: jwtToken, DeviceID: deviceID})
+	render.JSON(w, r, activateResponse{
+		Token:        jwtToken,
+		DeviceID:     deviceID,
+		MQTTUsername: mqttUsername,
+		MQTTPassword: mqttPassword,
+		MQTTHost:     h.MQTTHost,
+		MQTTPort:     h.MQTTPort,
+	})
 }

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 	"github.com/go-chi/chi/v5"
 )
@@ -364,9 +365,15 @@ func (s *stubProvisioningStore) ClaimCode(_ context.Context, _ string) (string, 
 	return s.claimedDeviceID, "user-uuid", s.claimErr
 }
 
-func (s *stubProvisioningStore) Activate(_ context.Context, _ string) error {
+func (s *stubProvisioningStore) Activate(_ context.Context, _, _, _ string) error {
 	return s.activateErr
 }
+
+// stubHiveMQClient implements hivemq.Client for tests.
+type stubHiveMQClient struct{ err error }
+
+func (s *stubHiveMQClient) ProvisionDevice(_ context.Context, _, _ string) error { return s.err }
+func (s *stubHiveMQClient) DeleteDevice(_ context.Context, _ string) error       { return s.err }
 
 func TestProvisionHandler(t *testing.T) {
 	t.Run("returns 201 with code and device_id", func(t *testing.T) {
@@ -431,10 +438,15 @@ func (s *stubSigner) Issuer() string                         { return "" }
 func TestActivateHandler(t *testing.T) {
 	validBody := `{"code":"ABC123"}`
 
-	t.Run("returns 201 with jwt token and device_id", func(t *testing.T) {
+	noopHiveMQ := hivemq.NewNoOp()
+
+	t.Run("returns 201 with token, device_id and mqtt credentials", func(t *testing.T) {
 		h := &sensors.ActivateHandler{
-			Store:  &stubProvisioningStore{claimedDeviceID: "dev-uuid"},
-			Signer: &stubSigner{token: "signed.jwt.token"},
+			Store:    &stubProvisioningStore{claimedDeviceID: "dev-uuid"},
+			Signer:   &stubSigner{token: "signed.jwt.token"},
+			HiveMQ:   noopHiveMQ,
+			MQTTHost: "broker.example.com",
+			MQTTPort: 8883,
 		}
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
@@ -443,15 +455,41 @@ func TestActivateHandler(t *testing.T) {
 		if rec.Code != http.StatusCreated {
 			t.Fatalf("expected 201, got %d", rec.Code)
 		}
-		var body map[string]string
+		var body map[string]any
 		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
 		if body["device_id"] != "dev-uuid" {
-			t.Errorf("expected device_id dev-uuid, got %s", body["device_id"])
+			t.Errorf("expected device_id dev-uuid, got %v", body["device_id"])
 		}
 		if body["token"] != "signed.jwt.token" {
-			t.Errorf("expected token=signed.jwt.token, got %q", body["token"])
+			t.Errorf("expected token=signed.jwt.token, got %v", body["token"])
+		}
+		if body["mqtt_username"] != "dev-uuid" {
+			t.Errorf("expected mqtt_username=dev-uuid, got %v", body["mqtt_username"])
+		}
+		if body["mqtt_password"] == "" {
+			t.Error("expected non-empty mqtt_password")
+		}
+		if body["mqtt_host"] != "broker.example.com" {
+			t.Errorf("expected mqtt_host=broker.example.com, got %v", body["mqtt_host"])
+		}
+		if body["mqtt_port"] != float64(8883) {
+			t.Errorf("expected mqtt_port=8883, got %v", body["mqtt_port"])
+		}
+	})
+
+	t.Run("hivemq error returns 500", func(t *testing.T) {
+		h := &sensors.ActivateHandler{
+			Store:  &stubProvisioningStore{claimedDeviceID: "dev-uuid"},
+			Signer: &stubSigner{token: "signed.jwt.token"},
+			HiveMQ: &stubHiveMQClient{err: errors.New("api down")},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
 		}
 	})
 
@@ -459,6 +497,7 @@ func TestActivateHandler(t *testing.T) {
 		h := &sensors.ActivateHandler{
 			Store:  &stubProvisioningStore{claimedDeviceID: "dev-uuid"},
 			Signer: &stubSigner{err: errors.New("sign failed")},
+			HiveMQ: noopHiveMQ,
 		}
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
@@ -469,7 +508,7 @@ func TestActivateHandler(t *testing.T) {
 	})
 
 	t.Run("missing code returns 400", func(t *testing.T) {
-		h := &sensors.ActivateHandler{Store: &stubProvisioningStore{}}
+		h := &sensors.ActivateHandler{Store: &stubProvisioningStore{}, HiveMQ: noopHiveMQ}
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(`{}`))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
@@ -480,7 +519,8 @@ func TestActivateHandler(t *testing.T) {
 
 	t.Run("unknown code returns 404", func(t *testing.T) {
 		h := &sensors.ActivateHandler{
-			Store: &stubProvisioningStore{claimErr: sensors.ErrCodeNotFound},
+			Store:  &stubProvisioningStore{claimErr: sensors.ErrCodeNotFound},
+			HiveMQ: noopHiveMQ,
 		}
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
@@ -492,7 +532,8 @@ func TestActivateHandler(t *testing.T) {
 
 	t.Run("already used code returns 409", func(t *testing.T) {
 		h := &sensors.ActivateHandler{
-			Store: &stubProvisioningStore{claimErr: sensors.ErrCodeAlreadyUsed},
+			Store:  &stubProvisioningStore{claimErr: sensors.ErrCodeAlreadyUsed},
+			HiveMQ: noopHiveMQ,
 		}
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
@@ -508,6 +549,7 @@ func TestActivateHandler(t *testing.T) {
 				claimedDeviceID: "dev-uuid",
 				activateErr:     errors.New("db down"),
 			},
+			HiveMQ: noopHiveMQ,
 		}
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -28,7 +28,6 @@ type ProvisioningStore interface {
 	// ClaimCode marks the code as used and returns the associated device ID and user ID.
 	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
 	ClaimCode(ctx context.Context, code string) (deviceID, userID string, err error)
-	// Activate sets the device status to active.
-	// Deprecated: device_tokens no longer used; token column ignored, kept for schema compatibility.
-	Activate(ctx context.Context, deviceID string) error
+	// Activate sets the device status to active and stores MQTT credentials.
+	Activate(ctx context.Context, deviceID, mqttUsername, mqttPassword string) error
 }

--- a/internal/sensors/store_provisioning_integration_test.go
+++ b/internal/sensors/store_provisioning_integration_test.go
@@ -132,7 +132,7 @@ func TestActivate_integration(t *testing.T) {
 			t.Fatalf("setup claim: %v", err)
 		}
 
-		if err := store.Activate(ctx, deviceID); err != nil {
+		if err := store.Activate(ctx, deviceID, "mqtt-user", "mqtt-pass"); err != nil {
 			t.Fatalf("activate: %v", err)
 		}
 
@@ -169,7 +169,7 @@ func TestActivate_integration(t *testing.T) {
 		if _, _, err := store.ClaimCode(ctx, code); err != nil {
 			t.Fatalf("setup claim: %v", err)
 		}
-		if err := store.Activate(ctx, deviceID); err != nil {
+		if err := store.Activate(ctx, deviceID, "mqtt-user", "mqtt-pass"); err != nil {
 			t.Fatalf("activate: %v", err)
 		}
 

--- a/internal/sensors/store_provisioning_postgres.go
+++ b/internal/sensors/store_provisioning_postgres.go
@@ -104,13 +104,10 @@ func (s *postgresProvisioningStore) ClaimCode(ctx context.Context, code string) 
 	return deviceID, userID, nil
 }
 
-// Activate sets the device status to active.
-// Note: device_tokens is no longer written here — JWT-based auth supersedes Bearer tokens.
-// The device_tokens table and LookupByToken are deprecated; see cleanup issue #46.
-func (s *postgresProvisioningStore) Activate(ctx context.Context, deviceID string) error {
+func (s *postgresProvisioningStore) Activate(ctx context.Context, deviceID, mqttUsername, mqttPassword string) error {
 	_, err := s.db.ExecContext(ctx, `
-		UPDATE devices SET status = 'active' WHERE id = $1
-	`, deviceID)
+		UPDATE devices SET status = 'active', mqtt_username = $2, mqtt_password = $3 WHERE id = $1
+	`, deviceID, mqttUsername, mqttPassword)
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/account"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
+	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
@@ -116,8 +117,31 @@ func main() {
 	r.Post("/auth/logout", (&auth.LogoutHandler{Service: authSvc}).ServeHTTP)
 	provisioningStore := sensors.NewProvisioningStore(db)
 
+	hivemqClient := hivemq.Client(hivemq.NewNoOp())
+	if baseURL := os.Getenv("HIVEMQ_API_BASE_URL"); baseURL != "" {
+		hivemqClient = hivemq.NewAPIClient(
+			baseURL,
+			os.Getenv("HIVEMQ_API_TOKEN"),
+			os.Getenv("HIVEMQ_DEVICE_ROLE_ID"),
+		)
+		log.Printf("HiveMQ API client configured: base_url=%s", baseURL)
+	} else {
+		log.Printf("warning: HIVEMQ_API_BASE_URL not set — MQTT credentials will not be provisioned at activation")
+	}
+
+	mqttPort, _ := strconv.Atoi(os.Getenv("HIVEMQ_PORT"))
+	if mqttPort == 0 {
+		mqttPort = 8883
+	}
+
 	r.Get("/.well-known/jwks.json", (&jwtutil.JWKSHandler{Signer: jwkSigner}).ServeHTTP)
-	r.Post("/devices/activate", (&sensors.ActivateHandler{Store: provisioningStore, Signer: deviceSigner}).ServeHTTP)
+	r.Post("/devices/activate", (&sensors.ActivateHandler{
+		Store:    provisioningStore,
+		Signer:   deviceSigner,
+		HiveMQ:   hivemqClient,
+		MQTTHost: os.Getenv("HIVEMQ_HOST"),
+		MQTTPort: mqttPort,
+	}).ServeHTTP)
 	r.Group(func(r chi.Router) {
 		r.Use(platform.DeviceAuthenticator(deviceSigner))
 		r.Post("/readings", readings.Create)


### PR DESCRIPTION
## Summary

- Migration 010: adds `mqtt_username` and `mqtt_password` columns to `devices`
- New `internal/hivemq` package: `Client` interface with `ProvisionDevice` (create credential + attach `device-role`, rollback on role-attach failure) and `DeleteDevice`; no-op when `HIVEMQ_API_BASE_URL` is unset
- `ProvisioningStore.Activate` extended to persist MQTT credentials
- `ActivateHandler` generates a 32-byte random password, provisions HiveMQ, and returns `mqtt_username`, `mqtt_password`, `mqtt_host`, `mqtt_port` in the activation response
- `main.go` wired from `HIVEMQ_API_BASE_URL`, `HIVEMQ_API_TOKEN`, `HIVEMQ_DEVICE_ROLE_ID`, `HIVEMQ_HOST`, `HIVEMQ_PORT`

## Test plan

- [x] `go test ./...` — all tests pass
- [ ] Deploy to Railway with `HIVEMQ_API_*` env vars set
- [ ] Activate a new device — verify HiveMQ credential appears in dashboard
- [ ] Verify firmware can connect to HiveMQ using returned credentials (tracked in fishhub-oss/fishhub-firmware#34)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)