### PR TITLE
docs: update all docs to reflect current server state

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,28 +15,9 @@ Health check. No authentication required.
 
 ---
 
-## POST /tokens
-
-> **Deprecated.** Legacy endpoint that creates a device and issues a hex Bearer token. Superseded by the `POST /api/devices/provision` → `POST /devices/activate` flow. Will be removed in a future cleanup (see issue #46).
-
-No request body required.
-
-**Response `201`**
-```json
-{
-  "token":     "b0a1aba84035c6844d739100e3a93f5911f7ecaf82cbf5bbb33306a1509854a5",
-  "device_id": "a1b2c3d4-...",
-  "user_id":   "00000000-0000-0000-0000-000000000001"
-}
-```
-
-**Response `500`** — DB failure
-
----
-
 ## POST /readings
 
-Accepts a SenML temperature reading from an authenticated device.
+Accepts a SenML reading from an authenticated device.
 
 **Headers**
 ```
@@ -57,13 +38,13 @@ Content-Type: application/json
 |---|---|---|
 | `bn` | string | Base name |
 | `bt` | int64 | Base time — Unix UTC timestamp of the reading |
-| `e[0].n` | string | Must be `"temperature"` |
-| `e[0].u` | string | Unit — must be `"Cel"` |
-| `e[0].v` | float | Temperature in Celsius |
+| `e[*].n` | string | Measurement name (e.g. `"temperature"`) |
+| `e[*].u` | string | Unit (e.g. `"Cel"`) |
+| `e[*].v` | float | Measurement value |
 
 **Response `201`** — `{}`
 
-**Response `400`** — malformed JSON, missing `bt`, or no `temperature` entry
+**Response `400`** — malformed JSON, missing `bt`, or empty entries
 
 **Response `401`** — missing or invalid device JWT
 
@@ -166,7 +147,7 @@ Cookie: session=<session-jwt>
 
 ## POST /api/devices/provision
 
-Creates (or returns the existing) pending device for the authenticated user, along with a 6-character pairing code. Idempotent — repeated calls return the same pending device and code until the device is activated.
+Creates (or returns the existing) pending provisioning code for the authenticated user. Idempotent — repeated calls return the same unused code until it is claimed by a device.
 
 **Headers** (one of):
 ```
@@ -179,15 +160,13 @@ No request body required.
 **Response `201`**
 ```json
 {
-  "code":      "A1B2C3",
-  "device_id": "a1b2c3d4-..."
+  "code": "A1B2C3"
 }
 ```
 
 | Field | Description |
 |---|---|
 | `code` | 6-char alphanumeric pairing code. Display this to the user (e.g. QR code or text) so they can enter it on the device captive portal. |
-| `device_id` | UUID of the pending device. |
 
 **Response `401`** — not authenticated
 
@@ -197,7 +176,7 @@ No request body required.
 
 ## POST /devices/activate
 
-Called by the ESP32 after the user enters the pairing code on the captive portal. No session auth required — the code itself is the credential. Marks the device active, kicks off async MQTT credential provisioning via HiveMQ, and issues a signed device JWT.
+Called by the ESP32 after the user enters the pairing code on the captive portal. No session auth required — the code itself is the credential. Creates the device row, enqueues async MQTT credential provisioning via HiveMQ, and issues a signed device JWT.
 
 No auth header required.
 
@@ -218,10 +197,10 @@ No auth header required.
 
 | Field | Description |
 |---|---|
-| `token` | RS256-signed JWT (`sub`=`device_id`, `user_id`, `iss`=`IDP_HOST`, `iat`). The device stores this in NVS and uses it as the `Authorization: Bearer` header for all subsequent requests. Empty string if `DEVICE_JWT_PRIVATE_KEY` is not configured on the server. |
-| `device_id` | UUID of the now-active device. |
+| `token` | RS256-signed JWT. Claims: `sub` (device_id), `user_id`, `iss` (IDP_HOST), `iat`, `exp` (10 years from issuance). The device stores this in NVS and uses it as the `Authorization: Bearer` header for all subsequent requests. Empty string if `DEVICE_JWT_PRIVATE_KEY` is not configured on the server. |
+| `device_id` | UUID of the newly activated device. |
 
-MQTT credentials are provisioned asynchronously. After receiving `202`, the device must poll `GET /devices/{id}/status` until `"status": "ready"` before attempting to connect to the MQTT broker.
+MQTT credentials are provisioned asynchronously via the outbox. After receiving `202`, the device must poll `GET /devices/{id}/status` until `"status": "ready"` before attempting to connect to the MQTT broker.
 
 **Response `400`** — missing or empty `code`
 
@@ -274,7 +253,7 @@ The JWT `sub` must match the `{id}` path parameter.
 
 ## GET /.well-known/jwks.json
 
-Returns the server's public key set in JWK format. Used by HiveMQ to verify device MQTT JWTs. No authentication required.
+Returns the server's public key set in JWK format. Used by HiveMQ to verify device MQTT JWTs. Also includes the session JWT public key. No authentication required.
 
 **Response `200`**
 ```json
@@ -282,7 +261,7 @@ Returns the server's public key set in JWK format. Used by HiveMQ to verify devi
   "keys": [
     {
       "kty": "RSA",
-      "kid": "<DEVICE_JWT_KID>",
+      "kid": "<key-id>",
       "use": "sig",
       "alg": "RS256",
       "n":   "<base64url-encoded modulus>",
@@ -292,25 +271,19 @@ Returns the server's public key set in JWK format. Used by HiveMQ to verify devi
 }
 ```
 
-Returns `{"keys":[]}` if `DEVICE_JWT_PRIVATE_KEY` is not configured.
+Returns `{"keys":[]}` if no keys are configured.
 
 ---
 
 ## GET /api/devices
 
-Returns devices belonging to the authenticated user. Pass `?status=active` (recommended) to exclude pending devices.
+Returns devices belonging to the authenticated user.
 
 **Headers** (one of):
 ```
 Authorization: Bearer <session-jwt>
 Cookie: session=<session-jwt>
 ```
-
-**Query parameters**
-
-| Param | Values | Default | Description |
-|---|---|---|---|
-| `status` | `active`, `pending`, _(empty)_ | _(empty)_ | Filter by device status. Omit to return all devices. |
 
 **Response `200`**
 ```json
@@ -353,9 +326,29 @@ Cookie: session=<session-jwt>
 
 ---
 
+## DELETE /api/devices/{id}
+
+Soft-deletes a device owned by the authenticated user. Sets `deleted_at` on the device row and revokes the device's MQTT credentials in HiveMQ.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Response `204`** — deleted
+
+**Response `401`** — not authenticated
+
+**Response `404`** — device not found or not owned by the authenticated user
+
+**Response `500`** — DB failure
+
+---
+
 ## GET /api/devices/{id}/readings
 
-Returns temperature readings for a device within a time window.
+Returns sensor readings for a device within a time window.
 
 **Headers** (one of):
 ```
@@ -370,6 +363,7 @@ Cookie: session=<session-jwt>
 | `from` | RFC3339 | 24 hours ago | Start of window (inclusive) |
 | `to` | RFC3339 | now | End of window (exclusive) |
 | `window` | string | `"5m"` | InfluxDB aggregation window (passed through to query) |
+| `measurements` | comma-separated strings | _(all)_ | Filter to specific measurement names (e.g. `temperature,ph`) |
 
 **Response `200`**
 ```json
@@ -378,13 +372,51 @@ Cookie: session=<session-jwt>
   "from": "2024-04-12T12:00:00Z",
   "to":   "2024-04-13T12:00:00Z",
   "readings": [
-    {"timestamp": "2024-04-12T12:05:00Z", "temperature": 23.4}
+    {
+      "timestamp": "2024-04-12T12:05:00Z",
+      "values": {"temperature": 23.4}
+    }
   ]
 }
 ```
+
+Each element of `readings` carries a `values` map from measurement name to float value. Multiple measurements per point are supported.
 
 **Response `400`** — invalid `from` or `to` format
 
 **Response `401`** — not authenticated
 
 **Response `404`** — device not found or not owned by the authenticated user
+
+---
+
+## POST /api/devices/{id}/peripherals/{name}/commands
+
+Sends a command to a named peripheral on a device via MQTT. The server publishes to the topic `fishhub/{device_id}/{peripheral_name}/commands`.
+
+**Headers** (one of):
+```
+Authorization: Bearer <session-jwt>
+Cookie: session=<session-jwt>
+```
+
+**Request body**
+```json
+{
+  "action": "set"
+}
+```
+
+| Field | Values | Description |
+|---|---|---|
+| `action` | `"set"` \| `"schedule"` | Command action to send to the peripheral |
+
+**Response `204`** — command published
+
+**Response `400`** — invalid action (must be `"set"` or `"schedule"`)
+
+**Response `401`** — not authenticated
+
+**Response `404`** — device not found or not owned by the authenticated user
+
+**Response `500`** — MQTT publish failure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,19 +9,21 @@ fishhub-server/
 ├── db/
 │   └── migrations/          # SQL migration files (golang-migrate format)
 └── internal/
-    ├── sensors/             # domain: device tokens, readings ingestion + query, InfluxDB, SenML
-    │   ├── handler.go               TokensHandler, ReadingsHandler, ReadingsQueryHandler,
-    │   │                            DevicesHandler, ProvisionHandler, ActivateHandler,
-    │   │                            PatchDeviceHandler
-    │   ├── store.go                 DeviceStore, TokenStore, ProvisioningStore interfaces
+    ├── sensors/             # domain: device provisioning, readings ingestion + query, commands
+    │   ├── handler.go               ReadingsHandler, ReadingsQueryHandler,
+    │   │                            DevicesHandler, DeleteDeviceHandler, PatchDeviceHandler,
+    │   │                            ProvisionHandler, ActivateHandler, ActivationStatusHandler,
+    │   │                            CommandHandler
+    │   ├── service.go               DeviceService, ReadingsService, ProvisioningService,
+    │   │                            ActivationService, HiveMQProvisionProcessor
+    │   ├── store.go                 DeviceStore, ProvisioningStore interfaces
     │   │                            + error sentinels (ErrCodeNotFound, ErrCodeAlreadyUsed,
-    │   │                            ErrDeviceNotFound, ErrTokenNotFound)
-    │   ├── store_postgres.go        DeviceStore + TokenStore Postgres impls (incl. PatchDevice)
+    │   │                            ErrDeviceNotFound, ErrInvalidCommand, ErrInfluxWrite)
+    │   ├── store_postgres.go        DeviceStore Postgres impl
     │   ├── store_provisioning_postgres.go  ProvisioningStore Postgres impl
-    │   │                            (GetOrCreatePending, ClaimCode, Activate)
     │   ├── influx.go                InfluxClient (ReadingWriter + ReadingQuerier), influxDBClient
     │   ├── senml.go                 SenML RFC 8428 parser
-    │   └── model.go                 DeviceInfo, TokenResult, Reading, context helpers
+    │   └── model.go                 DeviceInfo, context helpers
     ├── auth/                # domain: OIDC verification, JWT sessions, refresh token rotation
     │   ├── handler.go               VerifyHandler, RefreshHandler, LogoutHandler
     │   ├── service.go               AuthService interface, oidcService implementation
@@ -34,9 +36,29 @@ fishhub-server/
     │   ├── store_postgres.go        Postgres implementation
     │   ├── model.go                 Account struct
     │   └── events.go                AccountEventHandler (implements auth.UserEventHandler)
-    ├── platform/            # cross-cutting: DB setup, middleware, health
-    │   ├── db.go                    Open(), Migrate(), SeedUser(), SeedUserID()
-    │   └── middleware.go            DeviceAuthenticator(), SessionAuthenticator(), Health()
+    ├── devicejwt/           # device JWT issuance — wraps jwtutil with device-specific claims
+    │   └── devicejwt.go             Signer interface (Sign, PublicKey, KID)
+    │                                deviceSigner (RS256, claims: sub, user_id, iss, iat, exp)
+    │                                NewNoOp() for unconfigured environments
+    ├── jwtutil/             # low-level JWT primitives and JWKS endpoint
+    │   ├── signer.go                Signer interface (Sign, PublicKey, KID)
+    │   │                            rsaSigner — PKCS1 and PKCS8 PEM key support
+    │   │                            NewNoOp() for unconfigured environments
+    │   └── jwks.go                  JWKSHandler — serves GET /.well-known/jwks.json
+    │                                aggregates public keys from one or more Signers
+    ├── mqtt/                # MQTT command publishing
+    │   └── publisher.go             Publisher interface (Publish)
+    │                                pahoPublisher — TLS connection to HiveMQ broker (QoS 1)
+    │                                NewNoOpPublisher() when HIVEMQ_HOST not set
+    ├── hivemq/              # HiveMQ Cloud REST API client
+    │   └── client.go                Client interface (ProvisionDevice, DeleteDevice)
+    │                                apiClient — creates/deletes MQTT credentials + attaches role
+    │                                NewNoOp() when HIVEMQ_API_BASE_URL not set
+    ├── outbox/              # transactional outbox for async side-effects
+    │   ├── outbox.go                Event, EventProcessor interface, Store interface
+    │   ├── runner.go                Runner — polls Store, dispatches to EventProcessors
+    │   │                            one goroutine per event type per tick; sequential within type
+    │   └── store_postgres.go        Store Postgres impl (ClaimBatch with SELECT FOR UPDATE SKIP LOCKED)
     └── testutil/
         └── db.go                    NewTestDB(t) — starts Postgres container, runs migrations
 ```
@@ -46,41 +68,41 @@ fishhub-server/
 ```
 main.go
  ├── platform     — DB connection, migrations, seed, middleware
- ├── sensors      — device tokens, readings ingestion + query (InfluxDB), SenML
+ ├── jwtutil      — low-level JWT signing + JWKS handler
+ ├── devicejwt    — device JWT issuance (wraps jwtutil)
+ ├── sensors      — device provisioning, readings ingestion + query, commands
+ │    └── uses outbox.Store (for activation), hivemq.Client (for delete), mqtt.Publisher (for commands)
  ├── auth         — OIDC verification, JWT + refresh token issuance
- └── account      — account profiles, MeHandler
-      └── implements auth.UserEventHandler (called after OIDC verify)
+ ├── account      — account profiles, MeHandler
+ │    └── implements auth.UserEventHandler (called after OIDC verify)
+ ├── hivemq       — HiveMQ Cloud REST API client
+ ├── mqtt         — MQTT broker publisher
+ └── outbox       — outbox runner + Postgres store
+      └── runs sensors.HiveMQProvisionProcessor as EventProcessor
 ```
 
 ## Design principles
 
-**Dependency injection everywhere.** Handlers receive dependencies as struct fields — no package-level singletons.
+**Dependency injection everywhere.** Handlers and services receive dependencies as struct fields — no package-level singletons.
 
-**Depend on interfaces, not concrete types.** Each handler declares the smallest interface it needs (e.g. `TokenStore`, `DeviceStore`, `ReadingWriter`, `AuthService`). `main.go` is the only wiring point.
+**Depend on interfaces, not concrete types.** Each handler declares the smallest interface it needs (e.g. `DeviceStore`, `ProvisioningStore`, `CommandPublisher`). `main.go` is the only wiring point.
 
-**Domain packages never import each other.** `sensors`, `auth`, and `account` are fully isolated. Cross-domain dependencies use interfaces (e.g. `auth.UserEventHandler` is satisfied by `account.AccountEventHandler`).
+**Domain packages never import each other.** `sensors`, `auth`, and `account` are fully isolated. Cross-domain dependencies use interfaces.
 
 **`platform` may be imported by any domain.** It has no domain knowledge — only DB setup and middleware.
 
 **Context-based auth.** Device auth middleware stores `DeviceInfo` in the request context. Session auth middleware stores `auth.Claims`. Downstream handlers retrieve them without re-querying the DB.
 
+**Noop implementations for optional infrastructure.** `devicejwt`, `jwtutil`, `mqtt`, and `hivemq` all provide a `NewNoOp()` that satisfies the interface but does nothing. This lets the server start without external services configured (e.g. in development without HiveMQ credentials).
+
 ## Request lifecycle
 
-### POST /tokens (no auth)
-```
-TokensHandler.Create
-  └── TokenStore.CreateToken(userID)
-        ├── crypto/rand → 32 bytes → 64-char hex token
-        ├── INSERT INTO devices (user_id)
-        └── INSERT INTO device_tokens (device_id, token)
-  └── 201 {"token":"...","device_id":"...","user_id":"..."}
-```
-
-### POST /readings (device Bearer token)
+### POST /readings (device JWT auth)
 ```
 DeviceAuthenticator middleware
   ├── parse "Bearer <token>" from Authorization header
-  ├── DeviceStore.LookupByToken(token) → JOIN device_tokens + devices
+  ├── validate RS256 JWT signature with devicejwt.Signer.PublicKey()
+  ├── extract sub (device_id) and user_id claims
   ├── 401 if missing/invalid
   └── store DeviceInfo{DeviceID, UserID} in context
 
@@ -91,20 +113,6 @@ ReadingsHandler.Create
   └── InfluxClient.WriteReading(ctx, Reading) → InfluxDB 3 Core
 ```
 
-### GET /api/devices and /api/devices/{id}/readings (session JWT)
-```
-SessionAuthenticator middleware
-  ├── read "Bearer <token>" header OR "session" cookie
-  ├── AuthService.ValidateSessionJWT(token) → userID
-  ├── 401 if missing/invalid
-  └── store Claims{UserID} in context
-
-DevicesHandler.List / ReadingsQueryHandler.List
-  ├── ClaimsFromContext(ctx)
-  ├── DeviceStore.ListByUserID (accepts optional ?status filter) / FindByIDAndUserID
-  └── InfluxClient.QueryReadings (for readings endpoint)
-```
-
 ### POST /api/devices/provision → device pairing (session JWT)
 ```
 SessionAuthenticator middleware
@@ -112,27 +120,96 @@ SessionAuthenticator middleware
 
 ProvisionHandler
   ├── ClaimsFromContext(ctx)
-  └── ProvisioningStore.GetOrCreatePending(ctx, userID)
-        ├── atomic upsert: INSERT INTO devices WHERE NOT EXISTS pending for user
-        ├── INSERT INTO provisioning_codes (code CHAR(6), device_id) ON CONFLICT DO NOTHING
-        └── return (code, device_id)
-  └── 201 {"code":"...","device_id":"..."}
+  └── ProvisioningStore.GetOrCreateCode(ctx, userID)
+        ├── upsert provisioning_codes row for the user (code CHAR(6))
+        └── return code
+  └── 201 {"code":"..."}
 ```
 
-### POST /devices/activate → firmware token issuance (no auth)
+### POST /devices/activate → device creation + JWT issuance (no auth)
 ```
 ActivateHandler
-  ├── decode body {code}
-  ├── 400 if code missing
+  ├── decode body {code}; 400 if missing
   ├── ProvisioningStore.ClaimCode(ctx, code)
   │     ├── UPDATE provisioning_codes SET used_at=now() WHERE code=? AND used_at IS NULL
+  │     ├── INSERT INTO devices (user_id) → deviceID
   │     ├── 404 (ErrCodeNotFound) if no row matched
-  │     └── 409 (ErrCodeAlreadyUsed) if row exists but used_at already set
-  ├── crypto/rand → 32 bytes → 64-char hex Bearer token
-  └── ProvisioningStore.Activate(ctx, deviceID, token)
-        ├── INSERT INTO device_tokens (device_id, token)
-        └── UPDATE devices SET status='active' WHERE id=deviceID
-  └── 201 {"token":"...","device_id":"..."}
+  │     └── 409 (ErrCodeAlreadyUsed) if used_at already set
+  ├── devicejwt.Signer.Sign(deviceID, userID) → RS256 JWT
+  └── ActivationService.activate (within DB transaction):
+        ├── outbox.Store.Insert(tx, "hivemq.provision", payload)
+        └── commit
+  └── 202 {"token":"<jwt>","device_id":"..."}
+```
+
+### Async MQTT provisioning (outbox runner)
+```
+outbox.Runner (background goroutine, polls every 10s)
+  ├── outbox.Store.ClaimBatch() → []Event (SELECT FOR UPDATE SKIP LOCKED)
+  └── for each "hivemq.provision" event:
+        sensors.HiveMQProvisionProcessor.Process(ctx, event)
+          ├── hivemq.Client.ProvisionDevice(username, password)
+          │     ├── POST /mqtt/credentials → create credential
+          │     └── PUT /user/{username}/roles/{roleID}/attach
+          └── DeviceStore writes mqtt_username + mqtt_password to devices row
+        outbox.Store.MarkCompleted(id)
+        (on failure: RecordFailure; after 5 attempts: status='dead')
+```
+
+### GET /devices/{id}/status → activation polling (device JWT auth)
+```
+DeviceAuthenticator middleware
+  └── store DeviceInfo{DeviceID, UserID} in context
+
+ActivationStatusHandler
+  ├── verify JWT sub == {id} path param; 403 if mismatch
+  └── DeviceStore.GetActivationStatus(deviceID)
+        └── ready = mqtt_username + mqtt_password present AND no pending/processing outbox event
+  ├── not ready → 200 {"status":"provisioning"}
+  └── ready     → 200 {"status":"ready","mqtt_username":"...","mqtt_password":"...","mqtt_host":"...","mqtt_port":8883}
+```
+
+### POST /api/devices/{id}/peripherals/{name}/commands → MQTT command (session JWT)
+```
+SessionAuthenticator middleware
+  └── store Claims{UserID} in context
+
+CommandHandler
+  ├── ClaimsFromContext(ctx)
+  ├── read raw JSON body
+  └── DeviceService.SendCommand(ctx, deviceID, userID, peripheralName, body)
+        ├── validate action field ("set" | "schedule"); 400 (ErrInvalidCommand) otherwise
+        ├── DeviceStore.FindByIDAndUserID → 404 if not found
+        └── mqtt.Publisher.Publish(topic="fishhub/{deviceID}/{peripheralName}/commands", payload)
+  └── 204
+```
+
+### DELETE /api/devices/{id} → soft-delete + MQTT credential revocation (session JWT)
+```
+SessionAuthenticator middleware
+  └── store Claims{UserID} in context
+
+DeleteDeviceHandler
+  ├── ClaimsFromContext(ctx)
+  └── DeviceService.Delete(ctx, deviceID, userID)
+        ├── DeviceStore.DeleteDevice(deviceID, userID)
+        │     ├── UPDATE devices SET deleted_at=now() WHERE id=? AND user_id=?
+        │     └── return mqtt_username for cleanup
+        └── hivemq.Client.DeleteDevice(mqttUsername) — best effort
+  └── 204
+```
+
+### GET /api/devices and /api/devices/{id}/readings (session JWT)
+```
+SessionAuthenticator middleware
+  └── store Claims{UserID} in context
+
+DevicesHandler.List / ReadingsQueryHandler.List
+  ├── ClaimsFromContext(ctx)
+  ├── DeviceStore.ListByUserID / FindByIDAndUserID
+  └── InfluxClient.QueryReadings (for readings endpoint)
+        accepts optional ?measurements= filter (comma-separated names)
+        response: readings[].values map[string]float64
 ```
 
 ### PATCH /api/devices/{id} → rename device (session JWT)
@@ -143,9 +220,9 @@ SessionAuthenticator middleware
 PatchDeviceHandler
   ├── ClaimsFromContext(ctx)
   ├── decode body {name}; 400 if empty
-  ├── DeviceStore.PatchDevice(ctx, deviceID, userID, name)
-  │     ├── UPDATE devices SET name=? WHERE id=? AND user_id=?
-  │     └── 404 (ErrDeviceNotFound) if no row matched
+  └── DeviceStore.PatchDevice(ctx, deviceID, userID, name)
+        ├── UPDATE devices SET name=? WHERE id=? AND user_id=?
+        └── 404 (ErrDeviceNotFound) if no row matched
   └── 200 {"id":"...","name":"...","created_at":"..."}
 ```
 
@@ -156,7 +233,7 @@ VerifyHandler
   │     ├── OIDC ID token verification (go-oidc)
   │     ├── UserStore.Upsert(email, provider, sub)
   │     └── UserEventHandler.OnUserVerified → AccountStore.Upsert
-  ├── AuthService.IssueSessionJWT(userID) → signed HS256 JWT
+  ├── AuthService.IssueSessionJWT(userID) → RS256 JWT
   └── AuthService.IssueRefreshToken(ctx, userID) → stored hash, return raw
   └── 200 {"token":"<jwt>","refresh_token":"<64-char-hex>"}
 ```

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,43 +1,68 @@
 # Authentication
 
-FishHub has two separate authentication paths: **device Bearer tokens** (ESP32 → server) and **user session JWTs** (browser → server via the web frontend).
+FishHub has two separate authentication paths: **device JWTs** (ESP32 → server) and **user session JWTs** (browser → server via the web frontend).
 
 ---
 
-## Device Bearer tokens
+## Device JWTs
 
 ### Token lifecycle
 
-There are two paths for a device to obtain a Bearer token:
-
-**Legacy / seed path** — `POST /tokens`. The server creates a device row and generates a cryptographically random 64-char hex token (32 bytes from `crypto/rand`). Copy the token into the ESP32 firmware's `include/config.h` as `DEVICE_TOKEN`. Used for the initial PoC setup.
-
-**Provisioning path** (production flow):
-1. Web user calls `POST /api/devices/provision` (session JWT required) — receives a 6-char pairing `code` and a `device_id`.
+1. Web user calls `POST /api/devices/provision` (session JWT required) — receives a 6-char pairing `code`.
 2. User enters the code on the device captive portal (or transmits it via QR code).
-3. ESP32 calls `POST /devices/activate` with `{ "code": "..." }` (no auth). The server claims the code atomically, generates a 64-char hex Bearer token, activates the device, and returns `{ token, device_id }`.
-4. The firmware stores the token in NVS and sends `Authorization: Bearer <token>` on every `POST /readings`.
+3. ESP32 calls `POST /devices/activate` with `{ "code": "..." }` (no auth). The server claims the code atomically, creates the device row, enqueues async MQTT provisioning, and returns `{ token, device_id }` with `202 Accepted`.
+4. The firmware stores the JWT in NVS and sends `Authorization: Bearer <token>` on every subsequent request (`POST /readings`, `GET /devices/{id}/status`).
 
-For the PoC there is no revocation. Tokens are valid until the `device_tokens` row is deleted.
+### JWT structure
+
+Device JWTs are RS256-signed tokens produced by `devicejwt.Signer` (backed by `jwtutil.Signer`).
+
+**Claims:**
+
+| Claim | Value |
+|---|---|
+| `sub` | Device UUID |
+| `user_id` | Owner user UUID |
+| `iss` | `IDP_HOST` env var |
+| `iat` | Unix timestamp of issuance |
+| `exp` | `iat` + 10 years |
+
+The corresponding public key is served at `GET /.well-known/jwks.json` (alongside the session JWT public key). HiveMQ uses this endpoint to verify device MQTT JWTs.
+
+When `DEVICE_JWT_PRIVATE_KEY` is not configured, `devicejwt.NewNoOp()` is used — `Sign()` returns `""` and `PublicKey()` returns `nil`.
 
 ### `DeviceAuthenticator` middleware (`internal/platform/middleware.go`)
 
-`platform.DeviceAuthenticator(devices sensors.DeviceStore)` returns a chi middleware that:
+`platform.DeviceAuthenticator(signer devicejwt.Signer)` returns a chi middleware that:
 
 1. Reads `Authorization` header, extracts token from `"Bearer <token>"` format
-2. Calls `DeviceStore.LookupByToken(ctx, token)` — a JOIN of `device_tokens + devices`
-3. On success, stores `sensors.DeviceInfo{DeviceID, UserID}` in the request context via `sensors.DeviceContextKey`
-4. Returns `401` if header is missing, malformed, or token unknown
-5. Returns `500` on unexpected DB error
+2. Validates the token as an RS256 JWT using `signer.PublicKey()` — no database lookup
+3. Extracts `sub` (device_id) and `user_id` claims from the validated JWT
+4. On success, stores `sensors.DeviceInfo{DeviceID, UserID}` in the request context via `sensors.DeviceContextKey`
+5. Returns `401` if the header is missing, the token is malformed, the signature is invalid, or required claims are absent
 
 Downstream handlers retrieve it with:
 ```go
 device, ok := sensors.DeviceFromContext(r.Context())
 ```
 
-### Token storage
+There is no revocation mechanism — a device JWT is valid until its `exp` claim (10 years from issuance). To invalidate a device, soft-delete it; the `DeviceStore` excludes soft-deleted devices from all lookups.
 
-Tokens are stored as **plaintext** `CHAR(64)` in `device_tokens`. Acceptable for local-network PoC. Issue #6 evaluates hashing or JWT alternatives.
+---
+
+## MQTT credentials
+
+MQTT credentials (`mqtt_username`, `mqtt_password`) are distinct from the device JWT. They are used to authenticate the device directly to the HiveMQ broker over TLS.
+
+### Lifecycle
+
+1. `POST /devices/activate` inserts a `hivemq.provision` event into `outbox_events` (within the same DB transaction as the device row creation).
+2. The outbox runner picks up the event and calls `hivemq.Client.ProvisionDevice(username, password)`:
+   - `POST /mqtt/credentials` on the HiveMQ Cloud REST API
+   - `PUT /user/{username}/roles/{roleID}/attach` to grant the device role
+3. On success, `mqtt_username` and `mqtt_password` are written to the `devices` row.
+4. `GET /devices/{id}/status` returns `"status": "ready"` with the credentials once the device row has non-null values and no pending/processing outbox event exists for the device.
+5. `DELETE /api/devices/{id}` calls `hivemq.Client.DeleteDevice(mqttUsername)` (best effort) to revoke the credentials in HiveMQ.
 
 ---
 
@@ -85,7 +110,7 @@ Implemented by `oidcService`. Configured via `auth.NewOIDCService(ctx, OIDCConfi
 
 **`VerifyAndUpsert`** — verifies the ID token with the OIDC provider (go-oidc library), upserts the user row, then calls `UserEventHandler.OnUserVerified` (implemented by `account.AccountEventHandler`, which upserts the account row with name/email from ID token claims).
 
-**Session JWT** — RS256, signed with a dedicated RSA private key (`SESSION_JWT_PRIVATE_KEY`). Claims: `sub` (user UUID), `iat`, `exp`. Default TTL: 24h (configurable via `JWT_TTL_HOURS`). The corresponding public key is served at `GET /.well-known/jwks.json` alongside the device JWT public key.
+**Session JWT** — RS256, signed with a dedicated RSA private key (`SESSION_JWT_PRIVATE_KEY`). Claims: `sub` (user UUID), `iat`, `exp`. Default TTL: 24h (configurable via `JWT_TTL_HOURS`). The corresponding public key is included in `GET /.well-known/jwks.json`.
 
 **Refresh tokens** — 64-char raw hex token; stored as SHA-256 hash in `refresh_tokens`. TTL: 30 days. Rotation: every `RotateRefreshToken` call revokes the old token and issues a new one.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,6 +1,6 @@
 # Database
 
-FishHub uses **PostgreSQL** for application data (users, devices, tokens, accounts, refresh tokens) and **InfluxDB 3 Core** for time-series sensor readings.
+FishHub uses **PostgreSQL** for application data (users, devices, accounts, refresh tokens, outbox events) and **InfluxDB 3 Core** for time-series sensor readings.
 
 ## Schema
 
@@ -21,37 +21,29 @@ Stores one row per identity. The `provider`/`provider_sub` pair identifies the O
 ### `devices`
 ```
 devices
-├── id          UUID  PK  default gen_random_uuid()
-├── user_id     UUID  FK → users.id  NOT NULL
-├── name        TEXT  (nullable)
-├── status      TEXT  NOT NULL  default 'pending'  -- 'pending' | 'active'
-└── created_at  TIMESTAMPTZ  default now()
+├── id             UUID  PK  default gen_random_uuid()
+├── user_id        UUID  FK → users.id  NOT NULL
+├── name           TEXT  (nullable)
+├── mqtt_username  TEXT  (nullable)
+├── mqtt_password  TEXT  (nullable)
+├── deleted_at     TIMESTAMPTZ  (nullable)
+└── created_at     TIMESTAMPTZ  default now()
 ```
 
-A device starts as `pending` when created via `POST /api/devices/provision`. It transitions to `active` when the ESP32 claims the pairing code via `POST /devices/activate`.
-
-### `device_tokens`
-```
-device_tokens
-├── id          UUID  PK  default gen_random_uuid()
-├── device_id   UUID  FK → devices.id  UNIQUE NOT NULL
-├── token       CHAR(64)  UNIQUE NOT NULL
-└── created_at  TIMESTAMPTZ  default now()
-```
-
-One token per device (enforced by UNIQUE on `device_id`). Tokens are stored as plaintext 64-char hex strings.
+A device row is created when the ESP32 claims a pairing code via `POST /devices/activate`. `mqtt_username` and `mqtt_password` are populated asynchronously by the outbox runner after HiveMQ provisioning completes. `deleted_at` is set on soft-delete; soft-deleted devices are excluded from all queries.
 
 ### `provisioning_codes`
 ```
 provisioning_codes
 ├── id         UUID  PK  default gen_random_uuid()
 ├── code       CHAR(6)  UNIQUE NOT NULL
-├── device_id  UUID  FK → devices.id  NOT NULL
+├── user_id    UUID  FK → users.id  NOT NULL
+├── device_id  UUID  (nullable)
 ├── used_at    TIMESTAMPTZ  (nullable)
 └── created_at TIMESTAMPTZ  default now()
 ```
 
-Created alongside the pending device in `POST /api/devices/provision`. The `code` is a 6-character alphanumeric string displayed to the user (e.g. as a QR code) so they can enter it on the device captive portal. `used_at` is set atomically by `ProvisioningStore.ClaimCode` — the `WHERE used_at IS NULL` guard makes the claim race-safe. Once claimed the device is activated and the code cannot be reused.
+Created when a web user calls `POST /api/devices/provision`. `device_id` is null until the code is claimed — the device row does not exist yet at provisioning time. `used_at` is set atomically when the ESP32 calls `POST /devices/activate`; the `WHERE used_at IS NULL` guard makes the claim race-safe. Once claimed the code cannot be reused.
 
 ### `refresh_tokens`
 ```
@@ -75,19 +67,39 @@ accounts
 ├── user_id     UUID  UNIQUE NOT NULL
 ├── email       TEXT  NOT NULL
 ├── name        TEXT  NOT NULL  default ''
-└── created_at  TIMESTAMPTZ  NOT NULL  default now()
+├── created_at  TIMESTAMPTZ  NOT NULL  default now()
 └── updated_at  TIMESTAMPTZ  NOT NULL  default now()
 ```
 
 Created/updated automatically via `account.AccountEventHandler.OnUserVerified` on every successful OIDC login. Stores the display name from the ID token claims.
 
+### `outbox_events`
+```
+outbox_events
+├── id                    UUID  PK  default gen_random_uuid()
+├── event_type            TEXT  NOT NULL
+├── payload               JSONB  NOT NULL
+├── status                TEXT  NOT NULL  default 'pending'  -- 'pending' | 'processing' | 'completed' | 'dead'
+├── created_at            TIMESTAMPTZ  NOT NULL  default now()
+├── claimed_at            TIMESTAMPTZ  (nullable)
+├── claim_timeout_seconds INT  NOT NULL  default 300
+├── attempts              INT  NOT NULL  default 0
+└── last_error            TEXT  (nullable)
+
+INDEX outbox_events_claimable ON (event_type, created_at)
+  WHERE status = 'pending' OR status = 'processing'
+```
+
+Stores pending side-effects that must be processed asynchronously. Currently used for HiveMQ device provisioning: after `POST /devices/activate`, an event of type `hivemq.provision` is inserted here. The outbox runner polls this table, calls the HiveMQ REST API, and writes `mqtt_username` / `mqtt_password` back to the `devices` row on success. Events that fail `maxAttempts` times (default: 5) are moved to status `'dead'`.
+
 ## Relationships
 
 ```
-users ──< devices ──< device_tokens
-               └──< provisioning_codes
-users ──< refresh_tokens
-users ──  accounts  (1:1 via user_id UNIQUE)
+users ──< devices
+      └──< provisioning_codes
+      └──< refresh_tokens
+      └──  accounts  (1:1 via user_id UNIQUE)
+outbox_events  (standalone — no FK; device referenced via payload)
 ```
 
 ## Migrations
@@ -109,8 +121,14 @@ They run automatically on server startup via `platform.Migrate()`. Current migra
 | 004 | Add `provider` + `provider_sub` columns to `users` |
 | 005 | Create `refresh_tokens` table |
 | 006 | Create `accounts` table |
-| 007 | Add `status` column to `devices` table (`pending` \| `active`, default `pending`) |
+| 007 | Add `status` column to `devices` |
 | 008 | Create `provisioning_codes` table |
+| 009 | Drop `device_tokens` table |
+| 010 | Add `mqtt_username`, `mqtt_password` columns to `devices` |
+| 011 | Add `deleted_at` column to `devices` |
+| 012 | Make `provisioning_codes.device_id` nullable; add `user_id` column |
+| 013 | Drop `status` column from `devices` |
+| 014 | Create `outbox_events` table |
 
 To add a migration, create the next numbered `.up.sql` / `.down.sql` pair in `db/migrations/`. Migrations run on the next server startup.
 
@@ -124,8 +142,6 @@ To add a migration, create the next numbered `.up.sql` / `.down.sql` pair in `db
 | `email` | `admin@fishhub.local` |
 | `provider` | `local` |
 | `provider_sub` | `seed` |
-
-Tokens created via `POST /tokens` are always owned by this user. No registration flow needed for the device side of the PoC.
 
 ## Connection
 
@@ -148,6 +164,6 @@ Time-series readings are written to InfluxDB 3 Core. The `sensors` measurement u
 
 | Field | Value |
 |---|---|
-| `temperature` | float (Celsius) |
+| _(measurement name)_ | float — one field per named measurement in the SenML payload (e.g. `temperature`) |
 
 The server writes one point per `POST /readings` request and queries via raw SQL in `ReadingsQueryHandler`. Connection is configured via environment variables (see [development.md](development.md)).


### PR DESCRIPTION
## Summary

- **`api.md`**: removed `POST /tokens` (deleted endpoint); fixed `POST /api/devices/provision` response (no `device_id` field); updated `POST /devices/activate` to document RS256 JWT with `exp` claim and async MQTT provisioning; updated `GET /api/devices/{id}/readings` with `?measurements=` param and `values` map response shape; added `DELETE /api/devices/{id}` and `POST /api/devices/{id}/peripherals/{name}/commands`
- **`database.md`**: removed `device_tokens` table; updated `devices` schema (added `mqtt_username`, `mqtt_password`, `deleted_at`; removed `status`); updated `provisioning_codes` (nullable `device_id`, new `user_id` column); added `outbox_events` table; documented migrations 009–014
- **`architecture.md`**: added `devicejwt`, `jwtutil`, `mqtt`, `hivemq`, `outbox` packages to the layout and dependency graph; rewrote `DeviceAuthenticator` lifecycle (JWT validation, no DB lookup); added request lifecycle sections for all new/changed endpoints; documented the async outbox provisioning flow
- **`auth.md`**: replaced legacy hex Bearer token section with device JWT documentation (RS256, claims, 10-year exp, no revocation); documented MQTT credential lifecycle (outbox → HiveMQ → `devices` row); kept session JWT section intact

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)