### PR TITLE
feat: async HiveMQ provisioning via generic outbox

### DIFF
--- a/db/migrations/014_create_outbox_events.down.sql
+++ b/db/migrations/014_create_outbox_events.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS outbox_events;

--- a/db/migrations/014_create_outbox_events.up.sql
+++ b/db/migrations/014_create_outbox_events.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE outbox_events (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type  TEXT NOT NULL,
+    payload     JSONB NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    attempts    INT NOT NULL DEFAULT 0,
+    last_error  TEXT
+);
+
+CREATE INDEX outbox_events_pending ON outbox_events (event_type, created_at)
+    WHERE status = 'pending';

--- a/db/migrations/014_create_outbox_events.up.sql
+++ b/db/migrations/014_create_outbox_events.up.sql
@@ -1,12 +1,14 @@
 CREATE TABLE outbox_events (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    event_type  TEXT NOT NULL,
-    payload     JSONB NOT NULL,
-    status      TEXT NOT NULL DEFAULT 'pending',
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    attempts    INT NOT NULL DEFAULT 0,
-    last_error  TEXT
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type            TEXT NOT NULL,
+    payload               JSONB NOT NULL,
+    status                TEXT NOT NULL DEFAULT 'pending',
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    claimed_at            TIMESTAMPTZ,
+    claim_timeout_seconds INT NOT NULL DEFAULT 300,
+    attempts              INT NOT NULL DEFAULT 0,
+    last_error            TEXT
 );
 
-CREATE INDEX outbox_events_pending ON outbox_events (event_type, created_at)
-    WHERE status = 'pending';
+CREATE INDEX outbox_events_claimable ON outbox_events (event_type, created_at)
+    WHERE status = 'pending' OR status = 'processing';

--- a/docs/api.md
+++ b/docs/api.md
@@ -197,7 +197,7 @@ No request body required.
 
 ## POST /devices/activate
 
-Called by the ESP32 after the user enters the pairing code on the captive portal. No session auth required — the code itself is the credential. Marks the device active and issues a signed device JWT.
+Called by the ESP32 after the user enters the pairing code on the captive portal. No session auth required — the code itself is the credential. Marks the device active, kicks off async MQTT credential provisioning via HiveMQ, and issues a signed device JWT.
 
 No auth header required.
 
@@ -208,7 +208,7 @@ No auth header required.
 }
 ```
 
-**Response `201`**
+**Response `202`**
 ```json
 {
   "token":     "<signed-jwt>",
@@ -218,8 +218,10 @@ No auth header required.
 
 | Field | Description |
 |---|---|
-| `token` | RS256-signed JWT (`sub`=`device_id`, `user_id`, `iss`=`IDP_HOST`, `iat`). The device stores this in NVS and uses it as the `Authorization: Bearer` header for `/readings` calls and as the MQTT password when connecting to HiveMQ. Empty string if `DEVICE_JWT_PRIVATE_KEY` is not configured on the server. |
+| `token` | RS256-signed JWT (`sub`=`device_id`, `user_id`, `iss`=`IDP_HOST`, `iat`). The device stores this in NVS and uses it as the `Authorization: Bearer` header for all subsequent requests. Empty string if `DEVICE_JWT_PRIVATE_KEY` is not configured on the server. |
 | `device_id` | UUID of the now-active device. |
+
+MQTT credentials are provisioned asynchronously. After receiving `202`, the device must poll `GET /devices/{id}/status` until `"status": "ready"` before attempting to connect to the MQTT broker.
 
 **Response `400`** — missing or empty `code`
 
@@ -228,6 +230,45 @@ No auth header required.
 **Response `409`** — code already used
 
 **Response `500`** — DB or token-generation failure
+
+---
+
+## GET /devices/{id}/status
+
+Polls the activation status of a device. Returns MQTT credentials once HiveMQ provisioning completes. Called by the device after receiving `202` from `POST /devices/activate`.
+
+**Headers**
+```
+Authorization: Bearer <device-jwt>
+```
+
+The JWT `sub` must match the `{id}` path parameter.
+
+**Response `200` — still provisioning**
+```json
+{
+  "status": "provisioning"
+}
+```
+
+**Response `200` — ready**
+```json
+{
+  "status":        "ready",
+  "mqtt_username": "<hivemq-username>",
+  "mqtt_password": "<hivemq-password>",
+  "mqtt_host":     "broker.example.com",
+  "mqtt_port":     8883
+}
+```
+
+**Response `401`** — missing or invalid device JWT
+
+**Response `403`** — JWT `sub` does not match `{id}`
+
+**Response `404`** — device not found
+
+**Response `500`** — DB failure
 
 ---
 

--- a/internal/outbox/outbox.go
+++ b/internal/outbox/outbox.go
@@ -24,14 +24,17 @@ type EventProcessor interface {
 
 // Store is the persistence layer for the outbox.
 type Store interface {
-	// ListPending fetches up to limit rows where status = 'pending', oldest first.
-	ListPending(ctx context.Context, limit int) ([]Event, error)
+	// ClaimBatch atomically claims up to limit pending (or stale processing) rows,
+	// setting status = 'processing' and claimed_at = now().
+	// Uses SELECT FOR UPDATE SKIP LOCKED — safe for multiple concurrent runners.
+	ClaimBatch(ctx context.Context, limit int) ([]Event, error)
 	// MarkCompleted sets status = 'completed'.
 	MarkCompleted(ctx context.Context, id string) error
 	// RecordFailure increments attempts and writes the error message.
 	// If the new attempts count reaches maxAttempts, sets status = 'dead'.
 	RecordFailure(ctx context.Context, id string, attempts int, maxAttempts int, errMsg string) error
 	// Insert adds a new pending event within the provided transaction.
+	// claimTimeoutSeconds controls how long before a stale processing row is re-claimable.
 	// The caller owns the transaction boundary.
-	Insert(ctx context.Context, tx *sql.Tx, eventType string, payload any) error
+	Insert(ctx context.Context, tx *sql.Tx, eventType string, payload any, claimTimeoutSeconds int) error
 }

--- a/internal/outbox/outbox.go
+++ b/internal/outbox/outbox.go
@@ -1,0 +1,37 @@
+package outbox
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+)
+
+// Event is a single row from the outbox_events table.
+type Event struct {
+	ID        string
+	EventType string
+	Payload   json.RawMessage
+	Attempts  int
+}
+
+// EventProcessor handles events of a specific type.
+type EventProcessor interface {
+	// EventType returns the event_type string this processor handles.
+	EventType() string
+	// Process handles one event. Return nil to mark it completed; return an error to retry.
+	Process(ctx context.Context, event Event) error
+}
+
+// Store is the persistence layer for the outbox.
+type Store interface {
+	// ListPending fetches up to limit rows where status = 'pending', oldest first.
+	ListPending(ctx context.Context, limit int) ([]Event, error)
+	// MarkCompleted sets status = 'completed'.
+	MarkCompleted(ctx context.Context, id string) error
+	// RecordFailure increments attempts and writes the error message.
+	// If the new attempts count reaches maxAttempts, sets status = 'dead'.
+	RecordFailure(ctx context.Context, id string, attempts int, maxAttempts int, errMsg string) error
+	// Insert adds a new pending event within the provided transaction.
+	// The caller owns the transaction boundary.
+	Insert(ctx context.Context, tx *sql.Tx, eventType string, payload any) error
+}

--- a/internal/outbox/runner.go
+++ b/internal/outbox/runner.go
@@ -49,9 +49,9 @@ func (r *Runner) Run(ctx context.Context) {
 }
 
 func (r *Runner) tick(ctx context.Context) {
-	events, err := r.store.ListPending(ctx, batchSize)
+	events, err := r.store.ClaimBatch(ctx, batchSize)
 	if err != nil {
-		r.logger.Error("outbox: list pending", "error", err)
+		r.logger.Error("outbox: claim batch", "error", err)
 		return
 	}
 	if len(events) == 0 {

--- a/internal/outbox/runner.go
+++ b/internal/outbox/runner.go
@@ -1,0 +1,111 @@
+package outbox
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const batchSize = 50
+
+// Runner polls the outbox and dispatches events to registered processors.
+// One goroutine per event type is spawned per tick; rows within each type
+// are processed sequentially to preserve ordering.
+type Runner struct {
+	store       Store
+	processors  map[string]EventProcessor
+	interval    time.Duration
+	maxAttempts int
+	logger      *slog.Logger
+}
+
+func NewRunner(store Store, processors []EventProcessor, interval time.Duration, maxAttempts int, logger *slog.Logger) *Runner {
+	pm := make(map[string]EventProcessor, len(processors))
+	for _, p := range processors {
+		pm[p.EventType()] = p
+	}
+	return &Runner{
+		store:       store,
+		processors:  pm,
+		interval:    interval,
+		maxAttempts: maxAttempts,
+		logger:      logger,
+	}
+}
+
+func (r *Runner) Run(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.tick(ctx)
+		}
+	}
+}
+
+func (r *Runner) tick(ctx context.Context) {
+	events, err := r.store.ListPending(ctx, batchSize)
+	if err != nil {
+		r.logger.Error("outbox: list pending", "error", err)
+		return
+	}
+	if len(events) == 0 {
+		return
+	}
+
+	// Group by event type.
+	groups := make(map[string][]Event)
+	for _, e := range events {
+		groups[e.EventType] = append(groups[e.EventType], e)
+	}
+
+	var wg sync.WaitGroup
+	for eventType, batch := range groups {
+		processor, ok := r.processors[eventType]
+		if !ok {
+			r.logger.Warn("outbox: no processor registered", "event_type", eventType)
+			continue
+		}
+
+		wg.Add(1)
+		go func(p EventProcessor, batch []Event) {
+			defer wg.Done()
+			for _, e := range batch {
+				r.process(ctx, p, e)
+			}
+		}(processor, batch)
+	}
+	wg.Wait()
+}
+
+func (r *Runner) process(ctx context.Context, p EventProcessor, e Event) {
+	if err := p.Process(ctx, e); err != nil {
+		r.logger.Warn("outbox: process failed",
+			"event_id", e.ID,
+			"event_type", e.EventType,
+			"attempts", e.Attempts+1,
+			"error", err,
+		)
+		newAttempts := e.Attempts + 1
+		if ferr := r.store.RecordFailure(ctx, e.ID, e.Attempts, r.maxAttempts, err.Error()); ferr != nil {
+			r.logger.Error("outbox: record failure", "event_id", e.ID, "error", ferr)
+		}
+		if newAttempts >= r.maxAttempts {
+			r.logger.Error("outbox: event dead",
+				"event_id", e.ID,
+				"event_type", e.EventType,
+				"attempts", newAttempts,
+			)
+		}
+		return
+	}
+
+	if err := r.store.MarkCompleted(ctx, e.ID); err != nil {
+		r.logger.Error("outbox: mark completed", "event_id", e.ID, "error", err)
+	}
+}

--- a/internal/outbox/store_postgres.go
+++ b/internal/outbox/store_postgres.go
@@ -1,0 +1,80 @@
+package outbox
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewPostgresStore(db *sql.DB) Store {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) ListPending(ctx context.Context, limit int) ([]Event, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, event_type, payload, attempts
+		FROM outbox_events
+		WHERE status = 'pending'
+		ORDER BY created_at
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: list pending: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		if err := rows.Scan(&e.ID, &e.EventType, &e.Payload, &e.Attempts); err != nil {
+			return nil, fmt.Errorf("outbox: scan row: %w", err)
+		}
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+func (s *postgresStore) MarkCompleted(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE outbox_events SET status = 'completed' WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("outbox: mark completed: %w", err)
+	}
+	return nil
+}
+
+func (s *postgresStore) RecordFailure(ctx context.Context, id string, attempts int, maxAttempts int, errMsg string) error {
+	newAttempts := attempts + 1
+	status := "pending"
+	if newAttempts >= maxAttempts {
+		status = "dead"
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE outbox_events
+		SET attempts = $2, last_error = $3, status = $4
+		WHERE id = $1
+	`, id, newAttempts, errMsg, status)
+	if err != nil {
+		return fmt.Errorf("outbox: record failure: %w", err)
+	}
+	return nil
+}
+
+func (s *postgresStore) Insert(ctx context.Context, tx *sql.Tx, eventType string, payload any) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("outbox: marshal payload: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO outbox_events (event_type, payload) VALUES ($1, $2)
+	`, eventType, b)
+	if err != nil {
+		return fmt.Errorf("outbox: insert: %w", err)
+	}
+	return nil
+}

--- a/internal/outbox/store_postgres.go
+++ b/internal/outbox/store_postgres.go
@@ -15,16 +15,22 @@ func NewPostgresStore(db *sql.DB) Store {
 	return &postgresStore{db: db}
 }
 
-func (s *postgresStore) ListPending(ctx context.Context, limit int) ([]Event, error) {
+func (s *postgresStore) ClaimBatch(ctx context.Context, limit int) ([]Event, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, event_type, payload, attempts
-		FROM outbox_events
-		WHERE status = 'pending'
-		ORDER BY created_at
-		LIMIT $1
+		UPDATE outbox_events
+		SET status = 'processing', claimed_at = now()
+		WHERE id IN (
+			SELECT id FROM outbox_events
+			WHERE status = 'pending'
+			   OR (status = 'processing' AND claimed_at < now() - (claim_timeout_seconds || ' seconds')::interval)
+			ORDER BY created_at
+			FOR UPDATE SKIP LOCKED
+			LIMIT $1
+		)
+		RETURNING id, event_type, payload, attempts
 	`, limit)
 	if err != nil {
-		return nil, fmt.Errorf("outbox: list pending: %w", err)
+		return nil, fmt.Errorf("outbox: claim batch: %w", err)
 	}
 	defer rows.Close()
 
@@ -65,14 +71,15 @@ func (s *postgresStore) RecordFailure(ctx context.Context, id string, attempts i
 	return nil
 }
 
-func (s *postgresStore) Insert(ctx context.Context, tx *sql.Tx, eventType string, payload any) error {
+func (s *postgresStore) Insert(ctx context.Context, tx *sql.Tx, eventType string, payload any, claimTimeoutSeconds int) error {
 	b, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("outbox: marshal payload: %w", err)
 	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO outbox_events (event_type, payload) VALUES ($1, $2)
-	`, eventType, b)
+		INSERT INTO outbox_events (event_type, payload, claim_timeout_seconds)
+		VALUES ($1, $2, $3)
+	`, eventType, b, claimTimeoutSeconds)
 	if err != nil {
 		return fmt.Errorf("outbox: insert: %w", err)
 	}

--- a/internal/sensors/activation_service.go
+++ b/internal/sensors/activation_service.go
@@ -12,14 +12,12 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 )
 
-// ActivationResult holds everything the device needs after successful activation.
+// ActivationResult holds what the device receives immediately after activation.
+// MQTT credentials are not included — the device polls GET /devices/{id}/status
+// until they are ready.
 type ActivationResult struct {
-	Token        string
-	DeviceID     string
-	MQTTUsername string
-	MQTTPassword string
-	MQTTHost     string
-	MQTTPort     int
+	Token    string
+	DeviceID string
 }
 
 // ActivationService orchestrates device activation: claim code → store credentials
@@ -29,8 +27,6 @@ type ActivationService struct {
 	store       ProvisioningStore
 	outboxStore outbox.Store
 	signer      devicejwt.Signer
-	mqttHost    string
-	mqttPort    int
 	logger      *slog.Logger
 }
 
@@ -39,8 +35,6 @@ func NewActivationService(
 	store ProvisioningStore,
 	outboxStore outbox.Store,
 	signer devicejwt.Signer,
-	mqttHost string,
-	mqttPort int,
 	logger *slog.Logger,
 ) *ActivationService {
 	if logger == nil {
@@ -51,8 +45,6 @@ func NewActivationService(
 		store:       store,
 		outboxStore: outboxStore,
 		signer:      signer,
-		mqttHost:    mqttHost,
-		mqttPort:    mqttPort,
 		logger:      logger,
 	}
 }
@@ -110,11 +102,7 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 	}
 
 	return ActivationResult{
-		Token:        jwtToken,
-		DeviceID:     deviceID,
-		MQTTUsername: mqttUsername,
-		MQTTPassword: mqttPassword,
-		MQTTHost:     s.mqttHost,
-		MQTTPort:     s.mqttPort,
+		Token:    jwtToken,
+		DeviceID: deviceID,
 	}, nil
 }

--- a/internal/sensors/activation_service.go
+++ b/internal/sensors/activation_service.go
@@ -93,7 +93,7 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 		DeviceID: deviceID,
 		Username: mqttUsername,
 		Password: mqttPassword,
-	}); err != nil {
+	}, hiveMQProvisionClaimTimeoutSeconds); err != nil {
 		s.logger.Error("activate: enqueue hivemq provision", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("enqueue hivemq provision: %w", err)
 	}

--- a/internal/sensors/activation_service.go
+++ b/internal/sensors/activation_service.go
@@ -3,12 +3,13 @@ package sensors
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
 
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
-	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 )
 
 // ActivationResult holds everything the device needs after successful activation.
@@ -21,22 +22,39 @@ type ActivationResult struct {
 	MQTTPort     int
 }
 
-// ActivationService orchestrates device activation: claim code → provision MQTT
-// credentials → store in DB → sign JWT.
+// ActivationService orchestrates device activation: claim code → store credentials
+// + enqueue HiveMQ provisioning atomically → sign JWT.
 type ActivationService struct {
-	store    ProvisioningStore
-	hiveMQ   hivemq.Client
-	signer   devicejwt.Signer
-	mqttHost string
-	mqttPort int
-	logger   *slog.Logger
+	db          *sql.DB
+	store       ProvisioningStore
+	outboxStore outbox.Store
+	signer      devicejwt.Signer
+	mqttHost    string
+	mqttPort    int
+	logger      *slog.Logger
 }
 
-func NewActivationService(store ProvisioningStore, hiveMQ hivemq.Client, signer devicejwt.Signer, mqttHost string, mqttPort int, logger *slog.Logger) *ActivationService {
+func NewActivationService(
+	db *sql.DB,
+	store ProvisioningStore,
+	outboxStore outbox.Store,
+	signer devicejwt.Signer,
+	mqttHost string,
+	mqttPort int,
+	logger *slog.Logger,
+) *ActivationService {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &ActivationService{store: store, hiveMQ: hiveMQ, signer: signer, mqttHost: mqttHost, mqttPort: mqttPort, logger: logger}
+	return &ActivationService{
+		db:          db,
+		store:       store,
+		outboxStore: outboxStore,
+		signer:      signer,
+		mqttHost:    mqttHost,
+		mqttPort:    mqttPort,
+		logger:      logger,
+	}
 }
 
 // Activate claims the provisioning code and completes device activation.
@@ -59,14 +77,30 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 	}
 	mqttPassword := hex.EncodeToString(mqttPasswordBytes)
 
-	if err := s.hiveMQ.ProvisionDevice(ctx, mqttUsername, mqttPassword); err != nil {
-		s.logger.Error("activate: hivemq provision", "device_id", deviceID, "error", err)
-		return ActivationResult{}, fmt.Errorf("hivemq provision: %w", err)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		s.logger.Error("activate: begin tx", "device_id", deviceID, "error", err)
+		return ActivationResult{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if err := s.store.Activate(ctx, tx, deviceID, mqttUsername, mqttPassword); err != nil {
+		s.logger.Error("activate: store credentials", "device_id", deviceID, "error", err)
+		return ActivationResult{}, fmt.Errorf("activate device: %w", err)
 	}
 
-	if err := s.store.Activate(ctx, deviceID, mqttUsername, mqttPassword); err != nil {
-		s.logger.Error("activate: store", "device_id", deviceID, "error", err)
-		return ActivationResult{}, fmt.Errorf("activate device: %w", err)
+	if err := s.outboxStore.Insert(ctx, tx, EventTypeHiveMQProvision, HiveMQProvisionPayload{
+		DeviceID: deviceID,
+		Username: mqttUsername,
+		Password: mqttPassword,
+	}); err != nil {
+		s.logger.Error("activate: enqueue hivemq provision", "device_id", deviceID, "error", err)
+		return ActivationResult{}, fmt.Errorf("enqueue hivemq provision: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("activate: commit tx", "device_id", deviceID, "error", err)
+		return ActivationResult{}, fmt.Errorf("commit tx: %w", err)
 	}
 
 	jwtToken, err := s.signer.Sign(deviceID, userID)

--- a/internal/sensors/activation_test.go
+++ b/internal/sensors/activation_test.go
@@ -5,29 +5,45 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
 )
 
-func newActivationSvc(store *stubProvisioningStore, mq *stubHiveMQClient, signer *stubSigner) *sensors.ActivationService {
-	return sensors.NewActivationService(store, mq, signer, "broker.example.com", 8883, discardLogger)
+func newActivationSvc(t *testing.T, store sensors.ProvisioningStore, outboxStore outbox.Store, signer *stubSigner) *sensors.ActivationService {
+	t.Helper()
+	db := testutil.NewTestDB(t)
+	return sensors.NewActivationService(db, store, outboxStore, signer, "broker.example.com", 8883, discardLogger)
 }
 
 func TestActivationService_HappyPath(t *testing.T) {
-	svc := newActivationSvc(
-		&stubProvisioningStore{claimedDeviceID: "dev-1", claimUserID: "usr-1"},
-		&stubHiveMQClient{},
-		&stubSigner{token: "jwt-tok"},
-	)
+	db := testutil.NewTestDB(t)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
 
-	result, err := svc.Activate(context.Background(), "ABC123")
+	provStore := sensors.NewProvisioningStore(db)
+	outboxStore := outbox.NewPostgresStore(db)
+
+	code, err := provStore.GetOrCreateCode(ctx, userID)
+	if err != nil {
+		t.Fatalf("setup: get code: %v", err)
+	}
+
+	svc := sensors.NewActivationService(db, provStore, outboxStore, &stubSigner{token: "jwt-tok"}, "broker.example.com", 8883, discardLogger)
+
+	result, err := svc.Activate(ctx, code)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.Token != "jwt-tok" {
 		t.Errorf("token: got %q want %q", result.Token, "jwt-tok")
 	}
-	if result.DeviceID != "dev-1" {
-		t.Errorf("device_id: got %q want %q", result.DeviceID, "dev-1")
+	if result.DeviceID == "" {
+		t.Error("expected non-empty device_id")
+	}
+	if result.MQTTUsername == "" || result.MQTTPassword == "" {
+		t.Error("expected non-empty mqtt credentials")
 	}
 	if result.MQTTHost != "broker.example.com" {
 		t.Errorf("mqtt_host: got %q want %q", result.MQTTHost, "broker.example.com")
@@ -38,9 +54,9 @@ func TestActivationService_HappyPath(t *testing.T) {
 }
 
 func TestActivationService_CodeNotFound(t *testing.T) {
-	svc := newActivationSvc(
+	svc := newActivationSvc(t,
 		&stubProvisioningStore{claimErr: sensors.ErrCodeNotFound},
-		&stubHiveMQClient{},
+		&stubOutboxStore{},
 		&stubSigner{},
 	)
 	_, err := svc.Activate(context.Background(), "XXXXXX")
@@ -50,9 +66,9 @@ func TestActivationService_CodeNotFound(t *testing.T) {
 }
 
 func TestActivationService_CodeAlreadyUsed(t *testing.T) {
-	svc := newActivationSvc(
+	svc := newActivationSvc(t,
 		&stubProvisioningStore{claimErr: sensors.ErrCodeAlreadyUsed},
-		&stubHiveMQClient{},
+		&stubOutboxStore{},
 		&stubSigner{},
 	)
 	_, err := svc.Activate(context.Background(), "XXXXXX")
@@ -61,27 +77,11 @@ func TestActivationService_CodeAlreadyUsed(t *testing.T) {
 	}
 }
 
-func TestActivationService_HiveMQError(t *testing.T) {
-	provisionErr := errors.New("hivemq unavailable")
-	svc := newActivationSvc(
-		&stubProvisioningStore{claimedDeviceID: "dev-1", claimUserID: "usr-1"},
-		&stubHiveMQClient{err: provisionErr},
-		&stubSigner{},
-	)
-	_, err := svc.Activate(context.Background(), "ABC123")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, provisionErr) {
-		t.Errorf("expected wrapped provisionErr, got %v", err)
-	}
-}
-
 func TestActivationService_ActivateStoreError(t *testing.T) {
 	activateErr := errors.New("db error")
-	svc := newActivationSvc(
+	svc := newActivationSvc(t,
 		&stubProvisioningStore{claimedDeviceID: "dev-1", claimUserID: "usr-1", activateErr: activateErr},
-		&stubHiveMQClient{},
+		&stubOutboxStore{},
 		&stubSigner{},
 	)
 	_, err := svc.Activate(context.Background(), "ABC123")
@@ -91,13 +91,22 @@ func TestActivationService_ActivateStoreError(t *testing.T) {
 }
 
 func TestActivationService_SignerError(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	provStore := sensors.NewProvisioningStore(db)
+	outboxStore := outbox.NewPostgresStore(db)
+
+	code, err := provStore.GetOrCreateCode(ctx, userID)
+	if err != nil {
+		t.Fatalf("setup: get code: %v", err)
+	}
+
 	signErr := errors.New("signing key not configured")
-	svc := newActivationSvc(
-		&stubProvisioningStore{claimedDeviceID: "dev-1", claimUserID: "usr-1"},
-		&stubHiveMQClient{},
-		&stubSigner{err: signErr},
-	)
-	_, err := svc.Activate(context.Background(), "ABC123")
+	svc := sensors.NewActivationService(db, provStore, outboxStore, &stubSigner{err: signErr}, "broker.example.com", 8883, discardLogger)
+
+	_, err = svc.Activate(ctx, code)
 	if !errors.Is(err, signErr) {
 		t.Errorf("expected wrapped signErr, got %v", err)
 	}

--- a/internal/sensors/activation_test.go
+++ b/internal/sensors/activation_test.go
@@ -14,7 +14,7 @@ import (
 func newActivationSvc(t *testing.T, store sensors.ProvisioningStore, outboxStore outbox.Store, signer *stubSigner) *sensors.ActivationService {
 	t.Helper()
 	db := testutil.NewTestDB(t)
-	return sensors.NewActivationService(db, store, outboxStore, signer, "broker.example.com", 8883, discardLogger)
+	return sensors.NewActivationService(db, store, outboxStore, signer, discardLogger)
 }
 
 func TestActivationService_HappyPath(t *testing.T) {
@@ -30,7 +30,7 @@ func TestActivationService_HappyPath(t *testing.T) {
 		t.Fatalf("setup: get code: %v", err)
 	}
 
-	svc := sensors.NewActivationService(db, provStore, outboxStore, &stubSigner{token: "jwt-tok"}, "broker.example.com", 8883, discardLogger)
+	svc := sensors.NewActivationService(db, provStore, outboxStore, &stubSigner{token: "jwt-tok"}, discardLogger)
 
 	result, err := svc.Activate(ctx, code)
 	if err != nil {
@@ -41,15 +41,6 @@ func TestActivationService_HappyPath(t *testing.T) {
 	}
 	if result.DeviceID == "" {
 		t.Error("expected non-empty device_id")
-	}
-	if result.MQTTUsername == "" || result.MQTTPassword == "" {
-		t.Error("expected non-empty mqtt credentials")
-	}
-	if result.MQTTHost != "broker.example.com" {
-		t.Errorf("mqtt_host: got %q want %q", result.MQTTHost, "broker.example.com")
-	}
-	if result.MQTTPort != 8883 {
-		t.Errorf("mqtt_port: got %d want %d", result.MQTTPort, 8883)
 	}
 }
 
@@ -104,7 +95,7 @@ func TestActivationService_SignerError(t *testing.T) {
 	}
 
 	signErr := errors.New("signing key not configured")
-	svc := sensors.NewActivationService(db, provStore, outboxStore, &stubSigner{err: signErr}, "broker.example.com", 8883, discardLogger)
+	svc := sensors.NewActivationService(db, provStore, outboxStore, &stubSigner{err: signErr}, discardLogger)
 
 	_, err = svc.Activate(ctx, code)
 	if !errors.Is(err, signErr) {

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -274,12 +274,8 @@ type activateRequest struct {
 }
 
 type activateResponse struct {
-	Token        string `json:"token"`
-	DeviceID     string `json:"device_id"`
-	MQTTUsername string `json:"mqtt_username,omitempty"`
-	MQTTPassword string `json:"mqtt_password,omitempty"`
-	MQTTHost     string `json:"mqtt_host,omitempty"`
-	MQTTPort     int    `json:"mqtt_port,omitempty"`
+	Token    string `json:"token"`
+	DeviceID string `json:"device_id"`
 }
 
 func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -303,14 +299,62 @@ func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.Status(r, http.StatusCreated)
+	render.Status(r, http.StatusAccepted)
 	render.JSON(w, r, activateResponse{
-		Token:        result.Token,
-		DeviceID:     result.DeviceID,
-		MQTTUsername: result.MQTTUsername,
-		MQTTPassword: result.MQTTPassword,
-		MQTTHost:     result.MQTTHost,
-		MQTTPort:     result.MQTTPort,
+		Token:    result.Token,
+		DeviceID: result.DeviceID,
+	})
+}
+
+// ActivationStatusHandler handles GET /devices/{id}/status (device JWT auth).
+type ActivationStatusHandler struct {
+	Store    DeviceStore
+	MQTTHost string
+	MQTTPort int
+}
+
+type activationStatusResponse struct {
+	Status       string `json:"status"`
+	MQTTUsername string `json:"mqtt_username,omitempty"`
+	MQTTPassword string `json:"mqtt_password,omitempty"`
+	MQTTHost     string `json:"mqtt_host,omitempty"`
+	MQTTPort     int    `json:"mqtt_port,omitempty"`
+}
+
+func (h *ActivationStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	device, ok := DeviceFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	if deviceID != device.DeviceID {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	status, err := h.Store.GetActivationStatus(r.Context(), deviceID)
+	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			http.Error(w, "device not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if !status.Ready {
+		render.JSON(w, r, activationStatusResponse{Status: "provisioning"})
+		return
+	}
+
+	render.JSON(w, r, activationStatusResponse{
+		Status:       "ready",
+		MQTTUsername: status.MQTTUsername,
+		MQTTPassword: status.MQTTPassword,
+		MQTTHost:     h.MQTTHost,
+		MQTTPort:     h.MQTTPort,
 	})
 }
 

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -420,14 +420,14 @@ func newActivateHandler(t *testing.T, store *stubProvisioningStore, signer *stub
 	t.Helper()
 	db := testutil.NewTestDB(t)
 	return &sensors.ActivateHandler{
-		Service: sensors.NewActivationService(db, store, &stubOutboxStore{}, signer, "broker.example.com", 8883, discardLogger),
+		Service: sensors.NewActivationService(db, store, &stubOutboxStore{}, signer, discardLogger),
 	}
 }
 
 func TestActivateHandler(t *testing.T) {
 	validBody := `{"code":"ABC123"}`
 
-	t.Run("returns 201 with token, device_id and mqtt credentials", func(t *testing.T) {
+	t.Run("returns 202 with token and device_id", func(t *testing.T) {
 		h := newActivateHandler(t,
 			&stubProvisioningStore{claimedDeviceID: "dev-uuid"},
 			&stubSigner{token: "signed.jwt.token"},
@@ -435,8 +435,8 @@ func TestActivateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusCreated {
-			t.Fatalf("expected 201, got %d", rec.Code)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d", rec.Code)
 		}
 		var body map[string]any
 		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
@@ -448,17 +448,8 @@ func TestActivateHandler(t *testing.T) {
 		if body["token"] != "signed.jwt.token" {
 			t.Errorf("expected token=signed.jwt.token, got %v", body["token"])
 		}
-		if body["mqtt_username"] != "dev-uuid" {
-			t.Errorf("expected mqtt_username=dev-uuid, got %v", body["mqtt_username"])
-		}
-		if body["mqtt_password"] == "" {
-			t.Error("expected non-empty mqtt_password")
-		}
-		if body["mqtt_host"] != "broker.example.com" {
-			t.Errorf("expected mqtt_host=broker.example.com, got %v", body["mqtt_host"])
-		}
-		if body["mqtt_port"] != float64(8883) {
-			t.Errorf("expected mqtt_port=8883, got %v", body["mqtt_port"])
+		if _, ok := body["mqtt_username"]; ok {
+			t.Error("mqtt_username should not be present in 202 response")
 		}
 	})
 
@@ -521,6 +512,107 @@ func TestActivateHandler(t *testing.T) {
 		h.ServeHTTP(rec, req)
 		if rec.Code != http.StatusInternalServerError {
 			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+}
+
+// ── ActivationStatusHandler ──────────────────────────────────────────────────
+
+func TestActivationStatusHandler(t *testing.T) {
+	makeReq := func(deviceID string, info sensors.DeviceInfo) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/devices/"+deviceID+"/status", nil)
+		req = withDevice(req, info)
+		req = withChiParam(req, "id", deviceID)
+		return req
+	}
+
+	t.Run("provisioning returns 200 with status=provisioning", func(t *testing.T) {
+		h := &sensors.ActivationStatusHandler{
+			Store:    &stubDeviceStore{},
+			MQTTHost: "mqtt.example.com",
+			MQTTPort: 8883,
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-1", sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["status"] != "provisioning" {
+			t.Errorf("expected status=provisioning, got %v", body["status"])
+		}
+		if _, ok := body["mqtt_username"]; ok {
+			t.Error("mqtt_username should not be present when provisioning")
+		}
+	})
+
+	t.Run("ready returns 200 with credentials", func(t *testing.T) {
+		h := &sensors.ActivationStatusHandler{
+			Store: &stubActivationStatusStore{
+				status: sensors.ActivationStatus{
+					Ready:        true,
+					MQTTUsername: "device-abc",
+					MQTTPassword: "secret-pass",
+				},
+			},
+			MQTTHost: "mqtt.example.com",
+			MQTTPort: 8883,
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-1", sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"}))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["status"] != "ready" {
+			t.Errorf("expected status=ready, got %v", body["status"])
+		}
+		if body["mqtt_username"] != "device-abc" {
+			t.Errorf("expected mqtt_username=device-abc, got %v", body["mqtt_username"])
+		}
+		if body["mqtt_host"] != "mqtt.example.com" {
+			t.Errorf("expected mqtt_host=mqtt.example.com, got %v", body["mqtt_host"])
+		}
+	})
+
+	t.Run("device not found returns 404", func(t *testing.T) {
+		h := &sensors.ActivationStatusHandler{
+			Store: &stubActivationStatusStore{err: sensors.ErrDeviceNotFound},
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, makeReq("dev-x", sensors.DeviceInfo{DeviceID: "dev-x", UserID: "usr-1"}))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("device ID mismatch returns 403", func(t *testing.T) {
+		h := &sensors.ActivationStatusHandler{Store: &stubDeviceStore{}}
+		rec := httptest.NewRecorder()
+		// JWT claims dev-1 but URL param is dev-2
+		req := httptest.NewRequest(http.MethodGet, "/devices/dev-2/status", nil)
+		req = withDevice(req, sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"})
+		req = withChiParam(req, "id", "dev-2")
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", rec.Code)
+		}
+	})
+
+	t.Run("no device in context returns 401", func(t *testing.T) {
+		h := &sensors.ActivationStatusHandler{Store: &stubDeviceStore{}}
+		req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/status", nil)
+		req = withChiParam(req, "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
 		}
 	})
 }

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
-	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -416,20 +416,20 @@ func TestProvisionHandler(t *testing.T) {
 
 // ── ActivateHandler ───────────────────────────────────────────────────────────
 
-func newActivateHandler(store *stubProvisioningStore, mq hivemq.Client, signer *stubSigner) *sensors.ActivateHandler {
+func newActivateHandler(t *testing.T, store *stubProvisioningStore, signer *stubSigner) *sensors.ActivateHandler {
+	t.Helper()
+	db := testutil.NewTestDB(t)
 	return &sensors.ActivateHandler{
-		Service: sensors.NewActivationService(store, mq, signer, "broker.example.com", 8883, discardLogger),
+		Service: sensors.NewActivationService(db, store, &stubOutboxStore{}, signer, "broker.example.com", 8883, discardLogger),
 	}
 }
 
 func TestActivateHandler(t *testing.T) {
 	validBody := `{"code":"ABC123"}`
-	noopHiveMQ := hivemq.NewNoOp()
 
 	t.Run("returns 201 with token, device_id and mqtt credentials", func(t *testing.T) {
-		h := newActivateHandler(
+		h := newActivateHandler(t,
 			&stubProvisioningStore{claimedDeviceID: "dev-uuid"},
-			noopHiveMQ,
 			&stubSigner{token: "signed.jwt.token"},
 		)
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
@@ -462,24 +462,9 @@ func TestActivateHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("hivemq error returns 500", func(t *testing.T) {
-		h := newActivateHandler(
-			&stubProvisioningStore{claimedDeviceID: "dev-uuid"},
-			&stubHiveMQClient{err: errors.New("api down")},
-			&stubSigner{token: "signed.jwt.token"},
-		)
-		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
-	})
-
 	t.Run("signer error returns 500", func(t *testing.T) {
-		h := newActivateHandler(
+		h := newActivateHandler(t,
 			&stubProvisioningStore{claimedDeviceID: "dev-uuid"},
-			noopHiveMQ,
 			&stubSigner{err: errors.New("sign failed")},
 		)
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
@@ -491,7 +476,7 @@ func TestActivateHandler(t *testing.T) {
 	})
 
 	t.Run("missing code returns 400", func(t *testing.T) {
-		h := newActivateHandler(&stubProvisioningStore{}, noopHiveMQ, &stubSigner{})
+		h := newActivateHandler(t, &stubProvisioningStore{}, &stubSigner{})
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(`{}`))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
@@ -501,9 +486,8 @@ func TestActivateHandler(t *testing.T) {
 	})
 
 	t.Run("unknown code returns 404", func(t *testing.T) {
-		h := newActivateHandler(
+		h := newActivateHandler(t,
 			&stubProvisioningStore{claimErr: sensors.ErrCodeNotFound},
-			noopHiveMQ,
 			&stubSigner{},
 		)
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
@@ -515,9 +499,8 @@ func TestActivateHandler(t *testing.T) {
 	})
 
 	t.Run("already used code returns 409", func(t *testing.T) {
-		h := newActivateHandler(
+		h := newActivateHandler(t,
 			&stubProvisioningStore{claimErr: sensors.ErrCodeAlreadyUsed},
-			noopHiveMQ,
 			&stubSigner{},
 		)
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
@@ -529,9 +512,8 @@ func TestActivateHandler(t *testing.T) {
 	})
 
 	t.Run("activate error returns 500", func(t *testing.T) {
-		h := newActivateHandler(
+		h := newActivateHandler(t,
 			&stubProvisioningStore{claimedDeviceID: "dev-uuid", activateErr: errors.New("db down")},
-			noopHiveMQ,
 			&stubSigner{},
 		)
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))

--- a/internal/sensors/outbox_processor.go
+++ b/internal/sensors/outbox_processor.go
@@ -1,0 +1,55 @@
+package sensors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+)
+
+const EventTypeHiveMQProvision = "hivemq.provision_device"
+
+type HiveMQProvisionPayload struct {
+	DeviceID string `json:"device_id"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type HiveMQProvisionProcessor struct {
+	hiveMQ hivemq.Client
+	logger *slog.Logger
+}
+
+func NewHiveMQProvisionProcessor(hiveMQ hivemq.Client, logger *slog.Logger) *HiveMQProvisionProcessor {
+	return &HiveMQProvisionProcessor{hiveMQ: hiveMQ, logger: logger}
+}
+
+func (p *HiveMQProvisionProcessor) EventType() string { return EventTypeHiveMQProvision }
+
+func (p *HiveMQProvisionProcessor) Process(ctx context.Context, event outbox.Event) error {
+	var payload HiveMQProvisionPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal payload: %w", err)
+	}
+
+	err := p.hiveMQ.ProvisionDevice(ctx, payload.Username, payload.Password)
+	if err != nil && isAlreadyExists(err) {
+		p.logger.Info("hivemq provision: credential already exists, treating as success",
+			"device_id", payload.DeviceID)
+		return nil
+	}
+	return err
+}
+
+// isAlreadyExists reports whether the HiveMQ API error indicates the credential
+// already exists (HTTP 409 Conflict).
+func isAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "409")
+}

--- a/internal/sensors/outbox_processor.go
+++ b/internal/sensors/outbox_processor.go
@@ -12,6 +12,7 @@ import (
 )
 
 const EventTypeHiveMQProvision = "hivemq.provision_device"
+const hiveMQProvisionClaimTimeoutSeconds = 30
 
 type HiveMQProvisionPayload struct {
 	DeviceID string `json:"device_id"`

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -12,6 +12,15 @@ type Device struct {
 	CreatedAt time.Time
 }
 
+// ActivationStatus holds the device's MQTT readiness state.
+type ActivationStatus struct {
+	Ready        bool
+	MQTTUsername string
+	MQTTPassword string
+	MQTTHost     string
+	MQTTPort     int
+}
+
 type DeviceStore interface {
 	ListByUserID(ctx context.Context, userID string) ([]Device, error)
 	FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error)
@@ -21,6 +30,10 @@ type DeviceStore interface {
 	// DeleteDevice soft-deletes the device and returns its mqtt_username for cleanup.
 	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.
 	DeleteDevice(ctx context.Context, deviceID, userID string) (mqttUsername string, err error)
+	// GetActivationStatus returns whether the device's MQTT credentials are ready.
+	// Ready = credentials present in DB AND no pending/processing outbox event for the device.
+	// Returns ErrDeviceNotFound if the device does not exist.
+	GetActivationStatus(ctx context.Context, deviceID string) (ActivationStatus, error)
 }
 
 type ProvisioningStore interface {

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -2,6 +2,7 @@ package sensors
 
 import (
 	"context"
+	"database/sql"
 	"time"
 )
 
@@ -28,6 +29,7 @@ type ProvisioningStore interface {
 	// ClaimCode marks the code used, creates a new device row, and returns the device ID and user ID.
 	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
 	ClaimCode(ctx context.Context, code string) (deviceID, userID string, err error)
-	// Activate stores MQTT credentials on the device row.
-	Activate(ctx context.Context, deviceID, mqttUsername, mqttPassword string) error
+	// Activate stores MQTT credentials on the device row within the provided transaction.
+	// The caller owns the transaction boundary.
+	Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error
 }

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -84,7 +84,7 @@ func (s *postgresDeviceStore) GetActivationStatus(ctx context.Context, deviceID 
 				  AND status IN ('pending', 'processing')
 			)
 		FROM devices d
-		WHERE d.id = $1 AND d.deleted_at IS NULL
+		WHERE d.id = $1::uuid AND d.deleted_at IS NULL
 	`, deviceID).Scan(&username, &password, &pendingOutbox)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ActivationStatus{}, ErrDeviceNotFound

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -71,6 +71,37 @@ func (s *postgresDeviceStore) DeleteDevice(ctx context.Context, deviceID, userID
 	return mqttUsername, nil
 }
 
+func (s *postgresDeviceStore) GetActivationStatus(ctx context.Context, deviceID string) (ActivationStatus, error) {
+	var username, password sql.NullString
+	var pendingOutbox bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT
+			d.mqtt_username,
+			d.mqtt_password,
+			EXISTS (
+				SELECT 1 FROM outbox_events
+				WHERE payload->>'device_id' = $1
+				  AND status IN ('pending', 'processing')
+			)
+		FROM devices d
+		WHERE d.id = $1 AND d.deleted_at IS NULL
+	`, deviceID).Scan(&username, &password, &pendingOutbox)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ActivationStatus{}, ErrDeviceNotFound
+	}
+	if err != nil {
+		return ActivationStatus{}, fmt.Errorf("get activation status: %w", err)
+	}
+	if !username.Valid || !password.Valid || pendingOutbox {
+		return ActivationStatus{Ready: false}, nil
+	}
+	return ActivationStatus{
+		Ready:        true,
+		MQTTUsername: username.String,
+		MQTTPassword: password.String,
+	}, nil
+}
+
 func (s *postgresDeviceStore) PatchDevice(ctx context.Context, deviceID, userID, name string) (Device, error) {
 	var d Device
 	err := s.db.QueryRowContext(ctx, `

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -80,7 +80,7 @@ func (s *postgresDeviceStore) GetActivationStatus(ctx context.Context, deviceID 
 			d.mqtt_password,
 			EXISTS (
 				SELECT 1 FROM outbox_events
-				WHERE payload->>'device_id' = $1
+				WHERE payload->>'device_id' = $1::text
 				  AND status IN ('pending', 'processing')
 			)
 		FROM devices d

--- a/internal/sensors/store_provisioning_integration_test.go
+++ b/internal/sensors/store_provisioning_integration_test.go
@@ -130,8 +130,16 @@ func TestActivate_integration(t *testing.T) {
 			t.Fatalf("setup claim: %v", err)
 		}
 
-		if err := store.Activate(ctx, deviceID, "mqtt-user", "mqtt-pass"); err != nil {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		if err := store.Activate(ctx, tx, deviceID, "mqtt-user", "mqtt-pass"); err != nil {
+			tx.Rollback()
 			t.Fatalf("activate: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
 		}
 
 		devices, err := deviceStore.ListByUserID(ctx, userID)

--- a/internal/sensors/store_provisioning_postgres.go
+++ b/internal/sensors/store_provisioning_postgres.go
@@ -111,8 +111,8 @@ func (s *postgresProvisioningStore) ClaimCode(ctx context.Context, code string) 
 	return deviceID, userID, nil
 }
 
-func (s *postgresProvisioningStore) Activate(ctx context.Context, deviceID, mqttUsername, mqttPassword string) error {
-	_, err := s.db.ExecContext(ctx, `
+func (s *postgresProvisioningStore) Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error {
+	_, err := tx.ExecContext(ctx, `
 		UPDATE devices SET mqtt_username = $2, mqtt_password = $3 WHERE id = $1
 	`, deviceID, mqttUsername, mqttPassword)
 	return err

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -2,6 +2,7 @@ package sensors_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
@@ -66,6 +67,90 @@ func TestListByUserID_integration(t *testing.T) {
 		}
 		if len(devices) != 0 {
 			t.Errorf("expected empty slice, got %d devices", len(devices))
+		}
+	})
+}
+
+func TestGetActivationStatus_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewDeviceStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	// helper: insert a device with mqtt credentials and optional outbox event
+	setupDevice := func(t *testing.T, withCreds bool, withPendingOutbox bool) string {
+		t.Helper()
+		var deviceID string
+		err := db.QueryRowContext(ctx,
+			`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+		).Scan(&deviceID)
+		if err != nil {
+			t.Fatalf("insert device: %v", err)
+		}
+		if withCreds {
+			_, err = db.ExecContext(ctx, `
+				UPDATE devices SET mqtt_username='user1', mqtt_password='pass1'
+				WHERE id = $1`, deviceID)
+			if err != nil {
+				t.Fatalf("set mqtt creds: %v", err)
+			}
+		}
+		if withPendingOutbox {
+			_, err = db.ExecContext(ctx, `
+				INSERT INTO outbox_events (event_type, payload, status)
+				VALUES ('hivemq.provision_device', jsonb_build_object('device_id', $1::text), 'pending')`,
+				deviceID)
+			if err != nil {
+				t.Fatalf("insert outbox event: %v", err)
+			}
+		}
+		return deviceID
+	}
+
+	t.Run("ready when credentials present and no pending outbox", func(t *testing.T) {
+		deviceID := setupDevice(t, true, false)
+		status, err := store.GetActivationStatus(ctx, deviceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !status.Ready {
+			t.Error("expected Ready=true")
+		}
+		if status.MQTTUsername != "user1" {
+			t.Errorf("expected mqtt_username=user1, got %q", status.MQTTUsername)
+		}
+		if status.MQTTPassword != "pass1" {
+			t.Errorf("expected mqtt_password=pass1, got %q", status.MQTTPassword)
+		}
+		// mqtt_host is injected at the handler layer from server config, not stored in DB
+	})
+
+	t.Run("not ready when credentials present but outbox pending", func(t *testing.T) {
+		deviceID := setupDevice(t, true, true)
+		status, err := store.GetActivationStatus(ctx, deviceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Ready {
+			t.Error("expected Ready=false while outbox event is pending")
+		}
+	})
+
+	t.Run("not ready when credentials missing", func(t *testing.T) {
+		deviceID := setupDevice(t, false, false)
+		status, err := store.GetActivationStatus(ctx, deviceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Ready {
+			t.Error("expected Ready=false when no mqtt credentials")
+		}
+	})
+
+	t.Run("not found for unknown device id", func(t *testing.T) {
+		_, err := store.GetActivationStatus(ctx, "00000000-0000-0000-0000-000000000000")
+		if !errors.Is(err, sensors.ErrDeviceNotFound) {
+			t.Errorf("expected ErrDeviceNotFound, got %v", err)
 		}
 	})
 }

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -35,6 +35,9 @@ func (s *stubDeviceStore) PatchDevice(_ context.Context, _, _, _ string) (sensor
 func (s *stubDeviceStore) DeleteDevice(_ context.Context, _, _ string) (string, error) {
 	return s.deleteMQTTUser, s.deleteErr
 }
+func (s *stubDeviceStore) GetActivationStatus(_ context.Context, _ string) (sensors.ActivationStatus, error) {
+	return sensors.ActivationStatus{}, nil
+}
 
 // ── ProvisioningStore ─────────────────────────────────────────────────────────
 
@@ -138,6 +141,18 @@ func (s *stubPublisher) Publish(_ context.Context, topic string, payload []byte)
 	s.publishedPayload = payload
 	s.called = true
 	return s.err
+}
+
+// ── ActivationStatusStore ─────────────────────────────────────────────────────
+
+type stubActivationStatusStore struct {
+	stubDeviceStore
+	status sensors.ActivationStatus
+	err    error
+}
+
+func (s *stubActivationStatusStore) GetActivationStatus(_ context.Context, _ string) (sensors.ActivationStatus, error) {
+	return s.status, s.err
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -3,8 +3,11 @@ package sensors_test
 import (
 	"context"
 	"crypto/rsa"
+	"database/sql"
+	"encoding/json"
 	"time"
 
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 )
 
@@ -57,8 +60,30 @@ func (s *stubProvisioningStore) ClaimCode(_ context.Context, _ string) (string, 
 	}
 	return s.claimedDeviceID, uid, s.claimErr
 }
-func (s *stubProvisioningStore) Activate(_ context.Context, _, _, _ string) error {
+func (s *stubProvisioningStore) Activate(_ context.Context, _ *sql.Tx, _, _, _ string) error {
 	return s.activateErr
+}
+
+// ── OutboxStore ───────────────────────────────────────────────────────────────
+
+type stubOutboxStore struct {
+	insertErr error
+}
+
+func (s *stubOutboxStore) ListPending(_ context.Context, _ int) ([]outbox.Event, error) {
+	return nil, nil
+}
+func (s *stubOutboxStore) MarkCompleted(_ context.Context, _ string) error { return nil }
+func (s *stubOutboxStore) RecordFailure(_ context.Context, _ string, _, _ int, _ string) error {
+	return nil
+}
+func (s *stubOutboxStore) Insert(_ context.Context, _ *sql.Tx, _ string, _ any) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	// Validate that payload is JSON-serialisable.
+	_, err := json.Marshal(nil)
+	return err
 }
 
 // ── HiveMQ ────────────────────────────────────────────────────────────────────

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"database/sql"
-	"encoding/json"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
@@ -70,20 +69,15 @@ type stubOutboxStore struct {
 	insertErr error
 }
 
-func (s *stubOutboxStore) ListPending(_ context.Context, _ int) ([]outbox.Event, error) {
+func (s *stubOutboxStore) ClaimBatch(_ context.Context, _ int) ([]outbox.Event, error) {
 	return nil, nil
 }
 func (s *stubOutboxStore) MarkCompleted(_ context.Context, _ string) error { return nil }
 func (s *stubOutboxStore) RecordFailure(_ context.Context, _ string, _, _ int, _ string) error {
 	return nil
 }
-func (s *stubOutboxStore) Insert(_ context.Context, _ *sql.Tx, _ string, _ any) error {
-	if s.insertErr != nil {
-		return s.insertErr
-	}
-	// Validate that payload is JSON-serialisable.
-	_, err := json.Marshal(nil)
-	return err
+func (s *stubOutboxStore) Insert(_ context.Context, _ *sql.Tx, _ string, _ any, _ int) error {
+	return s.insertErr
 }
 
 // ── HiveMQ ────────────────────────────────────────────────────────────────────

--- a/main.go
+++ b/main.go
@@ -215,7 +215,7 @@ func main() {
 	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
 	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
 	provisioningSvc := sensors.NewProvisioningService(provisioningStore, logger)
-	activationSvc := sensors.NewActivationService(db, provisioningStore, outboxStore, deviceSigner, cfg.HiveMQHost, cfg.HiveMQPort, logger)
+	activationSvc := sensors.NewActivationService(db, provisioningStore, outboxStore, deviceSigner, logger)
 
 	// ── Outbox runner ─────────────────────────────────────────────────────────
 	outboxRunner := outbox.NewRunner(
@@ -249,6 +249,11 @@ func main() {
 	r.Group(func(r chi.Router) {
 		r.Use(platform.DeviceAuthenticator(deviceSigner))
 		r.Post("/readings", (&sensors.ReadingsHandler{Service: readingsSvc}).Create)
+		r.Get("/devices/{id}/status", (&sensors.ActivationStatusHandler{
+			Store:    deviceStore,
+			MQTTHost: cfg.HiveMQHost,
+			MQTTPort: cfg.HiveMQPort,
+		}).ServeHTTP)
 	})
 
 	r.Group(func(r chi.Router) {

--- a/main.go
+++ b/main.go
@@ -6,8 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/account"
@@ -16,6 +18,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
 	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 	"github.com/go-chi/chi/v5"
@@ -88,6 +91,9 @@ func loadConfig() config {
 }
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	cfg := loadConfig()
 
 	var logHandler slog.Handler
@@ -150,7 +156,7 @@ func main() {
 	}
 
 	accountStore := account.NewPostgresStore(db)
-	authSvc, err := auth.NewOIDCService(context.Background(), auth.OIDCConfig{
+	authSvc, err := auth.NewOIDCService(ctx, auth.OIDCConfig{
 		Providers:    map[string]string{"google": cfg.GoogleClientID},
 		Store:        auth.NewPostgresStore(db),
 		RefreshStore: auth.NewPostgresRefreshTokenStore(db),
@@ -205,10 +211,23 @@ func main() {
 	// ── Stores & services ─────────────────────────────────────────────────────
 	deviceStore := sensors.NewDeviceStore(db)
 	provisioningStore := sensors.NewProvisioningStore(db)
+	outboxStore := outbox.NewPostgresStore(db)
 	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
 	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
 	provisioningSvc := sensors.NewProvisioningService(provisioningStore, logger)
-	activationSvc := sensors.NewActivationService(provisioningStore, hivemqClient, deviceSigner, cfg.HiveMQHost, cfg.HiveMQPort, logger)
+	activationSvc := sensors.NewActivationService(db, provisioningStore, outboxStore, deviceSigner, cfg.HiveMQHost, cfg.HiveMQPort, logger)
+
+	// ── Outbox runner ─────────────────────────────────────────────────────────
+	outboxRunner := outbox.NewRunner(
+		outboxStore,
+		[]outbox.EventProcessor{
+			sensors.NewHiveMQProvisionProcessor(hivemqClient, logger),
+		},
+		10*time.Second,
+		5,
+		logger,
+	)
+	go outboxRunner.Run(ctx)
 
 	// ── Router ────────────────────────────────────────────────────────────────
 	r := chi.NewRouter()


### PR DESCRIPTION
## Summary

- `POST /devices/activate` no longer calls HiveMQ synchronously — response time drops from seconds to ~1 DB round-trip, fixing ESP32 timeout
- New `internal/outbox` package: generic `EventProcessor` interface, `Store`, and `Runner` — single polling loop, per-type goroutines, sequential within each type
- Events transition `pending → completed` on success, `pending → dead` after max attempts (retained for inspection, excluded from future polls)
- `HiveMQProvisionProcessor` in `internal/sensors` handles `hivemq.provision_device` events; absorbs 409 duplicates as idempotent success
- Activation atomically writes MQTT credentials + outbox event in one transaction — no data loss on crash
- `main.go` wires the outbox runner with a signal-cancellable context for clean shutdown

## Test plan

- [ ] `go test ./internal/sensors/... ./internal/outbox/...` passes
- [ ] Deploy and activate a device — confirm response is fast and MQTT credentials appear in HiveMQ within ~10s
- [ ] Kill server mid-activation, restart — confirm outbox event is retried and eventually completed
- [ ] Force 5 HiveMQ failures — confirm event is marked `dead` in `outbox_events`

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)