### PR TITLE
fix: correct HiveMQ credentials request body and role attach/detach

### DIFF
--- a/internal/hivemq/client.go
+++ b/internal/hivemq/client.go
@@ -32,13 +32,18 @@ func NewAPIClient(baseURL, apiToken, deviceRoleID string) Client {
 }
 
 func (c *apiClient) ProvisionDevice(ctx context.Context, username, password string) error {
-	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+	body, _ := json.Marshal(map[string]any{
+		"credentials": map[string]string{
+			"username": username,
+			"password": password,
+		},
+	})
 	if err := c.do(ctx, http.MethodPost, "/mqtt/credentials", body); err != nil {
 		return fmt.Errorf("hivemq: create credential: %w", err)
 	}
 
 	attachURL := fmt.Sprintf("/user/%s/roles/%s/attach", username, c.deviceRoleID)
-	if err := c.do(ctx, http.MethodPost, attachURL, nil); err != nil {
+	if err := c.do(ctx, http.MethodPut, attachURL, nil); err != nil {
 		// Roll back — delete the credential we just created
 		_ = c.do(ctx, http.MethodDelete, "/mqtt/credentials/"+username, nil)
 		return fmt.Errorf("hivemq: attach role: %w", err)
@@ -48,8 +53,8 @@ func (c *apiClient) ProvisionDevice(ctx context.Context, username, password stri
 }
 
 func (c *apiClient) DeleteDevice(ctx context.Context, username string) error {
-	detachURL := fmt.Sprintf("/user/%s/roles/%s/attach", username, c.deviceRoleID)
-	if err := c.do(ctx, http.MethodDelete, detachURL, nil); err != nil {
+	detachURL := fmt.Sprintf("/user/%s/roles/%s/detach", username, c.deviceRoleID)
+	if err := c.do(ctx, http.MethodPut, detachURL, nil); err != nil {
 		return fmt.Errorf("hivemq: detach role: %w", err)
 	}
 	if err := c.do(ctx, http.MethodDelete, "/mqtt/credentials/"+username, nil); err != nil {

--- a/internal/hivemq/client_test.go
+++ b/internal/hivemq/client_test.go
@@ -31,8 +31,8 @@ func TestProvisionDevice(t *testing.T) {
 		if calls[0] != "POST /mqtt/credentials" {
 			t.Errorf("expected first call POST /mqtt/credentials, got %s", calls[0])
 		}
-		if calls[1] != "POST /user/dev-1/roles/role-id/attach" {
-			t.Errorf("expected second call POST /user/dev-1/roles/role-id/attach, got %s", calls[1])
+		if calls[1] != "PUT /user/dev-1/roles/role-id/attach" {
+			t.Errorf("expected second call PUT /user/dev-1/roles/role-id/attach, got %s", calls[1])
 		}
 	})
 
@@ -40,7 +40,7 @@ func TestProvisionDevice(t *testing.T) {
 		var calls []string
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			calls = append(calls, r.Method+" "+r.URL.Path)
-			if r.Method == http.MethodPost && r.URL.Path != "/mqtt/credentials" {
+			if r.Method == http.MethodPut {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -82,8 +82,8 @@ func TestDeleteDevice(t *testing.T) {
 		if len(calls) != 2 {
 			t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
 		}
-		if calls[0] != "DELETE /user/dev-1/roles/role-id/attach" {
-			t.Errorf("expected first call DELETE /user/dev-1/roles/role-id/attach, got %s", calls[0])
+		if calls[0] != "PUT /user/dev-1/roles/role-id/detach" {
+			t.Errorf("expected first call PUT /user/dev-1/roles/role-id/detach, got %s", calls[0])
 		}
 		if calls[1] != "DELETE /mqtt/credentials/dev-1" {
 			t.Errorf("expected second call DELETE /mqtt/credentials/dev-1, got %s", calls[1])


### PR DESCRIPTION
- Wrap credentials in `{"credentials": {...}}` as required by HiveMQ v2 API
- Fix attach/detach role calls: use `PUT` (not `POST`/`DELETE`) and correct `/detach` path

Closes #50