### PR TITLE
fix: MQTT keepalive and connection lifecycle logging

### DIFF
--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"time"
 
 	paho "github.com/eclipse/paho.mqtt.golang"
 )
-
 
 // Publisher publishes a payload to an MQTT topic.
 type Publisher interface {
@@ -28,8 +28,15 @@ func NewPublisher(host string, port int, username, password string) (Publisher, 
 		SetPassword(password).
 		SetTLSConfig(&tls.Config{}).
 		SetConnectTimeout(10 * time.Second).
+		SetKeepAlive(30 * time.Second).
 		SetAutoReconnect(true).
-		SetCleanSession(true)
+		SetCleanSession(true).
+		SetConnectionLostHandler(func(_ paho.Client, err error) {
+			log.Printf("mqtt: connection lost: %v", err)
+		}).
+		SetOnConnectHandler(func(_ paho.Client) {
+			log.Printf("mqtt: connected to %s:%d", host, port)
+		})
 
 	c := paho.NewClient(opts)
 	token := c.Connect()
@@ -44,7 +51,7 @@ func NewPublisher(host string, port int, username, password string) (Publisher, 
 }
 
 func (p *pahoPublisher) Publish(_ context.Context, topic string, payload []byte) error {
-	token := p.client.Publish(topic, 1, true, payload)
+	token := p.client.Publish(topic, 1, false, payload)
 	if !token.WaitTimeout(10 * time.Second) {
 		return fmt.Errorf("mqtt: publish timeout")
 	}
@@ -57,5 +64,5 @@ func (p *pahoPublisher) Publish(_ context.Context, topic string, payload []byte)
 // noopPublisher is returned when HIVEMQ_HOST is not configured.
 type noopPublisher struct{}
 
-func NewNoOpPublisher() Publisher                                                  { return &noopPublisher{} }
+func NewNoOpPublisher() Publisher                                              { return &noopPublisher{} }
 func (n *noopPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }


### PR DESCRIPTION
## Summary

- Add `SetKeepAlive(30s)` to prevent HiveMQ from closing idle connections, which caused publish timeouts on the first command after a period of inactivity
- Add `ConnectionLostHandler` and `OnConnectHandler` to log connection drops and reconnects, making the root cause visible in production logs
- Revert publish to QoS 1, `retained=false`: QoS 1 ensures delivery; non-retained prevents stale commands from replaying when a device reconnects

## Root cause (tentative)

The broker was closing the idle connection. Paho's `SetAutoReconnect` reconnects in the background, but a publish fired during the reconnect handshake never receives a PUBACK, causing the 10s timeout.

## Test plan

- [ ] Deploy and leave idle for several minutes
- [ ] Send a command — verify no timeout
- [ ] Check logs for `mqtt: connected` on startup and `mqtt: connection lost` if a drop occurs

Closes #67