### PR TITLE
feat: add DELETE /api/devices/{id} with HiveMQ credential cleanup

### DIFF
--- a/db/migrations/011_add_device_deleted_at.down.sql
+++ b/db/migrations/011_add_device_deleted_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN deleted_at;

--- a/db/migrations/011_add_device_deleted_at.up.sql
+++ b/db/migrations/011_add_device_deleted_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices ADD COLUMN deleted_at TIMESTAMPTZ;

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -203,6 +203,39 @@ func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, map[string]string{})
 }
 
+// DeleteDeviceHandler handles DELETE /api/devices/{id} (session auth).
+type DeleteDeviceHandler struct {
+	Store  DeviceStore
+	HiveMQ hivemq.Client
+}
+
+func (h *DeleteDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	mqttUsername, err := h.Store.DeleteDevice(r.Context(), deviceID, claims.UserID)
+	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if mqttUsername != "" {
+		if err := h.HiveMQ.DeleteDevice(r.Context(), mqttUsername); err != nil {
+			log.Printf("hivemq delete device error (device_id=%s): %v", deviceID, err)
+		}
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // PatchDeviceHandler handles PATCH /api/devices/{id} (session auth).
 type PatchDeviceHandler struct {
 	Store DeviceStore

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -31,17 +31,18 @@ func (s *stubReadingWriter) WriteReading(_ context.Context, r sensors.Reading) e
 }
 
 type stubDeviceStore struct {
-	info        sensors.DeviceInfo
-	device      sensors.Device
-	findErr     error
-	patchDevice sensors.Device
-	patchErr    error
+	info             sensors.DeviceInfo
+	device           sensors.Device
+	findErr          error
+	patchDevice      sensors.Device
+	patchErr         error
+	deleteMQTTUser   string
+	deleteErr        error
 }
 
 func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensors.Device, error) {
 	return nil, nil
 }
-
 
 func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sensors.Device, error) {
 	return s.device, s.findErr
@@ -49,6 +50,10 @@ func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sen
 
 func (s *stubDeviceStore) PatchDevice(_ context.Context, _, _, _ string) (sensors.Device, error) {
 	return s.patchDevice, s.patchErr
+}
+
+func (s *stubDeviceStore) DeleteDevice(_ context.Context, _, _ string) (string, error) {
+	return s.deleteMQTTUser, s.deleteErr
 }
 
 type stubReadingQuerier struct {
@@ -630,6 +635,78 @@ func TestCommandHandler(t *testing.T) {
 		h.ServeHTTP(rec, makeReq(body, "user-1"))
 		if rec.Code != http.StatusInternalServerError {
 			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+}
+
+// --- DeleteDeviceHandler ---
+
+func TestDeleteDeviceHandler(t *testing.T) {
+	makeReq := func(deviceID, userID string) *http.Request {
+		req := httptest.NewRequest(http.MethodDelete, "/api/devices/"+deviceID, nil)
+		if userID != "" {
+			req = withClaims(req, userID)
+		}
+		req = withChiParam(req, "id", deviceID)
+		return req
+	}
+
+	t.Run("204 when device deleted and HiveMQ succeeds", func(t *testing.T) {
+		store := &stubDeviceStore{deleteMQTTUser: "dev-uuid"}
+		h := &sensors.DeleteDeviceHandler{Store: store, HiveMQ: &stubHiveMQClient{}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-uuid", "user-uuid"))
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", rec.Code)
+		}
+	})
+
+	t.Run("204 when device deleted but HiveMQ fails (non-fatal)", func(t *testing.T) {
+		store := &stubDeviceStore{deleteMQTTUser: "dev-uuid"}
+		h := &sensors.DeleteDeviceHandler{Store: store, HiveMQ: &stubHiveMQClient{err: errors.New("hivemq down")}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-uuid", "user-uuid"))
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", rec.Code)
+		}
+	})
+
+	t.Run("204 when device has no mqtt_username (HiveMQ skipped)", func(t *testing.T) {
+		store := &stubDeviceStore{deleteMQTTUser: ""}
+		h := &sensors.DeleteDeviceHandler{Store: store, HiveMQ: &stubHiveMQClient{}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-uuid", "user-uuid"))
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", rec.Code)
+		}
+	})
+
+	t.Run("404 when device not found", func(t *testing.T) {
+		store := &stubDeviceStore{deleteErr: sensors.ErrDeviceNotFound}
+		h := &sensors.DeleteDeviceHandler{Store: store, HiveMQ: &stubHiveMQClient{}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-x", "user-uuid"))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("500 on store error", func(t *testing.T) {
+		store := &stubDeviceStore{deleteErr: errors.New("db down")}
+		h := &sensors.DeleteDeviceHandler{Store: store, HiveMQ: &stubHiveMQClient{}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-uuid", "user-uuid"))
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+
+	t.Run("401 when no claims", func(t *testing.T) {
+		h := &sensors.DeleteDeviceHandler{Store: &stubDeviceStore{}, HiveMQ: &stubHiveMQClient{}}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-uuid", ""))
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
 		}
 	})
 }

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -19,6 +19,9 @@ type DeviceStore interface {
 	// PatchDevice updates the name of the device owned by userID.
 	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.
 	PatchDevice(ctx context.Context, deviceID, userID, name string) (Device, error)
+	// DeleteDevice soft-deletes the device and returns its mqtt_username for cleanup.
+	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.
+	DeleteDevice(ctx context.Context, deviceID, userID string) (mqttUsername string, err error)
 }
 
 type ProvisioningStore interface {

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -24,14 +24,14 @@ func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID, status s
 		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, COALESCE(name, ''), created_at
 			FROM devices
-			WHERE user_id = $1 AND status = $2
+			WHERE user_id = $1 AND status = $2 AND deleted_at IS NULL
 			ORDER BY created_at DESC
 		`, userID, status)
 	} else {
 		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, COALESCE(name, ''), created_at
 			FROM devices
-			WHERE user_id = $1
+			WHERE user_id = $1 AND deleted_at IS NULL
 			ORDER BY created_at DESC
 		`, userID)
 	}
@@ -56,7 +56,7 @@ func (s *postgresDeviceStore) FindByIDAndUserID(ctx context.Context, deviceID, u
 	err := s.db.QueryRowContext(ctx, `
 		SELECT id, COALESCE(name, ''), created_at
 		FROM devices
-		WHERE id = $1 AND user_id = $2
+		WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
 	`, deviceID, userID).Scan(&d.ID, &d.Name, &d.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Device{}, ErrDeviceNotFound
@@ -67,12 +67,29 @@ func (s *postgresDeviceStore) FindByIDAndUserID(ctx context.Context, deviceID, u
 	return d, nil
 }
 
+func (s *postgresDeviceStore) DeleteDevice(ctx context.Context, deviceID, userID string) (string, error) {
+	var mqttUsername string
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE devices
+		SET deleted_at = now()
+		WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
+		RETURNING COALESCE(mqtt_username, '')
+	`, deviceID, userID).Scan(&mqttUsername)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrDeviceNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("delete device: %w", err)
+	}
+	return mqttUsername, nil
+}
+
 func (s *postgresDeviceStore) PatchDevice(ctx context.Context, deviceID, userID, name string) (Device, error) {
 	var d Device
 	err := s.db.QueryRowContext(ctx, `
 		UPDATE devices
 		SET name = $1
-		WHERE id = $2 AND user_id = $3
+		WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL
 		RETURNING id, COALESCE(name, ''), created_at
 	`, name, deviceID, userID).Scan(&d.ID, &d.Name, &d.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/main.go
+++ b/main.go
@@ -167,6 +167,7 @@ func main() {
 		r.Post("/api/devices/provision", (&sensors.ProvisionHandler{Store: provisioningStore}).ServeHTTP)
 		r.Get("/api/devices", (&sensors.DevicesHandler{Store: deviceStore}).List)
 		r.Patch("/api/devices/{id}", (&sensors.PatchDeviceHandler{Store: deviceStore}).ServeHTTP)
+		r.Delete("/api/devices/{id}", (&sensors.DeleteDeviceHandler{Store: deviceStore, HiveMQ: hivemqClient}).ServeHTTP)
 		r.Get("/api/devices/{id}/readings", (&sensors.ReadingsQueryHandler{
 			Querier: influxClient,
 			Devices: deviceStore,


### PR DESCRIPTION
## Summary

- Adds migration 011: `deleted_at TIMESTAMPTZ` column on `devices`
- Soft-deletes the device via `DELETE /api/devices/{id}` (session-auth)
- Calls `hivemq.Client.DeleteDevice` to detach role + delete MQTT credential — failure is non-fatal (logged, not returned)
- All existing `DeviceStore` queries updated with `AND deleted_at IS NULL`
- Unit tests cover: 204 on success, 204 when HiveMQ fails, 204 with no mqtt_username, 404 not found, 500 store error, 401 unauthenticated

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)