### PR TITLE
feat: decouple provisioning code from device row

### DIFF
--- a/db/migrations/012_restructure_provisioning_codes.down.sql
+++ b/db/migrations/012_restructure_provisioning_codes.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE provisioning_codes ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE provisioning_codes DROP COLUMN user_id;
+ALTER TABLE provisioning_codes ALTER COLUMN device_id SET NOT NULL;
+ALTER TABLE provisioning_codes ADD CONSTRAINT provisioning_codes_device_id_fkey FOREIGN KEY (device_id) REFERENCES devices(id);

--- a/db/migrations/012_restructure_provisioning_codes.up.sql
+++ b/db/migrations/012_restructure_provisioning_codes.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE provisioning_codes ALTER COLUMN device_id DROP NOT NULL;
+ALTER TABLE provisioning_codes DROP CONSTRAINT provisioning_codes_device_id_fkey;
+ALTER TABLE provisioning_codes ADD COLUMN user_id UUID REFERENCES users(id);
+UPDATE provisioning_codes pc SET user_id = d.user_id FROM devices d WHERE d.id = pc.device_id;
+ALTER TABLE provisioning_codes ALTER COLUMN user_id SET NOT NULL;

--- a/db/migrations/013_drop_device_status.down.sql
+++ b/db/migrations/013_drop_device_status.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices ADD COLUMN status TEXT NOT NULL DEFAULT 'pending';

--- a/db/migrations/013_drop_device_status.up.sql
+++ b/db/migrations/013_drop_device_status.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN status;

--- a/internal/sensors/device_service.go
+++ b/internal/sensors/device_service.go
@@ -46,9 +46,9 @@ func (s *DeviceService) Delete(ctx context.Context, deviceID, userID string) err
 	return nil
 }
 
-// List returns all devices belonging to userID, optionally filtered by status.
-func (s *DeviceService) List(ctx context.Context, userID, status string) ([]Device, error) {
-	devices, err := s.store.ListByUserID(ctx, userID, status)
+// List returns all devices belonging to userID.
+func (s *DeviceService) List(ctx context.Context, userID string) ([]Device, error) {
+	devices, err := s.store.ListByUserID(ctx, userID)
 	if err != nil {
 		s.logger.Error("list devices", "user_id", userID, "error", err)
 	}

--- a/internal/sensors/device_service_test.go
+++ b/internal/sensors/device_service_test.go
@@ -76,7 +76,7 @@ func TestDeviceService_List_HappyPath(t *testing.T) {
 		{ID: "dev-1", Name: "Tank", CreatedAt: time.Now()},
 	}
 	svc := sensors.NewDeviceService(&stubDeviceStore{listDevices: devices}, &stubHiveMQClient{}, &stubPublisher{}, discardLogger)
-	got, err := svc.List(context.Background(), "usr-1", "")
+	got, err := svc.List(context.Background(), "usr-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -31,8 +31,7 @@ func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	status := r.URL.Query().Get("status")
-	devices, err := h.Service.List(r.Context(), claims.UserID, status)
+	devices, err := h.Service.List(r.Context(), claims.UserID)
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -245,8 +245,7 @@ type ProvisionHandler struct {
 }
 
 type provisionResponse struct {
-	Code     string `json:"code"`
-	DeviceID string `json:"device_id"`
+	Code string `json:"code"`
 }
 
 func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -256,14 +255,14 @@ func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deviceID, code, err := h.Service.Provision(r.Context(), claims.UserID)
+	code, err := h.Service.Provision(r.Context(), claims.UserID)
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, provisionResponse{Code: code, DeviceID: deviceID})
+	render.JSON(w, r, provisionResponse{Code: code})
 }
 
 // ActivateHandler handles POST /devices/activate (no auth — called by the device).

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -369,9 +369,9 @@ func TestProvisionHandler(t *testing.T) {
 		return sensors.NewProvisioningService(store, discardLogger)
 	}
 
-	t.Run("returns 201 with code and device_id", func(t *testing.T) {
+	t.Run("returns 201 with code", func(t *testing.T) {
 		h := &sensors.ProvisionHandler{
-			Service: newProvSvc(&stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"}),
+			Service: newProvSvc(&stubProvisioningStore{code: "ABC123"}),
 		}
 		req := withClaims(httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil), "user-uuid")
 		rec := httptest.NewRecorder()
@@ -386,8 +386,8 @@ func TestProvisionHandler(t *testing.T) {
 		if body["code"] != "ABC123" {
 			t.Errorf("expected code ABC123, got %s", body["code"])
 		}
-		if body["device_id"] != "dev-uuid" {
-			t.Errorf("expected device_id dev-uuid, got %s", body["device_id"])
+		if _, ok := body["device_id"]; ok {
+			t.Error("device_id should not be present in provision response")
 		}
 	})
 

--- a/internal/sensors/provisioning_service.go
+++ b/internal/sensors/provisioning_service.go
@@ -18,12 +18,12 @@ func NewProvisioningService(store ProvisioningStore, logger *slog.Logger) *Provi
 	return &ProvisioningService{store: store, logger: logger}
 }
 
-// Provision returns an existing pending provisioning code for the user or
-// creates a new one. The returned values are the device ID and the code.
-func (s *ProvisioningService) Provision(ctx context.Context, userID string) (deviceID, code string, err error) {
-	deviceID, code, err = s.store.GetOrCreatePending(ctx, userID)
+// Provision returns an existing unused provisioning code for the user or
+// creates a new one.
+func (s *ProvisioningService) Provision(ctx context.Context, userID string) (code string, err error) {
+	code, err = s.store.GetOrCreateCode(ctx, userID)
 	if err != nil {
-		s.logger.Error("provision device", "user_id", userID, "error", err)
+		s.logger.Error("provision: get or create code", "user_id", userID, "error", err)
 	}
-	return deviceID, code, err
+	return code, err
 }

--- a/internal/sensors/provisioning_service_test.go
+++ b/internal/sensors/provisioning_service_test.go
@@ -9,13 +9,10 @@ import (
 )
 
 func TestProvisioningService_Provision_HappyPath(t *testing.T) {
-	svc := sensors.NewProvisioningService(&stubProvisioningStore{deviceID: "dev-uuid", code: "ABC123"}, discardLogger)
-	deviceID, code, err := svc.Provision(context.Background(), "usr-1")
+	svc := sensors.NewProvisioningService(&stubProvisioningStore{code: "ABC123"}, discardLogger)
+	code, err := svc.Provision(context.Background(), "usr-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if deviceID != "dev-uuid" {
-		t.Errorf("device_id: got %q want %q", deviceID, "dev-uuid")
 	}
 	if code != "ABC123" {
 		t.Errorf("code: got %q want %q", code, "ABC123")
@@ -25,7 +22,7 @@ func TestProvisioningService_Provision_HappyPath(t *testing.T) {
 func TestProvisioningService_Provision_StoreError(t *testing.T) {
 	storeErr := errors.New("db down")
 	svc := sensors.NewProvisioningService(&stubProvisioningStore{getErr: storeErr}, discardLogger)
-	_, _, err := svc.Provision(context.Background(), "usr-1")
+	_, err := svc.Provision(context.Background(), "usr-1")
 	if !errors.Is(err, storeErr) {
 		t.Errorf("expected wrapped storeErr, got %v", err)
 	}

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -12,9 +12,7 @@ type Device struct {
 }
 
 type DeviceStore interface {
-	// ListByUserID returns all devices owned by userID. The status parameter is accepted
-	// for backwards compatibility but is ignored — all rows in devices are active by definition.
-	ListByUserID(ctx context.Context, userID, status string) ([]Device, error)
+	ListByUserID(ctx context.Context, userID string) ([]Device, error)
 	FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error)
 	// PatchDevice updates the name of the device owned by userID.
 	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -12,8 +12,8 @@ type Device struct {
 }
 
 type DeviceStore interface {
-	// ListByUserID returns devices owned by userID. If status is non-empty, only
-	// devices with that status are returned.
+	// ListByUserID returns all devices owned by userID. The status parameter is accepted
+	// for backwards compatibility but is ignored — all rows in devices are active by definition.
 	ListByUserID(ctx context.Context, userID, status string) ([]Device, error)
 	FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error)
 	// PatchDevice updates the name of the device owned by userID.
@@ -25,12 +25,11 @@ type DeviceStore interface {
 }
 
 type ProvisioningStore interface {
-	// GetOrCreatePending returns the existing pending device + code for the user,
-	// or creates both atomically if none exists.
-	GetOrCreatePending(ctx context.Context, userID string) (deviceID, code string, err error)
-	// ClaimCode marks the code as used and returns the associated device ID and user ID.
+	// GetOrCreateCode returns the existing unused code for the user, or creates one.
+	GetOrCreateCode(ctx context.Context, userID string) (code string, err error)
+	// ClaimCode marks the code used, creates a new device row, and returns the device ID and user ID.
 	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
 	ClaimCode(ctx context.Context, code string) (deviceID, userID string, err error)
-	// Activate sets the device status to active and stores MQTT credentials.
+	// Activate stores MQTT credentials on the device row.
 	Activate(ctx context.Context, deviceID, mqttUsername, mqttPassword string) error
 }

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -15,7 +15,7 @@ func NewDeviceStore(db *sql.DB) DeviceStore {
 	return &postgresDeviceStore{db: db}
 }
 
-func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID, _ string) ([]Device, error) {
+func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID string) ([]Device, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, COALESCE(name, ''), created_at
 		FROM devices

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -15,26 +15,13 @@ func NewDeviceStore(db *sql.DB) DeviceStore {
 	return &postgresDeviceStore{db: db}
 }
 
-func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID, status string) ([]Device, error) {
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	if status != "" {
-		rows, err = s.db.QueryContext(ctx, `
-			SELECT id, COALESCE(name, ''), created_at
-			FROM devices
-			WHERE user_id = $1 AND status = $2 AND deleted_at IS NULL
-			ORDER BY created_at DESC
-		`, userID, status)
-	} else {
-		rows, err = s.db.QueryContext(ctx, `
-			SELECT id, COALESCE(name, ''), created_at
-			FROM devices
-			WHERE user_id = $1 AND deleted_at IS NULL
-			ORDER BY created_at DESC
-		`, userID)
-	}
+func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID, _ string) ([]Device, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, COALESCE(name, ''), created_at
+		FROM devices
+		WHERE user_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at DESC
+	`, userID)
 	if err != nil {
 		return nil, fmt.Errorf("list devices: %w", err)
 	}

--- a/internal/sensors/store_provisioning_integration_test.go
+++ b/internal/sensors/store_provisioning_integration_test.go
@@ -134,7 +134,7 @@ func TestActivate_integration(t *testing.T) {
 			t.Fatalf("activate: %v", err)
 		}
 
-		devices, err := deviceStore.ListByUserID(ctx, userID, "")
+		devices, err := deviceStore.ListByUserID(ctx, userID)
 		if err != nil {
 			t.Fatalf("list devices: %v", err)
 		}

--- a/internal/sensors/store_provisioning_integration_test.go
+++ b/internal/sensors/store_provisioning_integration_test.go
@@ -11,26 +11,23 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/testutil"
 )
 
-func TestGetOrCreatePending_integration(t *testing.T) {
+func TestGetOrCreateCode_integration(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	store := sensors.NewProvisioningStore(db)
 	ctx := context.Background()
 	userID := platform.SeedUserID()
 
-	t.Run("creates a pending device and code on first call", func(t *testing.T) {
-		deviceID, code, err := store.GetOrCreatePending(ctx, userID)
+	t.Run("creates a code on first call", func(t *testing.T) {
+		code, err := store.GetOrCreateCode(ctx, userID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
-		}
-		if deviceID == "" {
-			t.Error("expected non-empty device_id")
 		}
 		if len(code) != 6 {
 			t.Errorf("expected 6-char code, got %q", code)
 		}
 	})
 
-	t.Run("second call returns same device and code", func(t *testing.T) {
+	t.Run("second call returns same code", func(t *testing.T) {
 		var uid string
 		if err := db.QueryRowContext(ctx, `
 			INSERT INTO users (email, provider, provider_sub)
@@ -40,16 +37,13 @@ func TestGetOrCreatePending_integration(t *testing.T) {
 			t.Fatalf("insert user: %v", err)
 		}
 
-		deviceID1, code1, err := store.GetOrCreatePending(ctx, uid)
+		code1, err := store.GetOrCreateCode(ctx, uid)
 		if err != nil {
 			t.Fatalf("first call: %v", err)
 		}
-		deviceID2, code2, err := store.GetOrCreatePending(ctx, uid)
+		code2, err := store.GetOrCreateCode(ctx, uid)
 		if err != nil {
 			t.Fatalf("second call: %v", err)
-		}
-		if deviceID1 != deviceID2 {
-			t.Errorf("expected same device_id, got %s and %s", deviceID1, deviceID2)
 		}
 		if code1 != code2 {
 			t.Errorf("expected same code, got %s and %s", code1, code2)
@@ -75,25 +69,28 @@ func TestClaimCode_integration(t *testing.T) {
 		return uid
 	}
 
-	t.Run("claims code and returns device_id", func(t *testing.T) {
+	t.Run("claims code and creates device row", func(t *testing.T) {
 		userID := insertUser(t, "a")
-		deviceID, code, err := store.GetOrCreatePending(ctx, userID)
+		code, err := store.GetOrCreateCode(ctx, userID)
 		if err != nil {
 			t.Fatalf("setup: %v", err)
 		}
 
-		claimedDeviceID, _, err := store.ClaimCode(ctx, code)
+		deviceID, claimedUserID, err := store.ClaimCode(ctx, code)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if claimedDeviceID != deviceID {
-			t.Errorf("expected device_id %s, got %s", deviceID, claimedDeviceID)
+		if deviceID == "" {
+			t.Error("expected non-empty device_id")
+		}
+		if claimedUserID != userID {
+			t.Errorf("expected user_id %s, got %s", userID, claimedUserID)
 		}
 	})
 
 	t.Run("claiming same code twice returns ErrCodeAlreadyUsed", func(t *testing.T) {
 		userID := insertUser(t, "b")
-		_, code, err := store.GetOrCreatePending(ctx, userID)
+		code, err := store.GetOrCreateCode(ctx, userID)
 		if err != nil {
 			t.Fatalf("setup: %v", err)
 		}
@@ -123,12 +120,13 @@ func TestActivate_integration(t *testing.T) {
 	ctx := context.Background()
 	userID := platform.SeedUserID()
 
-	t.Run("sets device status to active", func(t *testing.T) {
-		deviceID, code, err := store.GetOrCreatePending(ctx, userID)
+	t.Run("sets mqtt credentials on device", func(t *testing.T) {
+		code, err := store.GetOrCreateCode(ctx, userID)
 		if err != nil {
 			t.Fatalf("setup provision: %v", err)
 		}
-		if _, _, err := store.ClaimCode(ctx, code); err != nil {
+		deviceID, _, err := store.ClaimCode(ctx, code)
+		if err != nil {
 			t.Fatalf("setup claim: %v", err)
 		}
 
@@ -136,9 +134,9 @@ func TestActivate_integration(t *testing.T) {
 			t.Fatalf("activate: %v", err)
 		}
 
-		devices, err := deviceStore.ListByUserID(ctx, userID, "active")
+		devices, err := deviceStore.ListByUserID(ctx, userID, "")
 		if err != nil {
-			t.Fatalf("list active: %v", err)
+			t.Fatalf("list devices: %v", err)
 		}
 		found := false
 		for _, d := range devices {
@@ -148,56 +146,35 @@ func TestActivate_integration(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("expected device %s to be active", deviceID)
+			t.Errorf("expected device %s to appear in list", deviceID)
 		}
 	})
 
-	t.Run("active device appears in ListByUserID with status filter", func(t *testing.T) {
+	t.Run("new code can be created after claim", func(t *testing.T) {
 		var uid string
 		if err := db.QueryRowContext(ctx, `
 			INSERT INTO users (email, provider, provider_sub)
-			VALUES ('activate-list@test.com', 'test', 'sub-activate-list')
+			VALUES ('activate-new@test.com', 'test', 'sub-activate-new')
 			RETURNING id`,
 		).Scan(&uid); err != nil {
 			t.Fatalf("insert user: %v", err)
 		}
 
-		deviceID, code, err := store.GetOrCreatePending(ctx, uid)
+		code1, err := store.GetOrCreateCode(ctx, uid)
 		if err != nil {
 			t.Fatalf("setup provision: %v", err)
 		}
-		if _, _, err := store.ClaimCode(ctx, code); err != nil {
+		if _, _, err := store.ClaimCode(ctx, code1); err != nil {
 			t.Fatalf("setup claim: %v", err)
 		}
-		if err := store.Activate(ctx, deviceID, "mqtt-user", "mqtt-pass"); err != nil {
-			t.Fatalf("activate: %v", err)
-		}
 
-		active, err := deviceStore.ListByUserID(ctx, uid, "active")
+		// after claim, user can get a fresh code
+		code2, err := store.GetOrCreateCode(ctx, uid)
 		if err != nil {
-			t.Fatalf("list active: %v", err)
+			t.Fatalf("second provision: %v", err)
 		}
-		found := false
-		for _, d := range active {
-			if d.ID == deviceID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected activated device %s in active list", deviceID)
-		}
-
-		_, _, err = store.GetOrCreatePending(ctx, uid)
-		if err != nil {
-			t.Fatalf("create pending: %v", err)
-		}
-		active2, err := deviceStore.ListByUserID(ctx, uid, "active")
-		if err != nil {
-			t.Fatalf("list active after pending: %v", err)
-		}
-		if len(active2) != len(active) {
-			t.Errorf("pending device leaked into active list (before: %d, after: %d)", len(active), len(active2))
+		if code2 == code1 {
+			t.Error("expected a new code after the first was claimed")
 		}
 	})
 }

--- a/internal/sensors/store_provisioning_postgres.go
+++ b/internal/sensors/store_provisioning_postgres.go
@@ -18,61 +18,51 @@ func NewProvisioningStore(db *sql.DB) ProvisioningStore {
 	return &postgresProvisioningStore{db: db}
 }
 
-func (s *postgresProvisioningStore) GetOrCreatePending(ctx context.Context, userID string) (string, string, error) {
+func (s *postgresProvisioningStore) GetOrCreateCode(ctx context.Context, userID string) (string, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("begin tx: %w", err)
+		return "", fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
-	var deviceID, code string
+	var code string
 	err = tx.QueryRowContext(ctx, `
-		SELECT d.id, pc.code
-		FROM devices d
-		JOIN provisioning_codes pc ON pc.device_id = d.id
-		WHERE d.user_id = $1 AND d.status = 'pending'
+		SELECT code
+		FROM provisioning_codes
+		WHERE user_id = $1 AND used_at IS NULL
 		LIMIT 1
 		FOR UPDATE
-	`, userID).Scan(&deviceID, &code)
+	`, userID).Scan(&code)
 
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", "", fmt.Errorf("lookup pending device: %w", err)
+		return "", fmt.Errorf("lookup code: %w", err)
 	}
 
 	if err == nil {
-		// existing pending device — return as-is
 		if err := tx.Commit(); err != nil {
-			return "", "", fmt.Errorf("commit tx: %w", err)
+			return "", fmt.Errorf("commit tx: %w", err)
 		}
-		return deviceID, code, nil
-	}
-
-	// no pending device — create one
-	if err := tx.QueryRowContext(ctx, `
-		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
-	`, userID).Scan(&deviceID); err != nil {
-		return "", "", fmt.Errorf("insert device: %w", err)
+		return code, nil
 	}
 
 	code, err = generateCode()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO provisioning_codes (code, device_id) VALUES ($1, $2)
-	`, code, deviceID); err != nil {
-		return "", "", fmt.Errorf("insert provisioning code: %w", err)
+		INSERT INTO provisioning_codes (code, user_id) VALUES ($1, $2)
+	`, code, userID); err != nil {
+		return "", fmt.Errorf("insert provisioning code: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return "", "", fmt.Errorf("commit tx: %w", err)
+		return "", fmt.Errorf("commit tx: %w", err)
 	}
-	return deviceID, code, nil
+	return code, nil
 }
 
 func (s *postgresProvisioningStore) ClaimCode(ctx context.Context, code string) (string, string, error) {
-	// check existence and used state before attempting update
 	var usedAt sql.NullTime
 	err := s.db.QueryRowContext(ctx, `
 		SELECT used_at FROM provisioning_codes WHERE code = $1
@@ -87,26 +77,43 @@ func (s *postgresProvisioningStore) ClaimCode(ctx context.Context, code string) 
 		return "", "", ErrCodeAlreadyUsed
 	}
 
-	var deviceID, userID string
-	err = s.db.QueryRowContext(ctx, `
-		UPDATE provisioning_codes
-		SET used_at = now()
-		WHERE code = $1 AND used_at IS NULL
-		RETURNING device_id, (SELECT user_id FROM devices WHERE id = device_id)
-	`, code).Scan(&deviceID, &userID)
-	if errors.Is(err, sql.ErrNoRows) {
-		// raced — another request claimed it between our SELECT and UPDATE
-		return "", "", ErrCodeAlreadyUsed
-	}
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return "", "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var userID string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT user_id FROM provisioning_codes WHERE code = $1 AND used_at IS NULL FOR UPDATE
+	`, code).Scan(&userID); errors.Is(err, sql.ErrNoRows) {
+		return "", "", ErrCodeAlreadyUsed
+	} else if err != nil {
+		return "", "", fmt.Errorf("lock code: %w", err)
+	}
+
+	var deviceID string
+	if err := tx.QueryRowContext(ctx, `
+		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
+	`, userID).Scan(&deviceID); err != nil {
+		return "", "", fmt.Errorf("insert device: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE provisioning_codes SET used_at = now(), device_id = $2 WHERE code = $1
+	`, code, deviceID); err != nil {
 		return "", "", fmt.Errorf("claim code: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", "", fmt.Errorf("commit tx: %w", err)
 	}
 	return deviceID, userID, nil
 }
 
 func (s *postgresProvisioningStore) Activate(ctx context.Context, deviceID, mqttUsername, mqttPassword string) error {
 	_, err := s.db.ExecContext(ctx, `
-		UPDATE devices SET status = 'active', mqtt_username = $2, mqtt_password = $3 WHERE id = $1
+		UPDATE devices SET mqtt_username = $2, mqtt_password = $3 WHERE id = $1
 	`, deviceID, mqttUsername, mqttPassword)
 	return err
 }
@@ -122,4 +129,3 @@ func generateCode() (string, error) {
 	}
 	return string(code), nil
 }
-

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -32,7 +32,7 @@ func TestListByUserID_integration(t *testing.T) {
 			t.Fatalf("setup device 2: %v", err)
 		}
 
-		devices, err := store.ListByUserID(ctx, userID, "")
+		devices, err := store.ListByUserID(ctx, userID)
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}
@@ -60,7 +60,7 @@ func TestListByUserID_integration(t *testing.T) {
 			t.Fatalf("insert user: %v", err)
 		}
 
-		devices, err := store.ListByUserID(ctx, newUserID, "")
+		devices, err := store.ListByUserID(ctx, newUserID)
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -18,9 +18,13 @@ func TestListByUserID_integration(t *testing.T) {
 	userID := platform.SeedUserID()
 
 	t.Run("returns devices for the user ordered by created_at DESC", func(t *testing.T) {
-		d1, _, err := provisioning.GetOrCreatePending(ctx, userID)
+		code, err := provisioning.GetOrCreateCode(ctx, userID)
 		if err != nil {
-			t.Fatalf("setup device 1: %v", err)
+			t.Fatalf("setup code: %v", err)
+		}
+		d1, _, err := provisioning.ClaimCode(ctx, code)
+		if err != nil {
+			t.Fatalf("setup claim: %v", err)
 		}
 		// create a second device via direct insert so we have two distinct ones
 		var d2 string

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -21,7 +21,7 @@ type stubDeviceStore struct {
 	deleteErr      error
 }
 
-func (s *stubDeviceStore) ListByUserID(_ context.Context, _, _ string) ([]sensors.Device, error) {
+func (s *stubDeviceStore) ListByUserID(_ context.Context, _ string) ([]sensors.Device, error) {
 	return s.listDevices, s.listErr
 }
 func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sensors.Device, error) {

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -37,9 +37,8 @@ func (s *stubDeviceStore) DeleteDevice(_ context.Context, _, _ string) (string, 
 // ── ProvisioningStore ─────────────────────────────────────────────────────────
 
 type stubProvisioningStore struct {
-	deviceID string
-	code     string
-	getErr   error
+	code   string
+	getErr error
 
 	claimedDeviceID string
 	claimUserID     string
@@ -48,8 +47,8 @@ type stubProvisioningStore struct {
 	activateErr error
 }
 
-func (s *stubProvisioningStore) GetOrCreatePending(_ context.Context, _ string) (string, string, error) {
-	return s.deviceID, s.code, s.getErr
+func (s *stubProvisioningStore) GetOrCreateCode(_ context.Context, _ string) (string, error) {
+	return s.code, s.getErr
 }
 func (s *stubProvisioningStore) ClaimCode(_ context.Context, _ string) (string, string, error) {
 	uid := s.claimUserID


### PR DESCRIPTION
## Summary

- Provisioning codes are now standalone invites owned by a user (`user_id` added to `provisioning_codes`; `device_id` becomes nullable)
- Device rows are created atomically inside `ClaimCode`, not at provision time
- `status` column dropped from `devices` — all rows are active by definition
- `ProvisionHandler` response no longer includes `device_id`
- `GetOrCreateCode` replaces `GetOrCreatePending`; `Activate` drops the `status = 'active'` write

## Migrations

- `012_restructure_provisioning_codes`: makes `device_id` nullable, adds `user_id`, backfills from existing FK
- `013_drop_device_status`: drops `status` column from `devices`

## Test plan

- [x] Unit tests pass (`go test ./internal/sensors/ -run "^Test[^_]"`)
- [x] Integration tests pass (`go test ./internal/sensors/ -run "_integration"`)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)