### PR TITLE
feat: migrate session JWTs from HS256 to RS256

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -85,7 +85,7 @@ Implemented by `oidcService`. Configured via `auth.NewOIDCService(ctx, OIDCConfi
 
 **`VerifyAndUpsert`** — verifies the ID token with the OIDC provider (go-oidc library), upserts the user row, then calls `UserEventHandler.OnUserVerified` (implemented by `account.AccountEventHandler`, which upserts the account row with name/email from ID token claims).
 
-**Session JWT** — HS256, signed with `JWT_SECRET`. Claims: `sub` (user UUID), `iat`, `exp`. Default TTL: 24h (configurable via `JWT_TTL_HOURS`).
+**Session JWT** — RS256, signed with a dedicated RSA private key (`SESSION_JWT_PRIVATE_KEY`). Claims: `sub` (user UUID), `iat`, `exp`. Default TTL: 24h (configurable via `JWT_TTL_HOURS`). The corresponding public key is served at `GET /.well-known/jwks.json` alongside the device JWT public key.
 
 **Refresh tokens** — 64-char raw hex token; stored as SHA-256 hash in `refresh_tokens`. TTL: 30 days. Rotation: every `RotateRefreshToken` call revokes the old token and issues a new one.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,7 +30,8 @@ PORT=9090 make dev
 | `INFLUXDB3_TOKEN` | — | InfluxDB admin token |
 | `INFLUXDB3_DATABASE` | — | InfluxDB database name |
 | `GOOGLE_CLIENT_ID` | — | Google OAuth client ID (OIDC verification) |
-| `JWT_SECRET` | — | Secret for signing HS256 session JWTs |
+| `SESSION_JWT_PRIVATE_KEY` | — | PEM-encoded RSA private key for signing RS256 session JWTs (`\n`-escaped for env) |
+| `SESSION_JWT_KID` | — | Key ID included in the JWT header and JWKS entry (e.g. `session-v1`) |
 | `JWT_TTL_HOURS` | `24` | Session JWT validity in hours |
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:3001` | Comma-separated list of allowed CORS origins |
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -11,6 +11,8 @@ import (
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
 )
 
 var ErrUnsupportedProvider = errors.New("unsupported provider")
@@ -23,7 +25,7 @@ type OIDCConfig struct {
 	Store        UserStore
 	RefreshStore RefreshTokenStore
 	EventHandler UserEventHandler
-	JWTSecret    string
+	Signer       jwtutil.Signer
 	JWTTTL       time.Duration
 }
 
@@ -41,7 +43,7 @@ type oidcService struct {
 	store        UserStore
 	refreshStore RefreshTokenStore
 	eventHandler UserEventHandler
-	jwtSecret    []byte
+	signer       jwtutil.Signer
 	jwtTTL       time.Duration
 }
 
@@ -66,7 +68,7 @@ func NewOIDCService(ctx context.Context, cfg OIDCConfig) (AuthService, error) {
 		store:        cfg.Store,
 		refreshStore: cfg.RefreshStore,
 		eventHandler: cfg.EventHandler,
-		jwtSecret:    []byte(cfg.JWTSecret),
+		signer:       cfg.Signer,
 		jwtTTL:       cfg.JWTTTL,
 	}, nil
 }
@@ -120,12 +122,11 @@ func (s *oidcService) VerifyAndUpsert(ctx context.Context, provider, rawIDToken 
 
 func (s *oidcService) IssueSessionJWT(userID string) (string, error) {
 	now := time.Now()
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+	signed, err := s.signer.Sign(map[string]any{
 		"sub": userID,
 		"iat": now.Unix(),
 		"exp": now.Add(s.jwtTTL).Unix(),
 	})
-	signed, err := token.SignedString(s.jwtSecret)
 	if err != nil {
 		return "", fmt.Errorf("sign jwt: %w", err)
 	}
@@ -134,11 +135,11 @@ func (s *oidcService) IssueSessionJWT(userID string) (string, error) {
 
 func (s *oidcService) ValidateSessionJWT(raw string) (string, error) {
 	token, err := jwt.Parse(raw, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
-		return s.jwtSecret, nil
-	}, jwt.WithValidMethods([]string{"HS256"}))
+		return s.signer.PublicKey(), nil
+	}, jwt.WithValidMethods([]string{"RS256"}))
 	if err != nil || !token.Valid {
 		return "", fmt.Errorf("invalid session token: %w", err)
 	}

--- a/internal/auth/service_events_test.go
+++ b/internal/auth/service_events_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
 )
 
 type stubEventHandler struct {
@@ -37,7 +39,7 @@ func directService(store UserStore, handler UserEventHandler) *oidcService {
 		store:        store,
 		refreshStore: &noopRefreshStore{},
 		eventHandler: handler,
-		jwtSecret:    []byte("secret"),
+		signer:       jwtutil.NewNoOp(),
 		jwtTTL:       time.Hour,
 	}
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -2,22 +2,44 @@ package auth_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
 )
+
+func newTestSigner(t *testing.T) jwtutil.Signer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	s, err := jwtutil.NewRSASigner(string(pemBytes), "test-kid")
+	if err != nil {
+		t.Fatalf("NewRSASigner: %v", err)
+	}
+	return s
+}
 
 // jwtOnlyService builds an oidcService with no OIDC verifiers (empty providers map)
 // so we can test JWT issue/validate in isolation.
-func jwtOnlyService(t *testing.T, secret string, ttl time.Duration) auth.AuthService {
+func jwtOnlyService(t *testing.T, ttl time.Duration) auth.AuthService {
 	t.Helper()
 	svc, err := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
 		Providers:    map[string]string{},
 		Store:        &stubUserStore{},
 		RefreshStore: &stubRefreshTokenStore{},
-		JWTSecret:    secret,
+		Signer:       newTestSigner(t),
 		JWTTTL:       ttl,
 	})
 	if err != nil {
@@ -27,7 +49,7 @@ func jwtOnlyService(t *testing.T, secret string, ttl time.Duration) auth.AuthSer
 }
 
 func TestIssueAndValidateSessionJWT(t *testing.T) {
-	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+	svc := jwtOnlyService(t, time.Hour)
 
 	token, err := svc.IssueSessionJWT("user-uuid-123")
 	if err != nil {
@@ -47,7 +69,7 @@ func TestIssueAndValidateSessionJWT(t *testing.T) {
 }
 
 func TestValidateSessionJWT_Expired(t *testing.T) {
-	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", -time.Second)
+	svc := jwtOnlyService(t, -time.Second)
 
 	token, err := svc.IssueSessionJWT("user-uuid-123")
 	if err != nil {
@@ -60,9 +82,9 @@ func TestValidateSessionJWT_Expired(t *testing.T) {
 	}
 }
 
-func TestValidateSessionJWT_WrongSecret(t *testing.T) {
-	svc1 := jwtOnlyService(t, "secret-one-32-bytes-long-enough!!", time.Hour)
-	svc2 := jwtOnlyService(t, "secret-two-32-bytes-long-enough!!", time.Hour)
+func TestValidateSessionJWT_WrongKey(t *testing.T) {
+	svc1 := jwtOnlyService(t, time.Hour)
+	svc2 := jwtOnlyService(t, time.Hour)
 
 	token, err := svc1.IssueSessionJWT("user-uuid-123")
 	if err != nil {
@@ -71,12 +93,12 @@ func TestValidateSessionJWT_WrongSecret(t *testing.T) {
 
 	_, err = svc2.ValidateSessionJWT(token)
 	if err == nil {
-		t.Fatal("expected error for wrong secret, got nil")
+		t.Fatal("expected error for wrong key, got nil")
 	}
 }
 
 func TestVerifyAndUpsert_UnsupportedProvider(t *testing.T) {
-	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+	svc := jwtOnlyService(t, time.Hour)
 
 	_, err := svc.VerifyAndUpsert(context.Background(), "github", "some-token")
 	if err == nil {
@@ -85,7 +107,7 @@ func TestVerifyAndUpsert_UnsupportedProvider(t *testing.T) {
 }
 
 func TestIssueRefreshToken(t *testing.T) {
-	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+	svc := jwtOnlyService(t, time.Hour)
 
 	raw, err := svc.IssueRefreshToken(context.Background(), "user-uuid-123")
 	if err != nil {
@@ -105,7 +127,7 @@ func TestRotateRefreshToken(t *testing.T) {
 		Providers:    map[string]string{},
 		Store:        &stubUserStore{},
 		RefreshStore: store,
-		JWTSecret:    "test-secret-32-bytes-long-enough!",
+		Signer:       newTestSigner(t),
 		JWTTTL:       time.Hour,
 	})
 	if err != nil {
@@ -135,7 +157,7 @@ func TestRotateRefreshToken_Revoked(t *testing.T) {
 		Providers:    map[string]string{},
 		Store:        &stubUserStore{},
 		RefreshStore: store,
-		JWTSecret:    "test-secret-32-bytes-long-enough!",
+		Signer:       newTestSigner(t),
 		JWTTTL:       time.Hour,
 	})
 
@@ -154,7 +176,7 @@ func TestRotateRefreshToken_Expired(t *testing.T) {
 		Providers:    map[string]string{},
 		Store:        &stubUserStore{},
 		RefreshStore: store,
-		JWTSecret:    "test-secret-32-bytes-long-enough!",
+		Signer:       newTestSigner(t),
 		JWTTTL:       time.Hour,
 	})
 
@@ -167,7 +189,7 @@ func TestRotateRefreshToken_Expired(t *testing.T) {
 }
 
 func TestRotateRefreshToken_NotFound(t *testing.T) {
-	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+	svc := jwtOnlyService(t, time.Hour)
 
 	_, _, err := svc.RotateRefreshToken(context.Background(), "nonexistent-token")
 	if err != auth.ErrTokenNotFound {
@@ -176,7 +198,7 @@ func TestRotateRefreshToken_NotFound(t *testing.T) {
 }
 
 func TestRevokeRefreshToken_NotFound(t *testing.T) {
-	svc := jwtOnlyService(t, "test-secret-32-bytes-long-enough!", time.Hour)
+	svc := jwtOnlyService(t, time.Hour)
 
 	err := svc.RevokeRefreshToken(context.Background(), "nonexistent-token")
 	if err != auth.ErrTokenNotFound {

--- a/internal/jwtutil/jwks.go
+++ b/internal/jwtutil/jwks.go
@@ -20,30 +20,28 @@ type jwkSet struct {
 	Keys []jwk `json:"keys"`
 }
 
-// JWKSHandler serves GET /.well-known/jwks.json for a given Signer.
+// JWKSHandler serves GET /.well-known/jwks.json for one or more Signers.
 type JWKSHandler struct {
-	Signer Signer
+	Signers []Signer
 }
 
 func (h *JWKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	pub := h.Signer.PublicKey()
-	if pub == nil {
-		json.NewEncoder(w).Encode(jwkSet{Keys: []jwk{}})
-		return
+	keys := make([]jwk, 0, len(h.Signers))
+	for _, s := range h.Signers {
+		pub := s.PublicKey()
+		if pub == nil {
+			continue
+		}
+		keys = append(keys, jwk{
+			Kty: "RSA",
+			Kid: s.KID(),
+			Use: "sig",
+			Alg: "RS256",
+			N:   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+			E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+		})
 	}
-
-	json.NewEncoder(w).Encode(jwkSet{
-		Keys: []jwk{
-			{
-				Kty: "RSA",
-				Kid: h.Signer.KID(),
-				Use: "sig",
-				Alg: "RS256",
-				N:   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
-				E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
-			},
-		},
-	})
+	json.NewEncoder(w).Encode(jwkSet{Keys: keys})
 }

--- a/internal/jwtutil/signer_test.go
+++ b/internal/jwtutil/signer_test.go
@@ -121,7 +121,7 @@ func TestJWKSHandler_withSigner(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
 	rec := httptest.NewRecorder()
-	(&jwtutil.JWKSHandler{Signer: signer}).ServeHTTP(rec, req)
+	(&jwtutil.JWKSHandler{Signers: []jwtutil.Signer{signer}}).ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -164,7 +164,7 @@ func TestJWKSHandler_withSigner(t *testing.T) {
 func TestJWKSHandler_noOp(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
 	rec := httptest.NewRecorder()
-	(&jwtutil.JWKSHandler{Signer: jwtutil.NewNoOp()}).ServeHTTP(rec, req)
+	(&jwtutil.JWKSHandler{Signers: []jwtutil.Signer{jwtutil.NewNoOp()}}).ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,8 @@ import (
 type config struct {
 	Port             string
 	LogFormat        string
-	JWTSecret        string
+	SessionJWTPEMKey string
+	SessionJWTKID    string
 	JWTTTLHours      int
 	GoogleClientID   string
 	InfluxHost       string
@@ -65,7 +66,8 @@ func loadConfig() config {
 	return config{
 		Port:             port,
 		LogFormat:        os.Getenv("LOG_FORMAT"),
-		JWTSecret:        os.Getenv("JWT_SECRET"),
+		SessionJWTPEMKey: strings.ReplaceAll(os.Getenv("SESSION_JWT_PRIVATE_KEY"), `\n`, "\n"),
+		SessionJWTKID:    os.Getenv("SESSION_JWT_KID"),
 		JWTTTLHours:      jwtTTLHours,
 		GoogleClientID:   os.Getenv("GOOGLE_CLIENT_ID"),
 		InfluxHost:       os.Getenv("INFLUXDB3_HOST"),
@@ -134,13 +136,26 @@ func main() {
 		jwtTTL = time.Duration(cfg.JWTTTLHours) * time.Hour
 	}
 
+	sessionSigner := jwtutil.Signer(jwtutil.NewNoOp())
+	if cfg.SessionJWTPEMKey != "" {
+		s, err := jwtutil.NewRSASigner(cfg.SessionJWTPEMKey, cfg.SessionJWTKID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "session jwt init: %v\n", err)
+			os.Exit(1)
+		}
+		sessionSigner = s
+		logger.Info("session jwt signer configured", "kid", cfg.SessionJWTKID)
+	} else {
+		logger.Warn("session jwt not configured — session tokens will not be signed with RSA")
+	}
+
 	accountStore := account.NewPostgresStore(db)
 	authSvc, err := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
 		Providers:    map[string]string{"google": cfg.GoogleClientID},
 		Store:        auth.NewPostgresStore(db),
 		RefreshStore: auth.NewPostgresRefreshTokenStore(db),
 		EventHandler: &account.AccountEventHandler{Store: accountStore},
-		JWTSecret:    cfg.JWTSecret,
+		Signer:       sessionSigner,
 		JWTTTL:       jwtTTL,
 	})
 	if err != nil {
@@ -206,7 +221,7 @@ func main() {
 	}))
 
 	r.Get("/health", platform.Health)
-	r.Get("/.well-known/jwks.json", (&jwtutil.JWKSHandler{Signer: jwkSigner}).ServeHTTP)
+	r.Get("/.well-known/jwks.json", (&jwtutil.JWKSHandler{Signers: []jwtutil.Signer{jwkSigner, sessionSigner}}).ServeHTTP)
 	r.Post("/auth/verify", auth.NewVerifyHandler(authSvc, logger).ServeHTTP)
 	r.Post("/auth/refresh", auth.NewRefreshHandler(authSvc, logger).ServeHTTP)
 	r.Post("/auth/logout", auth.NewLogoutHandler(authSvc).ServeHTTP)


### PR DESCRIPTION
## Summary

- Replace HS256 shared-secret session JWTs with RS256 (RSA) — consistent with device JWTs already in place
- `JWKSHandler` now accepts `[]Signer` and serves both device and session public keys at `/.well-known/jwks.json`
- `JWT_SECRET` env var removed; replaced by `SESSION_JWT_PRIVATE_KEY` (PEM key) and `SESSION_JWT_KID`
- Tests updated to generate in-memory RSA keys instead of using a string secret

## Test plan

- [ ] `go test ./internal/auth/... ./internal/jwtutil/...` passes
- [ ] Deploy with `SESSION_JWT_PRIVATE_KEY` + `SESSION_JWT_KID` set; verify login flow issues RS256 tokens
- [ ] Verify `GET /.well-known/jwks.json` returns two keys (device + session)
- [ ] Existing refresh tokens re-issue new RS256 session tokens on rotation

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)