### PR TITLE
feat: structured logging with log/slog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,12 @@ internal/
 - Wire format for sensor readings: **SenML JSON (RFC 8428)**
 - Auth: **Bearer token** (random 32-byte hex), one token per device
 - Integration tests use `testutil.NewTestDB(t)` — never mock the database
+
+## Logging
+
+- Use `log/slog` — never `log.Printf` or `fmt.Println`.
+- Inject `*slog.Logger` via struct fields; never use a package-level logger or pass via context.
+- Levels: `Info` for normal events, `Warn` for non-fatal degraded state (auth failures, optional components not configured), `Error` for failures that affect the response.
+- Handler-layer 5xx errors are covered by `platform.RequestLogger` middleware — no per-handler log calls needed.
+- Service-layer errors (external call failures) should log at the service level with structured key-value pairs.
+- `LOG_FORMAT=json` → JSON output (production/Railway); anything else → text output (development).

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -10,6 +11,7 @@ import (
 
 type VerifyHandler struct {
 	Service AuthService
+	Logger  *slog.Logger
 }
 
 type verifyRequest struct {
@@ -38,18 +40,21 @@ func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid id token", http.StatusUnauthorized)
 			return
 		}
+		h.Logger.Error("auth verify", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	sessionToken, err := h.Service.IssueSessionJWT(user.ID)
 	if err != nil {
+		h.Logger.Error("auth verify: issue session jwt", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	refreshToken, err := h.Service.IssueRefreshToken(r.Context(), user.ID)
 	if err != nil {
+		h.Logger.Error("auth verify: issue refresh token", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -62,6 +67,7 @@ func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type RefreshHandler struct {
 	Service AuthService
+	Logger  *slog.Logger
 }
 
 type refreshRequest struct {
@@ -85,6 +91,7 @@ func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid or expired refresh token", http.StatusUnauthorized)
 			return
 		}
+		h.Logger.Error("auth refresh", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -10,8 +10,15 @@ import (
 )
 
 type VerifyHandler struct {
-	Service AuthService
-	Logger  *slog.Logger
+	service AuthService
+	logger  *slog.Logger
+}
+
+func NewVerifyHandler(service AuthService, logger *slog.Logger) *VerifyHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &VerifyHandler{service: service, logger: logger}
 }
 
 type verifyRequest struct {
@@ -30,7 +37,7 @@ func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.Service.VerifyAndUpsert(r.Context(), req.Provider, req.IDToken)
+	user, err := h.service.VerifyAndUpsert(r.Context(), req.Provider, req.IDToken)
 	if err != nil {
 		if errors.Is(err, ErrUnsupportedProvider) {
 			http.Error(w, "unsupported provider", http.StatusUnprocessableEntity)
@@ -40,21 +47,21 @@ func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid id token", http.StatusUnauthorized)
 			return
 		}
-		h.Logger.Error("auth verify", "error", err)
+		h.logger.Error("auth verify", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	sessionToken, err := h.Service.IssueSessionJWT(user.ID)
+	sessionToken, err := h.service.IssueSessionJWT(user.ID)
 	if err != nil {
-		h.Logger.Error("auth verify: issue session jwt", "error", err)
+		h.logger.Error("auth verify: issue session jwt", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	refreshToken, err := h.Service.IssueRefreshToken(r.Context(), user.ID)
+	refreshToken, err := h.service.IssueRefreshToken(r.Context(), user.ID)
 	if err != nil {
-		h.Logger.Error("auth verify: issue refresh token", "error", err)
+		h.logger.Error("auth verify: issue refresh token", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -66,8 +73,15 @@ func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type RefreshHandler struct {
-	Service AuthService
-	Logger  *slog.Logger
+	service AuthService
+	logger  *slog.Logger
+}
+
+func NewRefreshHandler(service AuthService, logger *slog.Logger) *RefreshHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RefreshHandler{service: service, logger: logger}
 }
 
 type refreshRequest struct {
@@ -85,13 +99,13 @@ func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newRaw, sessionJWT, err := h.Service.RotateRefreshToken(r.Context(), req.RefreshToken)
+	newRaw, sessionJWT, err := h.service.RotateRefreshToken(r.Context(), req.RefreshToken)
 	if err != nil {
 		if errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrTokenRevoked) {
 			http.Error(w, "invalid or expired refresh token", http.StatusUnauthorized)
 			return
 		}
-		h.Logger.Error("auth refresh", "error", err)
+		h.logger.Error("auth refresh", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -103,7 +117,11 @@ func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type LogoutHandler struct {
-	Service AuthService
+	service AuthService
+}
+
+func NewLogoutHandler(service AuthService) *LogoutHandler {
+	return &LogoutHandler{service: service}
 }
 
 type logoutRequest struct {
@@ -117,7 +135,7 @@ func (h *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if req.RefreshToken != "" {
 		// ignore revocation errors; the cookie is cleared regardless
-		h.Service.RevokeRefreshToken(r.Context(), req.RefreshToken) //nolint:errcheck
+		h.service.RevokeRefreshToken(r.Context(), req.RefreshToken) //nolint:errcheck
 	}
 
 	http.SetCookie(w, &http.Cookie{

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -49,11 +49,11 @@ func TestVerifyHandler(t *testing.T) {
 	validUser := auth.User{ID: "user-uuid"}
 
 	t.Run("valid request returns token and refresh_token", func(t *testing.T) {
-		h := &auth.VerifyHandler{Service: &stubAuthService{
+		h := auth.NewVerifyHandler(&stubAuthService{
 			user:       validUser,
 			jwtToken:   "signed.jwt.token",
 			refreshRaw: "raw-refresh-token",
-		}}
+		}, nil)
 		body, _ := json.Marshal(map[string]string{"provider": "google", "id_token": "raw-id-token"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -73,7 +73,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("missing id_token returns 400", func(t *testing.T) {
-		h := &auth.VerifyHandler{Service: &stubAuthService{}}
+		h := auth.NewVerifyHandler(&stubAuthService{}, nil)
 		body, _ := json.Marshal(map[string]string{"provider": "google"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -84,7 +84,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("missing provider returns 400", func(t *testing.T) {
-		h := &auth.VerifyHandler{Service: &stubAuthService{}}
+		h := auth.NewVerifyHandler(&stubAuthService{}, nil)
 		body, _ := json.Marshal(map[string]string{"id_token": "tok"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -95,7 +95,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("unsupported provider returns 422", func(t *testing.T) {
-		h := &auth.VerifyHandler{Service: &stubAuthService{upsertErr: auth.ErrUnsupportedProvider}}
+		h := auth.NewVerifyHandler(&stubAuthService{upsertErr: auth.ErrUnsupportedProvider}, nil)
 		body, _ := json.Marshal(map[string]string{"provider": "github", "id_token": "tok"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("invalid id token returns 401", func(t *testing.T) {
-		h := &auth.VerifyHandler{Service: &stubAuthService{upsertErr: auth.ErrInvalidIDToken}}
+		h := auth.NewVerifyHandler(&stubAuthService{upsertErr: auth.ErrInvalidIDToken}, nil)
 		body, _ := json.Marshal(map[string]string{"provider": "google", "id_token": "bad"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -117,7 +117,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("malformed JSON returns 400", func(t *testing.T) {
-		h := &auth.VerifyHandler{Service: &stubAuthService{}}
+		h := auth.NewVerifyHandler(&stubAuthService{}, nil)
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader([]byte("not json")))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
@@ -129,10 +129,10 @@ func TestVerifyHandler(t *testing.T) {
 
 func TestRefreshHandler(t *testing.T) {
 	t.Run("valid refresh token returns new token pair", func(t *testing.T) {
-		h := &auth.RefreshHandler{Service: &stubAuthService{
+		h := auth.NewRefreshHandler(&stubAuthService{
 			newRaw: "new-raw-token",
 			newJWT: "new.jwt.token",
-		}}
+		}, nil)
 		body, _ := json.Marshal(map[string]string{"refresh_token": "old-raw-token"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -152,7 +152,7 @@ func TestRefreshHandler(t *testing.T) {
 	})
 
 	t.Run("missing refresh_token returns 400", func(t *testing.T) {
-		h := &auth.RefreshHandler{Service: &stubAuthService{}}
+		h := auth.NewRefreshHandler(&stubAuthService{}, nil)
 		body, _ := json.Marshal(map[string]string{})
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -163,7 +163,7 @@ func TestRefreshHandler(t *testing.T) {
 	})
 
 	t.Run("malformed JSON returns 400", func(t *testing.T) {
-		h := &auth.RefreshHandler{Service: &stubAuthService{}}
+		h := auth.NewRefreshHandler(&stubAuthService{}, nil)
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader([]byte("not json")))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
@@ -181,7 +181,7 @@ func TestRefreshHandler(t *testing.T) {
 		{"revoked returns 401", auth.ErrTokenRevoked},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			h := &auth.RefreshHandler{Service: &stubAuthService{rotateErr: tc.err}}
+			h := auth.NewRefreshHandler(&stubAuthService{rotateErr: tc.err}, nil)
 			body, _ := json.Marshal(map[string]string{"refresh_token": "some-token"})
 			req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
 			w := httptest.NewRecorder()
@@ -195,7 +195,7 @@ func TestRefreshHandler(t *testing.T) {
 
 func TestLogoutHandler(t *testing.T) {
 	t.Run("clears session cookie", func(t *testing.T) {
-		h := &auth.LogoutHandler{Service: &stubAuthService{}}
+		h := auth.NewLogoutHandler(&stubAuthService{})
 		body, _ := json.Marshal(map[string]string{"refresh_token": "some-token"})
 		req := httptest.NewRequest(http.MethodPost, "/auth/logout", bytes.NewReader(body))
 		w := httptest.NewRecorder()
@@ -216,7 +216,7 @@ func TestLogoutHandler(t *testing.T) {
 	})
 
 	t.Run("works without body", func(t *testing.T) {
-		h := &auth.LogoutHandler{Service: &stubAuthService{}}
+		h := auth.NewLogoutHandler(&stubAuthService{})
 		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -21,6 +21,9 @@ type pahoPublisher struct {
 
 // NewPublisher connects to the HiveMQ broker with the given server credentials and returns a Publisher.
 func NewPublisher(host string, port int, username, password string, logger *slog.Logger) (Publisher, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	opts := paho.NewClientOptions().
 		AddBroker(fmt.Sprintf("tls://%s:%d", host, port)).
 		SetClientID("fishhub-server").
@@ -32,14 +35,10 @@ func NewPublisher(host string, port int, username, password string, logger *slog
 		SetAutoReconnect(true).
 		SetCleanSession(true).
 		SetConnectionLostHandler(func(_ paho.Client, err error) {
-			if logger != nil {
-				logger.Warn("mqtt connection lost", "error", err)
-			}
+			logger.Warn("mqtt connection lost", "error", err)
 		}).
 		SetOnConnectHandler(func(_ paho.Client) {
-			if logger != nil {
-				logger.Info("mqtt connected", "host", host, "port", port)
-			}
+			logger.Info("mqtt connected", "host", host, "port", port)
 		})
 
 	c := paho.NewClient(opts)

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	paho "github.com/eclipse/paho.mqtt.golang"
@@ -20,7 +20,7 @@ type pahoPublisher struct {
 }
 
 // NewPublisher connects to the HiveMQ broker with the given server credentials and returns a Publisher.
-func NewPublisher(host string, port int, username, password string) (Publisher, error) {
+func NewPublisher(host string, port int, username, password string, logger *slog.Logger) (Publisher, error) {
 	opts := paho.NewClientOptions().
 		AddBroker(fmt.Sprintf("tls://%s:%d", host, port)).
 		SetClientID("fishhub-server").
@@ -32,10 +32,14 @@ func NewPublisher(host string, port int, username, password string) (Publisher, 
 		SetAutoReconnect(true).
 		SetCleanSession(true).
 		SetConnectionLostHandler(func(_ paho.Client, err error) {
-			log.Printf("mqtt: connection lost: %v", err)
+			if logger != nil {
+				logger.Warn("mqtt connection lost", "error", err)
+			}
 		}).
 		SetOnConnectHandler(func(_ paho.Client) {
-			log.Printf("mqtt: connected to %s:%d", host, port)
+			if logger != nil {
+				logger.Info("mqtt connected", "host", host, "port", port)
+			}
 		})
 
 	c := paho.NewClient(opts)

--- a/internal/platform/middleware.go
+++ b/internal/platform/middleware.go
@@ -2,15 +2,42 @@ package platform
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 	"github.com/golang-jwt/jwt/v5"
 )
+
+// RequestLogger logs method, path, status, and duration for every request.
+func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			start := time.Now()
+			defer func() {
+				status := ww.Status()
+				level := slog.LevelInfo
+				if status >= 500 {
+					level = slog.LevelError
+				}
+				logger.Log(r.Context(), level, "request",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"status", status,
+					"duration_ms", time.Since(start).Milliseconds(),
+				)
+			}()
+			next.ServeHTTP(ww, r)
+		})
+	}
+}
 
 // DeviceAuthenticator validates a device JWT from the Authorization header.
 // It extracts sub (device_id) and user_id claims and stores DeviceInfo in the request context.
@@ -20,12 +47,14 @@ func DeviceAuthenticator(signer devicejwt.Signer) func(http.Handler) http.Handle
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			raw := bearerToken(r)
 			if raw == "" {
+				slog.Warn("device auth failure", "reason", "missing bearer token", "path", r.URL.Path)
 				http.Error(w, "missing or malformed authorization header", http.StatusUnauthorized)
 				return
 			}
 
 			pub := signer.PublicKey()
 			if pub == nil {
+				slog.Warn("device auth failure", "reason", "signer not configured", "path", r.URL.Path)
 				http.Error(w, "device auth not configured", http.StatusUnauthorized)
 				return
 			}
@@ -37,12 +66,14 @@ func DeviceAuthenticator(signer devicejwt.Signer) func(http.Handler) http.Handle
 				return pub, nil
 			}, jwt.WithValidMethods([]string{"RS256"}))
 			if err != nil || !token.Valid {
+				slog.Warn("device auth failure", "reason", "invalid token", "path", r.URL.Path, "error", err)
 				http.Error(w, "invalid token", http.StatusUnauthorized)
 				return
 			}
 
 			claims, ok := token.Claims.(jwt.MapClaims)
 			if !ok {
+				slog.Warn("device auth failure", "reason", "invalid claims type", "path", r.URL.Path)
 				http.Error(w, "invalid token claims", http.StatusUnauthorized)
 				return
 			}
@@ -50,6 +81,7 @@ func DeviceAuthenticator(signer devicejwt.Signer) func(http.Handler) http.Handle
 			deviceID, _ := claims["sub"].(string)
 			userID, _ := claims["user_id"].(string)
 			if deviceID == "" || userID == "" {
+				slog.Warn("device auth failure", "reason", "missing claims", "path", r.URL.Path)
 				http.Error(w, "invalid token claims", http.StatusUnauthorized)
 				return
 			}
@@ -82,12 +114,14 @@ func SessionAuthenticator(svc auth.AuthService) func(http.Handler) http.Handler 
 				}
 			}
 			if token == "" {
+				slog.Warn("session auth failure", "reason", "missing token", "path", r.URL.Path)
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 				return
 			}
 
 			userID, err := svc.ValidateSessionJWT(token)
 			if err != nil {
+				slog.Warn("session auth failure", "reason", "invalid token", "path", r.URL.Path, "error", err)
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 				return
 			}

--- a/internal/sensors/activation_service.go
+++ b/internal/sensors/activation_service.go
@@ -24,22 +24,29 @@ type ActivationResult struct {
 // ActivationService orchestrates device activation: claim code → provision MQTT
 // credentials → store in DB → sign JWT.
 type ActivationService struct {
-	Store    ProvisioningStore
-	HiveMQ   hivemq.Client
-	Signer   devicejwt.Signer
-	MQTTHost string
-	MQTTPort int
-	Logger   *slog.Logger
+	store    ProvisioningStore
+	hiveMQ   hivemq.Client
+	signer   devicejwt.Signer
+	mqttHost string
+	mqttPort int
+	logger   *slog.Logger
+}
+
+func NewActivationService(store ProvisioningStore, hiveMQ hivemq.Client, signer devicejwt.Signer, mqttHost string, mqttPort int, logger *slog.Logger) *ActivationService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ActivationService{store: store, hiveMQ: hiveMQ, signer: signer, mqttHost: mqttHost, mqttPort: mqttPort, logger: logger}
 }
 
 // Activate claims the provisioning code and completes device activation.
 // Sentinel errors ErrCodeNotFound and ErrCodeAlreadyUsed are returned unwrapped
 // so callers can map them to HTTP status codes.
 func (s *ActivationService) Activate(ctx context.Context, code string) (ActivationResult, error) {
-	deviceID, userID, err := s.Store.ClaimCode(ctx, code)
+	deviceID, userID, err := s.store.ClaimCode(ctx, code)
 	if err != nil {
 		if err != ErrCodeNotFound && err != ErrCodeAlreadyUsed {
-			s.Logger.Error("activate: claim code", "error", err)
+			s.logger.Error("activate: claim code", "error", err)
 		}
 		return ActivationResult{}, err
 	}
@@ -47,24 +54,24 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 	mqttUsername := deviceID
 	mqttPasswordBytes := make([]byte, 32)
 	if _, err := rand.Read(mqttPasswordBytes); err != nil {
-		s.Logger.Error("activate: generate mqtt password", "device_id", deviceID, "error", err)
+		s.logger.Error("activate: generate mqtt password", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("generate mqtt password: %w", err)
 	}
 	mqttPassword := hex.EncodeToString(mqttPasswordBytes)
 
-	if err := s.HiveMQ.ProvisionDevice(ctx, mqttUsername, mqttPassword); err != nil {
-		s.Logger.Error("activate: hivemq provision", "device_id", deviceID, "error", err)
+	if err := s.hiveMQ.ProvisionDevice(ctx, mqttUsername, mqttPassword); err != nil {
+		s.logger.Error("activate: hivemq provision", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("hivemq provision: %w", err)
 	}
 
-	if err := s.Store.Activate(ctx, deviceID, mqttUsername, mqttPassword); err != nil {
-		s.Logger.Error("activate: store", "device_id", deviceID, "error", err)
+	if err := s.store.Activate(ctx, deviceID, mqttUsername, mqttPassword); err != nil {
+		s.logger.Error("activate: store", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("activate device: %w", err)
 	}
 
-	jwtToken, err := s.Signer.Sign(deviceID, userID)
+	jwtToken, err := s.signer.Sign(deviceID, userID)
 	if err != nil {
-		s.Logger.Error("activate: sign device jwt", "device_id", deviceID, "error", err)
+		s.logger.Error("activate: sign device jwt", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("sign device jwt: %w", err)
 	}
 
@@ -73,7 +80,7 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 		DeviceID:     deviceID,
 		MQTTUsername: mqttUsername,
 		MQTTPassword: mqttPassword,
-		MQTTHost:     s.MQTTHost,
-		MQTTPort:     s.MQTTPort,
+		MQTTHost:     s.mqttHost,
+		MQTTPort:     s.mqttPort,
 	}, nil
 }

--- a/internal/sensors/activation_service.go
+++ b/internal/sensors/activation_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
 	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
@@ -28,6 +29,7 @@ type ActivationService struct {
 	Signer   devicejwt.Signer
 	MQTTHost string
 	MQTTPort int
+	Logger   *slog.Logger
 }
 
 // Activate claims the provisioning code and completes device activation.
@@ -36,26 +38,33 @@ type ActivationService struct {
 func (s *ActivationService) Activate(ctx context.Context, code string) (ActivationResult, error) {
 	deviceID, userID, err := s.Store.ClaimCode(ctx, code)
 	if err != nil {
+		if err != ErrCodeNotFound && err != ErrCodeAlreadyUsed {
+			s.Logger.Error("activate: claim code", "error", err)
+		}
 		return ActivationResult{}, err
 	}
 
 	mqttUsername := deviceID
 	mqttPasswordBytes := make([]byte, 32)
 	if _, err := rand.Read(mqttPasswordBytes); err != nil {
+		s.Logger.Error("activate: generate mqtt password", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("generate mqtt password: %w", err)
 	}
 	mqttPassword := hex.EncodeToString(mqttPasswordBytes)
 
 	if err := s.HiveMQ.ProvisionDevice(ctx, mqttUsername, mqttPassword); err != nil {
+		s.Logger.Error("activate: hivemq provision", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("hivemq provision: %w", err)
 	}
 
 	if err := s.Store.Activate(ctx, deviceID, mqttUsername, mqttPassword); err != nil {
+		s.Logger.Error("activate: store", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("activate device: %w", err)
 	}
 
 	jwtToken, err := s.Signer.Sign(deviceID, userID)
 	if err != nil {
+		s.Logger.Error("activate: sign device jwt", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("sign device jwt: %w", err)
 	}
 

--- a/internal/sensors/activation_test.go
+++ b/internal/sensors/activation_test.go
@@ -9,14 +9,7 @@ import (
 )
 
 func newActivationSvc(store *stubProvisioningStore, mq *stubHiveMQClient, signer *stubSigner) *sensors.ActivationService {
-	return &sensors.ActivationService{
-		Store:    store,
-		HiveMQ:   mq,
-		Signer:   signer,
-		MQTTHost: "broker.example.com",
-		MQTTPort: 8883,
-		Logger:   discardLogger,
-	}
+	return sensors.NewActivationService(store, mq, signer, "broker.example.com", 8883, discardLogger)
 }
 
 func TestActivationService_HappyPath(t *testing.T) {

--- a/internal/sensors/activation_test.go
+++ b/internal/sensors/activation_test.go
@@ -15,6 +15,7 @@ func newActivationSvc(store *stubProvisioningStore, mq *stubHiveMQClient, signer
 		Signer:   signer,
 		MQTTHost: "broker.example.com",
 		MQTTPort: 8883,
+		Logger:   discardLogger,
 	}
 }
 

--- a/internal/sensors/device_service.go
+++ b/internal/sensors/device_service.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 
 	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 )
@@ -16,6 +16,7 @@ type DeviceService struct {
 	Store     DeviceStore
 	HiveMQ    hivemq.Client
 	Publisher CommandPublisher
+	Logger    *slog.Logger
 }
 
 // Delete soft-deletes the device and revokes its MQTT credentials.
@@ -28,7 +29,9 @@ func (s *DeviceService) Delete(ctx context.Context, deviceID, userID string) err
 	}
 	if mqttUsername != "" {
 		if err := s.HiveMQ.DeleteDevice(ctx, mqttUsername); err != nil {
-			log.Printf("hivemq delete device error (device_id=%s): %v", deviceID, err)
+			if s.Logger != nil {
+				s.Logger.Warn("hivemq delete device", "device_id", deviceID, "error", err)
+			}
 		}
 	}
 	return nil

--- a/internal/sensors/device_service.go
+++ b/internal/sensors/device_service.go
@@ -21,6 +21,9 @@ type DeviceService struct {
 }
 
 func NewDeviceService(store DeviceStore, hiveMQ hivemq.Client, publisher CommandPublisher, logger *slog.Logger) *DeviceService {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &DeviceService{store: store, hiveMQ: hiveMQ, publisher: publisher, logger: logger}
 }
 

--- a/internal/sensors/device_service.go
+++ b/internal/sensors/device_service.go
@@ -13,25 +13,27 @@ import (
 
 // DeviceService orchestrates multi-step device operations.
 type DeviceService struct {
-	Store     DeviceStore
-	HiveMQ    hivemq.Client
-	Publisher CommandPublisher
-	Logger    *slog.Logger
+	store     DeviceStore
+	hiveMQ    hivemq.Client
+	publisher CommandPublisher
+	logger    *slog.Logger
+}
+
+func NewDeviceService(store DeviceStore, hiveMQ hivemq.Client, publisher CommandPublisher, logger *slog.Logger) *DeviceService {
+	return &DeviceService{store: store, hiveMQ: hiveMQ, publisher: publisher, logger: logger}
 }
 
 // Delete soft-deletes the device and revokes its MQTT credentials.
 // Returns ErrDeviceNotFound unwrapped if the device does not exist or is not
 // owned by userID.
 func (s *DeviceService) Delete(ctx context.Context, deviceID, userID string) error {
-	mqttUsername, err := s.Store.DeleteDevice(ctx, deviceID, userID)
+	mqttUsername, err := s.store.DeleteDevice(ctx, deviceID, userID)
 	if err != nil {
 		return err
 	}
 	if mqttUsername != "" {
-		if err := s.HiveMQ.DeleteDevice(ctx, mqttUsername); err != nil {
-			if s.Logger != nil {
-				s.Logger.Warn("hivemq delete device", "device_id", deviceID, "error", err)
-			}
+		if err := s.hiveMQ.DeleteDevice(ctx, mqttUsername); err != nil {
+			s.logger.Warn("hivemq delete device", "device_id", deviceID, "error", err)
 		}
 	}
 	return nil
@@ -39,21 +41,21 @@ func (s *DeviceService) Delete(ctx context.Context, deviceID, userID string) err
 
 // List returns all devices belonging to userID, optionally filtered by status.
 func (s *DeviceService) List(ctx context.Context, userID, status string) ([]Device, error) {
-	return s.Store.ListByUserID(ctx, userID, status)
+	return s.store.ListByUserID(ctx, userID, status)
 }
 
 // Patch updates the device name and returns the updated device.
 // Returns ErrDeviceNotFound unwrapped if the device does not exist or is not
 // owned by userID.
 func (s *DeviceService) Patch(ctx context.Context, deviceID, userID, name string) (Device, error) {
-	return s.Store.PatchDevice(ctx, deviceID, userID, name)
+	return s.store.PatchDevice(ctx, deviceID, userID, name)
 }
 
 // SendCommand verifies ownership and publishes the raw command payload to the
 // device's MQTT topic. Returns ErrDeviceNotFound unwrapped if the device does
 // not exist or is not owned by userID.
 func (s *DeviceService) SendCommand(ctx context.Context, deviceID, userID, peripheralName string, body []byte) error {
-	if _, err := s.Store.FindByIDAndUserID(ctx, deviceID, userID); err != nil {
+	if _, err := s.store.FindByIDAndUserID(ctx, deviceID, userID); err != nil {
 		return err
 	}
 
@@ -66,7 +68,7 @@ func (s *DeviceService) SendCommand(ctx context.Context, deviceID, userID, perip
 	}
 
 	topic := fmt.Sprintf("fishhub/%s/commands/%s", deviceID, peripheralName)
-	if err := s.Publisher.Publish(ctx, topic, body); err != nil {
+	if err := s.publisher.Publish(ctx, topic, body); err != nil {
 		return fmt.Errorf("mqtt publish: %w", err)
 	}
 	return nil

--- a/internal/sensors/device_service.go
+++ b/internal/sensors/device_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -29,6 +30,9 @@ func NewDeviceService(store DeviceStore, hiveMQ hivemq.Client, publisher Command
 func (s *DeviceService) Delete(ctx context.Context, deviceID, userID string) error {
 	mqttUsername, err := s.store.DeleteDevice(ctx, deviceID, userID)
 	if err != nil {
+		if !errors.Is(err, ErrDeviceNotFound) {
+			s.logger.Error("delete device", "device_id", deviceID, "error", err)
+		}
 		return err
 	}
 	if mqttUsername != "" {
@@ -41,14 +45,22 @@ func (s *DeviceService) Delete(ctx context.Context, deviceID, userID string) err
 
 // List returns all devices belonging to userID, optionally filtered by status.
 func (s *DeviceService) List(ctx context.Context, userID, status string) ([]Device, error) {
-	return s.store.ListByUserID(ctx, userID, status)
+	devices, err := s.store.ListByUserID(ctx, userID, status)
+	if err != nil {
+		s.logger.Error("list devices", "user_id", userID, "error", err)
+	}
+	return devices, err
 }
 
 // Patch updates the device name and returns the updated device.
 // Returns ErrDeviceNotFound unwrapped if the device does not exist or is not
 // owned by userID.
 func (s *DeviceService) Patch(ctx context.Context, deviceID, userID, name string) (Device, error) {
-	return s.store.PatchDevice(ctx, deviceID, userID, name)
+	device, err := s.store.PatchDevice(ctx, deviceID, userID, name)
+	if err != nil && !errors.Is(err, ErrDeviceNotFound) {
+		s.logger.Error("patch device", "device_id", deviceID, "error", err)
+	}
+	return device, err
 }
 
 // SendCommand verifies ownership and publishes the raw command payload to the
@@ -56,6 +68,9 @@ func (s *DeviceService) Patch(ctx context.Context, deviceID, userID, name string
 // not exist or is not owned by userID.
 func (s *DeviceService) SendCommand(ctx context.Context, deviceID, userID, peripheralName string, body []byte) error {
 	if _, err := s.store.FindByIDAndUserID(ctx, deviceID, userID); err != nil {
+		if !errors.Is(err, ErrDeviceNotFound) {
+			s.logger.Error("send command: find device", "device_id", deviceID, "error", err)
+		}
 		return err
 	}
 
@@ -69,6 +84,7 @@ func (s *DeviceService) SendCommand(ctx context.Context, deviceID, userID, perip
 
 	topic := fmt.Sprintf("fishhub/%s/commands/%s", deviceID, peripheralName)
 	if err := s.publisher.Publish(ctx, topic, body); err != nil {
+		s.logger.Error("send command: mqtt publish", "device_id", deviceID, "error", err)
 		return fmt.Errorf("mqtt publish: %w", err)
 	}
 	return nil

--- a/internal/sensors/device_service_test.go
+++ b/internal/sensors/device_service_test.go
@@ -11,22 +11,14 @@ import (
 
 func TestDeviceService_Delete_HappyPath(t *testing.T) {
 	pub := &stubPublisher{}
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{deleteMQTTUser: "dev-1"},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: pub,
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{deleteMQTTUser: "dev-1"}, &stubHiveMQClient{}, pub, discardLogger)
 	if err := svc.Delete(context.Background(), "dev-1", "usr-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestDeviceService_Delete_NotFound(t *testing.T) {
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{deleteErr: sensors.ErrDeviceNotFound},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{deleteErr: sensors.ErrDeviceNotFound}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	err := svc.Delete(context.Background(), "dev-1", "usr-1")
 	if !errors.Is(err, sensors.ErrDeviceNotFound) {
 		t.Errorf("expected ErrDeviceNotFound, got %v", err)
@@ -34,11 +26,7 @@ func TestDeviceService_Delete_NotFound(t *testing.T) {
 }
 
 func TestDeviceService_Delete_HiveMQErrorIsLogged(t *testing.T) {
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{deleteMQTTUser: "dev-1"},
-		HiveMQ:    &stubHiveMQClient{err: errors.New("hivemq down")},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{deleteMQTTUser: "dev-1"}, &stubHiveMQClient{err: errors.New("hivemq down")}, &stubPublisher{}, discardLogger)
 	if err := svc.Delete(context.Background(), "dev-1", "usr-1"); err != nil {
 		t.Fatalf("expected nil error (HiveMQ errors are non-fatal), got %v", err)
 	}
@@ -46,11 +34,7 @@ func TestDeviceService_Delete_HiveMQErrorIsLogged(t *testing.T) {
 
 func TestDeviceService_SendCommand_HappyPath(t *testing.T) {
 	pub := &stubPublisher{}
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: pub,
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{}, &stubHiveMQClient{}, pub, discardLogger)
 	body := []byte(`{"action":"set","state":true}`)
 	if err := svc.SendCommand(context.Background(), "dev-1", "usr-1", "light", body); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -61,11 +45,7 @@ func TestDeviceService_SendCommand_HappyPath(t *testing.T) {
 }
 
 func TestDeviceService_SendCommand_NotFound(t *testing.T) {
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{findErr: sensors.ErrDeviceNotFound},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{findErr: sensors.ErrDeviceNotFound}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	err := svc.SendCommand(context.Background(), "dev-1", "usr-1", "light", []byte(`{"action":"set"}`))
 	if !errors.Is(err, sensors.ErrDeviceNotFound) {
 		t.Errorf("expected ErrDeviceNotFound, got %v", err)
@@ -73,11 +53,7 @@ func TestDeviceService_SendCommand_NotFound(t *testing.T) {
 }
 
 func TestDeviceService_SendCommand_InvalidAction(t *testing.T) {
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	err := svc.SendCommand(context.Background(), "dev-1", "usr-1", "light", []byte(`{"action":"delete"}`))
 	if !errors.Is(err, sensors.ErrInvalidCommand) {
 		t.Errorf("expected ErrInvalidCommand, got %v", err)
@@ -86,11 +62,7 @@ func TestDeviceService_SendCommand_InvalidAction(t *testing.T) {
 
 func TestDeviceService_SendCommand_PublishError(t *testing.T) {
 	publishErr := errors.New("broker unreachable")
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{err: publishErr},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{}, &stubHiveMQClient{}, &stubPublisher{err: publishErr}, discardLogger)
 	err := svc.SendCommand(context.Background(), "dev-1", "usr-1", "light", []byte(`{"action":"set"}`))
 	if !errors.Is(err, publishErr) {
 		t.Errorf("expected wrapped publishErr, got %v", err)
@@ -103,11 +75,7 @@ func TestDeviceService_List_HappyPath(t *testing.T) {
 	devices := []sensors.Device{
 		{ID: "dev-1", Name: "Tank", CreatedAt: time.Now()},
 	}
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{listDevices: devices},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{listDevices: devices}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	got, err := svc.List(context.Background(), "usr-1", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -121,11 +89,7 @@ func TestDeviceService_List_HappyPath(t *testing.T) {
 
 func TestDeviceService_Patch_HappyPath(t *testing.T) {
 	updated := sensors.Device{ID: "dev-1", Name: "Tank A", CreatedAt: time.Now()}
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{patchDevice: updated},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{patchDevice: updated}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	got, err := svc.Patch(context.Background(), "dev-1", "usr-1", "Tank A")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -136,11 +100,7 @@ func TestDeviceService_Patch_HappyPath(t *testing.T) {
 }
 
 func TestDeviceService_Patch_NotFound(t *testing.T) {
-	svc := &sensors.DeviceService{
-		Store:     &stubDeviceStore{patchErr: sensors.ErrDeviceNotFound},
-		HiveMQ:    &stubHiveMQClient{},
-		Publisher: &stubPublisher{},
-	}
+	svc := sensors.NewDeviceService(&stubDeviceStore{patchErr: sensors.ErrDeviceNotFound}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	_, err := svc.Patch(context.Background(), "dev-x", "usr-1", "Tank A")
 	if !errors.Is(err, sensors.ErrDeviceNotFound) {
 		t.Errorf("expected ErrDeviceNotFound, got %v", err)

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -35,7 +34,6 @@ func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	devices, err := h.Service.List(r.Context(), claims.UserID, status)
 	if err != nil {
-		log.Printf("list devices error: %v", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -69,8 +67,6 @@ func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("reading: device_id=%s bytes=%d", device.DeviceID, len(body))
-
 	if err := h.Service.Write(r.Context(), device, body); err != nil {
 		if errors.Is(err, ErrEmptyPayload) ||
 			errors.Is(err, ErrMissingBaseTime) ||
@@ -79,7 +75,6 @@ func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Is(err, ErrInfluxWrite) {
-			log.Printf("influx write error (device_id=%s): %v", device.DeviceID, err)
 			http.Error(w, "failed to persist reading", http.StatusInternalServerError)
 			return
 		}
@@ -160,7 +155,6 @@ func (h *ReadingsQueryHandler) List(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
-		log.Printf("query readings error (device_id=%s): %v", deviceID, err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -198,7 +192,6 @@ func (h *DeleteDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
-		log.Printf("delete device error (device_id=%s): %v", deviceID, err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -235,7 +228,6 @@ func (h *PatchDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
-		log.Printf("patch device error (device_id=%s): %v", deviceID, err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -266,7 +258,6 @@ func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	deviceID, code, err := h.Service.Provision(r.Context(), claims.UserID)
 	if err != nil {
-		log.Printf("get or create pending error (user_id=%s): %v", claims.UserID, err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -310,7 +301,6 @@ func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "provisioning code already used", http.StatusConflict)
 			return
 		}
-		log.Printf("activation error: %v", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -361,7 +351,6 @@ func (h *CommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ErrInvalidCommand.Error(), http.StatusBadRequest)
 			return
 		}
-		log.Printf("send command error (device_id=%s): %v", deviceID, err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -366,7 +366,7 @@ func TestPatchDeviceHandler(t *testing.T) {
 
 func TestProvisionHandler(t *testing.T) {
 	newProvSvc := func(store *stubProvisioningStore) *sensors.ProvisioningService {
-		return &sensors.ProvisioningService{Store: store, Logger: discardLogger}
+		return sensors.NewProvisioningService(store, discardLogger)
 	}
 
 	t.Run("returns 201 with code and device_id", func(t *testing.T) {
@@ -418,14 +418,7 @@ func TestProvisionHandler(t *testing.T) {
 
 func newActivateHandler(store *stubProvisioningStore, mq hivemq.Client, signer *stubSigner) *sensors.ActivateHandler {
 	return &sensors.ActivateHandler{
-		Service: &sensors.ActivationService{
-			Store:    store,
-			HiveMQ:   mq,
-			Signer:   signer,
-			MQTTHost: "broker.example.com",
-			MQTTPort: 8883,
-			Logger:   discardLogger,
-		},
+		Service: sensors.NewActivationService(store, mq, signer, "broker.example.com", 8883, discardLogger),
 	}
 }
 

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -366,7 +366,7 @@ func TestPatchDeviceHandler(t *testing.T) {
 
 func TestProvisionHandler(t *testing.T) {
 	newProvSvc := func(store *stubProvisioningStore) *sensors.ProvisioningService {
-		return &sensors.ProvisioningService{Store: store}
+		return &sensors.ProvisioningService{Store: store, Logger: discardLogger}
 	}
 
 	t.Run("returns 201 with code and device_id", func(t *testing.T) {
@@ -424,6 +424,7 @@ func newActivateHandler(store *stubProvisioningStore, mq hivemq.Client, signer *
 			Signer:   signer,
 			MQTTHost: "broker.example.com",
 			MQTTPort: 8883,
+			Logger:   discardLogger,
 		},
 	}
 }

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -44,11 +44,11 @@ func withChiParams(r *http.Request, params map[string]string) *http.Request {
 }
 
 func newReadingsService(writer *stubReadingWriter, querier *stubReadingQuerier, store *stubDeviceStore) *sensors.ReadingsService {
-	svc := &sensors.ReadingsService{Devices: store, Querier: querier}
+	var w sensors.ReadingWriter
 	if writer != nil {
-		svc.Writer = writer
+		w = writer
 	}
-	return svc
+	return sensors.NewReadingsService(store, querier, w, discardLogger)
 }
 
 // ── ReadingsHandler ───────────────────────────────────────────────────────────
@@ -246,7 +246,7 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 
 func TestDevicesHandler_List(t *testing.T) {
 	newSvc := func(store *stubDeviceStore) *sensors.DeviceService {
-		return &sensors.DeviceService{Store: store, HiveMQ: &stubHiveMQClient{}, Publisher: &stubPublisher{}}
+		return sensors.NewDeviceService(store, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	}
 
 	t.Run("returns devices for user", func(t *testing.T) {
@@ -300,7 +300,7 @@ func TestPatchDeviceHandler(t *testing.T) {
 	}
 
 	newPatchSvc := func(store *stubDeviceStore) *sensors.DeviceService {
-		return &sensors.DeviceService{Store: store, HiveMQ: &stubHiveMQClient{}, Publisher: &stubPublisher{}}
+		return sensors.NewDeviceService(store, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
 	}
 
 	t.Run("valid name returns 200 with updated device", func(t *testing.T) {
@@ -553,11 +553,7 @@ func TestActivateHandler(t *testing.T) {
 
 func newCommandHandler(store *stubDeviceStore, pub *stubPublisher) *sensors.CommandHandler {
 	return &sensors.CommandHandler{
-		Service: &sensors.DeviceService{
-			Store:     store,
-			HiveMQ:    &stubHiveMQClient{},
-			Publisher: pub,
-		},
+		Service: sensors.NewDeviceService(store, &stubHiveMQClient{}, pub, discardLogger),
 	}
 }
 
@@ -616,11 +612,7 @@ func TestCommandHandler(t *testing.T) {
 
 func newDeleteHandler(store *stubDeviceStore, mq *stubHiveMQClient) *sensors.DeleteDeviceHandler {
 	return &sensors.DeleteDeviceHandler{
-		Service: &sensors.DeviceService{
-			Store:     store,
-			HiveMQ:    mq,
-			Publisher: &stubPublisher{},
-		},
+		Service: sensors.NewDeviceService(store, mq, &stubPublisher{}, discardLogger),
 	}
 }
 

--- a/internal/sensors/provisioning_service.go
+++ b/internal/sensors/provisioning_service.go
@@ -7,16 +7,23 @@ import (
 
 // ProvisioningService orchestrates device provisioning from the user side.
 type ProvisioningService struct {
-	Store  ProvisioningStore
-	Logger *slog.Logger
+	store  ProvisioningStore
+	logger *slog.Logger
+}
+
+func NewProvisioningService(store ProvisioningStore, logger *slog.Logger) *ProvisioningService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ProvisioningService{store: store, logger: logger}
 }
 
 // Provision returns an existing pending provisioning code for the user or
 // creates a new one. The returned values are the device ID and the code.
 func (s *ProvisioningService) Provision(ctx context.Context, userID string) (deviceID, code string, err error) {
-	deviceID, code, err = s.Store.GetOrCreatePending(ctx, userID)
+	deviceID, code, err = s.store.GetOrCreatePending(ctx, userID)
 	if err != nil {
-		s.Logger.Error("provision device", "user_id", userID, "error", err)
+		s.logger.Error("provision device", "user_id", userID, "error", err)
 	}
 	return deviceID, code, err
 }

--- a/internal/sensors/provisioning_service.go
+++ b/internal/sensors/provisioning_service.go
@@ -1,14 +1,22 @@
 package sensors
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
 
 // ProvisioningService orchestrates device provisioning from the user side.
 type ProvisioningService struct {
-	Store ProvisioningStore
+	Store  ProvisioningStore
+	Logger *slog.Logger
 }
 
 // Provision returns an existing pending provisioning code for the user or
 // creates a new one. The returned values are the device ID and the code.
 func (s *ProvisioningService) Provision(ctx context.Context, userID string) (deviceID, code string, err error) {
-	return s.Store.GetOrCreatePending(ctx, userID)
+	deviceID, code, err = s.Store.GetOrCreatePending(ctx, userID)
+	if err != nil {
+		s.Logger.Error("provision device", "user_id", userID, "error", err)
+	}
+	return deviceID, code, err
 }

--- a/internal/sensors/provisioning_service_test.go
+++ b/internal/sensors/provisioning_service_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestProvisioningService_Provision_HappyPath(t *testing.T) {
 	svc := &sensors.ProvisioningService{
-		Store: &stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"},
+		Store:  &stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"},
+		Logger: discardLogger,
 	}
 	deviceID, code, err := svc.Provision(context.Background(), "usr-1")
 	if err != nil {
@@ -27,7 +28,8 @@ func TestProvisioningService_Provision_HappyPath(t *testing.T) {
 func TestProvisioningService_Provision_StoreError(t *testing.T) {
 	storeErr := errors.New("db down")
 	svc := &sensors.ProvisioningService{
-		Store: &stubProvisioningStore{getErr: storeErr},
+		Store:  &stubProvisioningStore{getErr: storeErr},
+		Logger: discardLogger,
 	}
 	_, _, err := svc.Provision(context.Background(), "usr-1")
 	if !errors.Is(err, storeErr) {

--- a/internal/sensors/provisioning_service_test.go
+++ b/internal/sensors/provisioning_service_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func TestProvisioningService_Provision_HappyPath(t *testing.T) {
-	svc := &sensors.ProvisioningService{
-		Store:  &stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"},
-		Logger: discardLogger,
-	}
+	svc := sensors.NewProvisioningService(&stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"}, discardLogger)
 	deviceID, code, err := svc.Provision(context.Background(), "usr-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -27,10 +24,7 @@ func TestProvisioningService_Provision_HappyPath(t *testing.T) {
 
 func TestProvisioningService_Provision_StoreError(t *testing.T) {
 	storeErr := errors.New("db down")
-	svc := &sensors.ProvisioningService{
-		Store:  &stubProvisioningStore{getErr: storeErr},
-		Logger: discardLogger,
-	}
+	svc := sensors.NewProvisioningService(&stubProvisioningStore{getErr: storeErr}, discardLogger)
 	_, _, err := svc.Provision(context.Background(), "usr-1")
 	if !errors.Is(err, storeErr) {
 		t.Errorf("expected wrapped storeErr, got %v", err)

--- a/internal/sensors/readings_service.go
+++ b/internal/sensors/readings_service.go
@@ -3,6 +3,7 @@ package sensors
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -11,6 +12,7 @@ type ReadingsService struct {
 	Devices DeviceStore
 	Querier ReadingQuerier
 	Writer  ReadingWriter
+	Logger  *slog.Logger
 }
 
 // Query verifies device ownership then fetches readings from InfluxDB.
@@ -35,6 +37,10 @@ func (s *ReadingsService) Write(ctx context.Context, device DeviceInfo, body []b
 		return err
 	}
 
+	if s.Logger != nil {
+		s.Logger.Info("reading received", "device_id", device.DeviceID, "bytes", len(body))
+	}
+
 	if s.Writer == nil {
 		return nil
 	}
@@ -49,6 +55,9 @@ func (s *ReadingsService) Write(ctx context.Context, device DeviceInfo, body []b
 		Timestamp:    time.Unix(reading.BaseTime, 0).UTC(),
 		Measurements: fields,
 	}); err != nil {
+		if s.Logger != nil {
+			s.Logger.Error("influx write", "device_id", device.DeviceID, "error", err)
+		}
 		return fmt.Errorf("%w: %w", ErrInfluxWrite, err)
 	}
 	return nil

--- a/internal/sensors/readings_service.go
+++ b/internal/sensors/readings_service.go
@@ -2,6 +2,7 @@ package sensors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -24,10 +25,14 @@ func NewReadingsService(devices DeviceStore, querier ReadingQuerier, writer Read
 // owned by userID.
 func (s *ReadingsService) Query(ctx context.Context, userID string, q ReadingQuery) ([]ReadingPoint, error) {
 	if _, err := s.devices.FindByIDAndUserID(ctx, q.DeviceID, userID); err != nil {
+		if !errors.Is(err, ErrDeviceNotFound) {
+			s.logger.Error("query readings: find device", "device_id", q.DeviceID, "error", err)
+		}
 		return nil, err
 	}
 	points, err := s.querier.QueryReadings(ctx, q)
 	if err != nil {
+		s.logger.Error("query readings", "device_id", q.DeviceID, "error", err)
 		return nil, fmt.Errorf("query readings: %w", err)
 	}
 	return points, nil

--- a/internal/sensors/readings_service.go
+++ b/internal/sensors/readings_service.go
@@ -17,6 +17,9 @@ type ReadingsService struct {
 }
 
 func NewReadingsService(devices DeviceStore, querier ReadingQuerier, writer ReadingWriter, logger *slog.Logger) *ReadingsService {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &ReadingsService{devices: devices, querier: querier, writer: writer, logger: logger}
 }
 

--- a/internal/sensors/readings_service.go
+++ b/internal/sensors/readings_service.go
@@ -9,20 +9,24 @@ import (
 
 // ReadingsService orchestrates sensor reading operations.
 type ReadingsService struct {
-	Devices DeviceStore
-	Querier ReadingQuerier
-	Writer  ReadingWriter
-	Logger  *slog.Logger
+	devices DeviceStore
+	querier ReadingQuerier
+	writer  ReadingWriter
+	logger  *slog.Logger
+}
+
+func NewReadingsService(devices DeviceStore, querier ReadingQuerier, writer ReadingWriter, logger *slog.Logger) *ReadingsService {
+	return &ReadingsService{devices: devices, querier: querier, writer: writer, logger: logger}
 }
 
 // Query verifies device ownership then fetches readings from InfluxDB.
 // Returns ErrDeviceNotFound unwrapped if the device does not exist or is not
 // owned by userID.
 func (s *ReadingsService) Query(ctx context.Context, userID string, q ReadingQuery) ([]ReadingPoint, error) {
-	if _, err := s.Devices.FindByIDAndUserID(ctx, q.DeviceID, userID); err != nil {
+	if _, err := s.devices.FindByIDAndUserID(ctx, q.DeviceID, userID); err != nil {
 		return nil, err
 	}
-	points, err := s.Querier.QueryReadings(ctx, q)
+	points, err := s.querier.QueryReadings(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("query readings: %w", err)
 	}
@@ -30,18 +34,16 @@ func (s *ReadingsService) Query(ctx context.Context, userID string, q ReadingQue
 }
 
 // Write parses a SenML payload and writes the reading to InfluxDB.
-// If Writer is nil the call is a no-op (InfluxDB not configured).
+// If writer is nil the call is a no-op (InfluxDB not configured).
 func (s *ReadingsService) Write(ctx context.Context, device DeviceInfo, body []byte) error {
 	reading, err := ParseSenML(body)
 	if err != nil {
 		return err
 	}
 
-	if s.Logger != nil {
-		s.Logger.Info("reading received", "device_id", device.DeviceID, "bytes", len(body))
-	}
+	s.logger.Info("reading received", "device_id", device.DeviceID, "bytes", len(body))
 
-	if s.Writer == nil {
+	if s.writer == nil {
 		return nil
 	}
 
@@ -49,15 +51,13 @@ func (s *ReadingsService) Write(ctx context.Context, device DeviceInfo, body []b
 	for _, m := range reading.Measurements {
 		fields[m.Name] = m.Value
 	}
-	if err := s.Writer.WriteReading(ctx, Reading{
+	if err := s.writer.WriteReading(ctx, Reading{
 		DeviceID:     device.DeviceID,
 		UserID:       device.UserID,
 		Timestamp:    time.Unix(reading.BaseTime, 0).UTC(),
 		Measurements: fields,
 	}); err != nil {
-		if s.Logger != nil {
-			s.Logger.Error("influx write", "device_id", device.DeviceID, "error", err)
-		}
+		s.logger.Error("influx write", "device_id", device.DeviceID, "error", err)
 		return fmt.Errorf("%w: %w", ErrInfluxWrite, err)
 	}
 	return nil

--- a/internal/sensors/readings_service_test.go
+++ b/internal/sensors/readings_service_test.go
@@ -3,19 +3,20 @@ package sensors_test
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 )
 
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
 func TestReadingsService_Query_HappyPath(t *testing.T) {
 	now := time.Now()
 	expected := []sensors.ReadingPoint{{Timestamp: now, Values: map[string]float64{"temperature": 25.5}}}
-	svc := &sensors.ReadingsService{
-		Devices: &stubDeviceStore{},
-		Querier: &stubReadingQuerier{points: expected},
-	}
+	svc := sensors.NewReadingsService(&stubDeviceStore{}, &stubReadingQuerier{points: expected}, nil, discardLogger)
 	points, err := svc.Query(context.Background(), "usr-1", sensors.ReadingQuery{DeviceID: "dev-1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -26,10 +27,7 @@ func TestReadingsService_Query_HappyPath(t *testing.T) {
 }
 
 func TestReadingsService_Query_DeviceNotOwned(t *testing.T) {
-	svc := &sensors.ReadingsService{
-		Devices: &stubDeviceStore{findErr: sensors.ErrDeviceNotFound},
-		Querier: &stubReadingQuerier{},
-	}
+	svc := sensors.NewReadingsService(&stubDeviceStore{findErr: sensors.ErrDeviceNotFound}, &stubReadingQuerier{}, nil, discardLogger)
 	_, err := svc.Query(context.Background(), "usr-1", sensors.ReadingQuery{DeviceID: "dev-1"})
 	if !errors.Is(err, sensors.ErrDeviceNotFound) {
 		t.Errorf("expected ErrDeviceNotFound, got %v", err)
@@ -38,10 +36,7 @@ func TestReadingsService_Query_DeviceNotOwned(t *testing.T) {
 
 func TestReadingsService_Query_QuerierError(t *testing.T) {
 	querierErr := errors.New("influx unavailable")
-	svc := &sensors.ReadingsService{
-		Devices: &stubDeviceStore{},
-		Querier: &stubReadingQuerier{err: querierErr},
-	}
+	svc := sensors.NewReadingsService(&stubDeviceStore{}, &stubReadingQuerier{err: querierErr}, nil, discardLogger)
 	_, err := svc.Query(context.Background(), "usr-1", sensors.ReadingQuery{DeviceID: "dev-1"})
 	if !errors.Is(err, querierErr) {
 		t.Errorf("expected wrapped querierErr, got %v", err)
@@ -53,9 +48,7 @@ func senMLPayload() []byte {
 }
 
 func TestReadingsService_Write_HappyPath(t *testing.T) {
-	svc := &sensors.ReadingsService{
-		Writer: &stubReadingWriter{},
-	}
+	svc := sensors.NewReadingsService(nil, nil, &stubReadingWriter{}, discardLogger)
 	device := sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}
 	if err := svc.Write(context.Background(), device, senMLPayload()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -63,7 +56,7 @@ func TestReadingsService_Write_HappyPath(t *testing.T) {
 }
 
 func TestReadingsService_Write_NilWriter(t *testing.T) {
-	svc := &sensors.ReadingsService{Writer: nil}
+	svc := sensors.NewReadingsService(nil, nil, nil, discardLogger)
 	device := sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}
 	if err := svc.Write(context.Background(), device, senMLPayload()); err != nil {
 		t.Fatalf("nil writer should be a no-op, got: %v", err)
@@ -71,7 +64,7 @@ func TestReadingsService_Write_NilWriter(t *testing.T) {
 }
 
 func TestReadingsService_Write_ParseError(t *testing.T) {
-	svc := &sensors.ReadingsService{Writer: &stubReadingWriter{}}
+	svc := sensors.NewReadingsService(nil, nil, &stubReadingWriter{}, discardLogger)
 	device := sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}
 	err := svc.Write(context.Background(), device, []byte(`not json`))
 	if err == nil {
@@ -80,7 +73,7 @@ func TestReadingsService_Write_ParseError(t *testing.T) {
 }
 
 func TestReadingsService_Write_EmptyPayload(t *testing.T) {
-	svc := &sensors.ReadingsService{Writer: &stubReadingWriter{}}
+	svc := sensors.NewReadingsService(nil, nil, &stubReadingWriter{}, discardLogger)
 	device := sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}
 	err := svc.Write(context.Background(), device, []byte(`[{"bn":"dev-1","bt":1700000000}]`))
 	if !errors.Is(err, sensors.ErrEmptyPayload) {
@@ -90,7 +83,7 @@ func TestReadingsService_Write_EmptyPayload(t *testing.T) {
 
 func TestReadingsService_Write_WriterError(t *testing.T) {
 	writeErr := errors.New("influx write failed")
-	svc := &sensors.ReadingsService{Writer: &stubReadingWriter{err: writeErr}}
+	svc := sensors.NewReadingsService(nil, nil, &stubReadingWriter{err: writeErr}, discardLogger)
 	device := sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}
 	err := svc.Write(context.Background(), device, senMLPayload())
 	if !errors.Is(err, sensors.ErrInfluxWrite) {

--- a/main.go
+++ b/main.go
@@ -192,15 +192,8 @@ func main() {
 	provisioningStore := sensors.NewProvisioningStore(db)
 	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
 	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
-	provisioningSvc := &sensors.ProvisioningService{Store: provisioningStore, Logger: logger}
-	activationSvc := &sensors.ActivationService{
-		Store:    provisioningStore,
-		HiveMQ:   hivemqClient,
-		Signer:   deviceSigner,
-		MQTTHost: cfg.HiveMQHost,
-		MQTTPort: cfg.HiveMQPort,
-		Logger:   logger,
-	}
+	provisioningSvc := sensors.NewProvisioningService(provisioningStore, logger)
+	activationSvc := sensors.NewActivationService(provisioningStore, hivemqClient, deviceSigner, cfg.HiveMQHost, cfg.HiveMQPort, logger)
 
 	// ── Router ────────────────────────────────────────────────────────────────
 	r := chi.NewRouter()
@@ -214,9 +207,9 @@ func main() {
 
 	r.Get("/health", platform.Health)
 	r.Get("/.well-known/jwks.json", (&jwtutil.JWKSHandler{Signer: jwkSigner}).ServeHTTP)
-	r.Post("/auth/verify", (&auth.VerifyHandler{Service: authSvc, Logger: logger}).ServeHTTP)
-	r.Post("/auth/refresh", (&auth.RefreshHandler{Service: authSvc, Logger: logger}).ServeHTTP)
-	r.Post("/auth/logout", (&auth.LogoutHandler{Service: authSvc}).ServeHTTP)
+	r.Post("/auth/verify", auth.NewVerifyHandler(authSvc, logger).ServeHTTP)
+	r.Post("/auth/refresh", auth.NewRefreshHandler(authSvc, logger).ServeHTTP)
+	r.Post("/auth/logout", auth.NewLogoutHandler(authSvc).ServeHTTP)
 	r.Post("/devices/activate", (&sensors.ActivateHandler{Service: activationSvc}).ServeHTTP)
 
 	r.Group(func(r chi.Router) {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -24,6 +24,7 @@ import (
 
 type config struct {
 	Port             string
+	LogFormat        string
 	JWTSecret        string
 	JWTTTLHours      int
 	GoogleClientID   string
@@ -63,6 +64,7 @@ func loadConfig() config {
 
 	return config{
 		Port:             port,
+		LogFormat:        os.Getenv("LOG_FORMAT"),
 		JWTSecret:        os.Getenv("JWT_SECRET"),
 		JWTTTLHours:      jwtTTLHours,
 		GoogleClientID:   os.Getenv("GOOGLE_CLIENT_ID"),
@@ -85,6 +87,15 @@ func loadConfig() config {
 
 func main() {
 	cfg := loadConfig()
+
+	var logHandler slog.Handler
+	if cfg.LogFormat == "json" {
+		logHandler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+	} else {
+		logHandler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+	}
+	logger := slog.New(logHandler)
+	slog.SetDefault(logger)
 
 	db, err := platform.Open()
 	if err != nil {
@@ -112,9 +123,9 @@ func main() {
 			os.Exit(1)
 		}
 		influxClient = c
-		log.Printf("InfluxDB client configured: host=%s database=%s", cfg.InfluxHost, cfg.InfluxDatabase)
+		logger.Info("influxdb configured", "host", cfg.InfluxHost, "database", cfg.InfluxDatabase)
 	} else {
-		log.Printf("warning: INFLUXDB3_HOST/TOKEN/DATABASE not set — readings will not be persisted to InfluxDB")
+		logger.Warn("influxdb not configured — readings will not be persisted")
 	}
 
 	// ── Auth ──────────────────────────────────────────────────────────────────
@@ -148,39 +159,39 @@ func main() {
 		}
 		jwkSigner = inner
 		deviceSigner = devicejwt.New(inner, cfg.IDPHost)
-		log.Printf("device JWT signer configured: kid=%s issuer=%s", cfg.DeviceJWTKID, cfg.IDPHost)
+		logger.Info("device jwt signer configured", "kid", cfg.DeviceJWTKID, "issuer", cfg.IDPHost)
 	} else {
-		log.Printf("warning: DEVICE_JWT_PRIVATE_KEY not set — token will not be issued at activation")
+		logger.Warn("device jwt not configured — tokens will not be issued at activation")
 	}
 
 	// ── HiveMQ ────────────────────────────────────────────────────────────────
 	hivemqClient := hivemq.Client(hivemq.NewNoOp())
 	if cfg.HiveMQBaseURL != "" {
 		hivemqClient = hivemq.NewAPIClient(cfg.HiveMQBaseURL, cfg.HiveMQAPIToken, cfg.HiveMQRoleID)
-		log.Printf("HiveMQ API client configured: base_url=%s", cfg.HiveMQBaseURL)
+		logger.Info("hivemq api configured", "base_url", cfg.HiveMQBaseURL)
 	} else {
-		log.Printf("warning: HIVEMQ_API_BASE_URL not set — MQTT credentials will not be provisioned at activation")
+		logger.Warn("hivemq api not configured — mqtt credentials will not be provisioned at activation")
 	}
 
 	// ── MQTT publisher ────────────────────────────────────────────────────────
 	var mqttPublisher sensors.CommandPublisher = mqtt.NewNoOpPublisher()
 	if cfg.HiveMQHost != "" {
-		p, err := mqtt.NewPublisher(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass)
+		p, err := mqtt.NewPublisher(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass, logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mqtt init: %v\n", err)
 			os.Exit(1)
 		}
 		mqttPublisher = p
-		log.Printf("MQTT publisher connected: host=%s", cfg.HiveMQHost)
+		logger.Info("mqtt publisher configured", "host", cfg.HiveMQHost)
 	} else {
-		log.Printf("warning: HIVEMQ_HOST not set — MQTT publishing disabled")
+		logger.Warn("mqtt publishing disabled — HIVEMQ_HOST not set")
 	}
 
 	// ── Stores & services ─────────────────────────────────────────────────────
 	deviceStore := sensors.NewDeviceStore(db)
 	provisioningStore := sensors.NewProvisioningStore(db)
-	readingsSvc := &sensors.ReadingsService{Devices: deviceStore, Querier: influxClient, Writer: influxClient}
-	deviceSvc := &sensors.DeviceService{Store: deviceStore, HiveMQ: hivemqClient, Publisher: mqttPublisher}
+	readingsSvc := &sensors.ReadingsService{Devices: deviceStore, Querier: influxClient, Writer: influxClient, Logger: logger}
+	deviceSvc := &sensors.DeviceService{Store: deviceStore, HiveMQ: hivemqClient, Publisher: mqttPublisher, Logger: logger}
 	provisioningSvc := &sensors.ProvisioningService{Store: provisioningStore}
 	activationSvc := &sensors.ActivationService{
 		Store:    provisioningStore,
@@ -192,6 +203,7 @@ func main() {
 
 	// ── Router ────────────────────────────────────────────────────────────────
 	r := chi.NewRouter()
+	r.Use(platform.RequestLogger(logger))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   cfg.CORSOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},

--- a/main.go
+++ b/main.go
@@ -190,8 +190,8 @@ func main() {
 	// ── Stores & services ─────────────────────────────────────────────────────
 	deviceStore := sensors.NewDeviceStore(db)
 	provisioningStore := sensors.NewProvisioningStore(db)
-	readingsSvc := &sensors.ReadingsService{Devices: deviceStore, Querier: influxClient, Writer: influxClient, Logger: logger}
-	deviceSvc := &sensors.DeviceService{Store: deviceStore, HiveMQ: hivemqClient, Publisher: mqttPublisher, Logger: logger}
+	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
+	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
 	provisioningSvc := &sensors.ProvisioningService{Store: provisioningStore}
 	activationSvc := &sensors.ActivationService{
 		Store:    provisioningStore,

--- a/main.go
+++ b/main.go
@@ -192,13 +192,14 @@ func main() {
 	provisioningStore := sensors.NewProvisioningStore(db)
 	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
 	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
-	provisioningSvc := &sensors.ProvisioningService{Store: provisioningStore}
+	provisioningSvc := &sensors.ProvisioningService{Store: provisioningStore, Logger: logger}
 	activationSvc := &sensors.ActivationService{
 		Store:    provisioningStore,
 		HiveMQ:   hivemqClient,
 		Signer:   deviceSigner,
 		MQTTHost: cfg.HiveMQHost,
 		MQTTPort: cfg.HiveMQPort,
+		Logger:   logger,
 	}
 
 	// ── Router ────────────────────────────────────────────────────────────────
@@ -213,8 +214,8 @@ func main() {
 
 	r.Get("/health", platform.Health)
 	r.Get("/.well-known/jwks.json", (&jwtutil.JWKSHandler{Signer: jwkSigner}).ServeHTTP)
-	r.Post("/auth/verify", (&auth.VerifyHandler{Service: authSvc}).ServeHTTP)
-	r.Post("/auth/refresh", (&auth.RefreshHandler{Service: authSvc}).ServeHTTP)
+	r.Post("/auth/verify", (&auth.VerifyHandler{Service: authSvc, Logger: logger}).ServeHTTP)
+	r.Post("/auth/refresh", (&auth.RefreshHandler{Service: authSvc, Logger: logger}).ServeHTTP)
 	r.Post("/auth/logout", (&auth.LogoutHandler{Service: authSvc}).ServeHTTP)
 	r.Post("/devices/activate", (&sensors.ActivateHandler{Service: activationSvc}).ServeHTTP)
 


### PR DESCRIPTION
## Summary

- Replaces all `log.Printf` calls with `log/slog` (stdlib, zero new deps)
- Adds `platform.RequestLogger` middleware — logs method, path, status, duration_ms for every request (Error level for 5xx)
- Auth failures in `DeviceAuthenticator` and `SessionAuthenticator` now log at Warn with structured fields
- `*slog.Logger` injected via struct fields into `ReadingsService`, `DeviceService`, and `mqtt.Publisher` — no package-level logger
- `LOG_FORMAT=json` → JSON handler (production/Railway); text handler otherwise (development)
- Updates `CLAUDE.md` with logging conventions

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/sensors/... ./internal/platform/...` passes
- [ ] `make dev` shows human-readable text logs
- [ ] Setting `LOG_FORMAT=json` produces parseable JSON output

Closes #10