### PR TITLE
Peripheral model, schedule storage, and MQTT push

### DIFF
--- a/db/migrations/015_create_peripherals.down.sql
+++ b/db/migrations/015_create_peripherals.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS peripherals;

--- a/db/migrations/015_create_peripherals.up.sql
+++ b/db/migrations/015_create_peripherals.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE peripherals (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id  UUID        NOT NULL REFERENCES devices(id),
+    name       TEXT        NOT NULL,
+    kind       TEXT        NOT NULL,
+    pin        INT         NOT NULL,
+    schedule   JSONB,
+    deleted_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX peripherals_device_name_active_idx
+    ON peripherals (device_id, name)
+    WHERE deleted_at IS NULL;

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -13,6 +13,8 @@ import (
 // Publisher publishes a payload to an MQTT topic.
 type Publisher interface {
 	Publish(ctx context.Context, topic string, payload []byte) error
+	// PublishRetained publishes with the MQTT retain flag set.
+	PublishRetained(ctx context.Context, topic string, payload []byte) error
 }
 
 type pahoPublisher struct {
@@ -54,7 +56,15 @@ func NewPublisher(host string, port int, username, password string, logger *slog
 }
 
 func (p *pahoPublisher) Publish(_ context.Context, topic string, payload []byte) error {
-	token := p.client.Publish(topic, 1, false, payload)
+	return p.publish(topic, false, payload)
+}
+
+func (p *pahoPublisher) PublishRetained(_ context.Context, topic string, payload []byte) error {
+	return p.publish(topic, true, payload)
+}
+
+func (p *pahoPublisher) publish(topic string, retain bool, payload []byte) error {
+	token := p.client.Publish(topic, 1, retain, payload)
 	if !token.WaitTimeout(10 * time.Second) {
 		return fmt.Errorf("mqtt: publish timeout")
 	}
@@ -67,5 +77,6 @@ func (p *pahoPublisher) Publish(_ context.Context, topic string, payload []byte)
 // noopPublisher is returned when HIVEMQ_HOST is not configured.
 type noopPublisher struct{}
 
-func NewNoOpPublisher() Publisher                                              { return &noopPublisher{} }
-func (n *noopPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+func NewNoOpPublisher() Publisher                                                      { return &noopPublisher{} }
+func (n *noopPublisher) Publish(_ context.Context, _ string, _ []byte) error         { return nil }
+func (n *noopPublisher) PublishRetained(_ context.Context, _ string, _ []byte) error { return nil }

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -363,6 +363,170 @@ type CommandPublisher interface {
 	Publish(ctx context.Context, topic string, payload []byte) error
 }
 
+type PeripheralResponse struct {
+	ID        string           `json:"id"`
+	DeviceID  string           `json:"device_id"`
+	Name      string           `json:"name"`
+	Kind      string           `json:"kind"`
+	Pin       int              `json:"pin"`
+	Schedule  []ScheduleWindow `json:"schedule"`
+	CreatedAt string           `json:"created_at"`
+	UpdatedAt string           `json:"updated_at"`
+}
+
+func peripheralResponse(p Peripheral) PeripheralResponse {
+	schedule := p.Schedule
+	if schedule == nil {
+		schedule = []ScheduleWindow{}
+	}
+	return PeripheralResponse{
+		ID:        p.ID,
+		DeviceID:  p.DeviceID,
+		Name:      p.Name,
+		Kind:      p.Kind,
+		Pin:       p.Pin,
+		Schedule:  schedule,
+		CreatedAt: p.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt: p.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// CreatePeripheralHandler handles POST /api/devices/{id}/peripherals (session auth).
+type CreatePeripheralHandler struct {
+	Service *PeripheralService
+}
+
+type createPeripheralRequest struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	Pin  int    `json:"pin"`
+}
+
+func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req createPeripheralRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" || req.Kind == "" {
+		http.Error(w, "name and kind are required", http.StatusBadRequest)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Pin)
+	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrPeripheralAlreadyExists) {
+			http.Error(w, "peripheral already exists", http.StatusConflict)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, peripheralResponse(p))
+}
+
+// ListPeripheralsHandler handles GET /api/devices/{id}/peripherals (session auth).
+type ListPeripheralsHandler struct {
+	Service *PeripheralService
+}
+
+func (h *ListPeripheralsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	peripherals, err := h.Service.List(r.Context(), deviceID, claims.UserID)
+	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]PeripheralResponse, len(peripherals))
+	for i, p := range peripherals {
+		resp[i] = peripheralResponse(p)
+	}
+	render.JSON(w, r, resp)
+}
+
+// SetPeripheralScheduleHandler handles PUT /api/devices/{id}/peripherals/{name}/schedule (session auth).
+type SetPeripheralScheduleHandler struct {
+	Service *PeripheralService
+}
+
+func (h *SetPeripheralScheduleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var schedule []ScheduleWindow
+	if err := render.DecodeJSON(r.Body, &schedule); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	p, err := h.Service.SetSchedule(r.Context(), deviceID, claims.UserID, name, schedule)
+	if err != nil {
+		if errors.Is(err, ErrPeripheralNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, peripheralResponse(p))
+}
+
+// DeletePeripheralHandler handles DELETE /api/devices/{id}/peripherals/{name} (session auth).
+type DeletePeripheralHandler struct {
+	Service *PeripheralService
+}
+
+func (h *DeletePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	if err := h.Service.Delete(r.Context(), deviceID, claims.UserID, name); err != nil {
+		if errors.Is(err, ErrPeripheralNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // CommandHandler handles POST /api/devices/{id}/peripherals/{name}/commands (session auth).
 type CommandHandler struct {
 	Service *DeviceService

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -453,10 +453,6 @@ func (h *ListPeripheralsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	deviceID := chi.URLParam(r, "id")
 	peripherals, err := h.Service.List(r.Context(), deviceID, claims.UserID)
 	if err != nil {
-		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
-			return
-		}
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -3,13 +3,34 @@ package sensors
 import (
 	"context"
 	"errors"
+	"time"
 )
 
-var ErrDeviceNotFound  = errors.New("device not found")
-var ErrCodeNotFound    = errors.New("provisioning code not found")
-var ErrCodeAlreadyUsed = errors.New("provisioning code already used")
-var ErrInvalidCommand  = errors.New("action must be 'set' or 'schedule'")
-var ErrInfluxWrite     = errors.New("failed to persist reading")
+type Peripheral struct {
+	ID        string
+	DeviceID  string
+	Name      string
+	Kind      string
+	Pin       int
+	Schedule  []ScheduleWindow
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type ScheduleWindow struct {
+	From  string  `json:"from"`
+	To    string  `json:"to"`
+	Value float64 `json:"value"`
+	Days  []int   `json:"days,omitempty"`
+}
+
+var ErrDeviceNotFound          = errors.New("device not found")
+var ErrCodeNotFound            = errors.New("provisioning code not found")
+var ErrCodeAlreadyUsed         = errors.New("provisioning code already used")
+var ErrInvalidCommand          = errors.New("action must be 'set' or 'schedule'")
+var ErrInfluxWrite             = errors.New("failed to persist reading")
+var ErrPeripheralNotFound      = errors.New("peripheral not found")
+var ErrPeripheralAlreadyExists = errors.New("peripheral already exists")
 
 type DeviceInfo struct {
 	DeviceID string

--- a/internal/sensors/outbox_processor.go
+++ b/internal/sensors/outbox_processor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
+	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 )
 
@@ -53,4 +54,46 @@ func isAlreadyExists(err error) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), "409")
+}
+
+const EventTypePeripheralPush = "peripheral.push"
+const peripheralPushClaimTimeoutSeconds = 30
+
+type PeripheralPushPayload struct {
+	DeviceID string `json:"device_id"`
+	Name     string `json:"name"`
+	Op       string `json:"op"` // "create" or "delete"
+	Kind     string `json:"kind,omitempty"`
+	Pin      int    `json:"pin,omitempty"`
+}
+
+// PeripheralPushProcessor publishes peripheral config to the firmware via retained MQTT.
+type PeripheralPushProcessor struct {
+	publisher mqtt.Publisher
+	logger    *slog.Logger
+}
+
+func NewPeripheralPushProcessor(publisher mqtt.Publisher, logger *slog.Logger) *PeripheralPushProcessor {
+	return &PeripheralPushProcessor{publisher: publisher, logger: logger}
+}
+
+func (p *PeripheralPushProcessor) EventType() string { return EventTypePeripheralPush }
+
+func (p *PeripheralPushProcessor) Process(ctx context.Context, event outbox.Event) error {
+	var payload PeripheralPushPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal payload: %w", err)
+	}
+
+	msg, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal mqtt message: %w", err)
+	}
+
+	topic := fmt.Sprintf("fishhub/%s/peripherals/%s", payload.DeviceID, payload.Name)
+	if err := p.publisher.PublishRetained(ctx, topic, msg); err != nil {
+		p.logger.Error("peripheral push: mqtt publish", "device_id", payload.DeviceID, "name", payload.Name, "error", err)
+		return fmt.Errorf("mqtt publish: %w", err)
+	}
+	return nil
 }

--- a/internal/sensors/outbox_processor_test.go
+++ b/internal/sensors/outbox_processor_test.go
@@ -1,0 +1,81 @@
+package sensors_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+)
+
+func TestPeripheralPushProcessor_create(t *testing.T) {
+	pub := &stubPublisher{}
+	proc := sensors.NewPeripheralPushProcessor(pub, discardLogger)
+
+	payload, _ := json.Marshal(sensors.PeripheralPushPayload{
+		DeviceID: "dev-1",
+		Name:     "light",
+		Op:       "create",
+		Kind:     "relay",
+		Pin:      5,
+	})
+
+	if err := proc.Process(context.Background(), outbox.Event{Payload: payload}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pub.called {
+		t.Fatal("expected publisher to be called")
+	}
+	wantTopic := "fishhub/dev-1/peripherals/light"
+	if pub.publishedTopic != wantTopic {
+		t.Errorf("expected topic %q, got %q", wantTopic, pub.publishedTopic)
+	}
+	var msg sensors.PeripheralPushPayload
+	if err := json.Unmarshal(pub.publishedPayload, &msg); err != nil {
+		t.Fatalf("unmarshal published payload: %v", err)
+	}
+	if msg.Op != "create" || msg.Kind != "relay" || msg.Pin != 5 {
+		t.Errorf("unexpected published payload: %+v", msg)
+	}
+}
+
+func TestPeripheralPushProcessor_delete(t *testing.T) {
+	pub := &stubPublisher{}
+	proc := sensors.NewPeripheralPushProcessor(pub, discardLogger)
+
+	payload, _ := json.Marshal(sensors.PeripheralPushPayload{
+		DeviceID: "dev-1",
+		Name:     "light",
+		Op:       "delete",
+	})
+
+	if err := proc.Process(context.Background(), outbox.Event{Payload: payload}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var msg sensors.PeripheralPushPayload
+	if err := json.Unmarshal(pub.publishedPayload, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Op != "delete" {
+		t.Errorf("expected op 'delete', got %q", msg.Op)
+	}
+}
+
+func TestPeripheralPushProcessor_publishError(t *testing.T) {
+	pub := &stubPublisher{err: errSentinel}
+	proc := sensors.NewPeripheralPushProcessor(pub, discardLogger)
+
+	payload, _ := json.Marshal(sensors.PeripheralPushPayload{DeviceID: "d", Name: "n", Op: "create"})
+	err := proc.Process(context.Background(), outbox.Event{Payload: payload})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestPeripheralPushProcessor_eventType(t *testing.T) {
+	proc := sensors.NewPeripheralPushProcessor(&stubPublisher{}, discardLogger)
+	if proc.EventType() != sensors.EventTypePeripheralPush {
+		t.Errorf("unexpected event type: %q", proc.EventType())
+	}
+}

--- a/internal/sensors/peripheral_handler_test.go
+++ b/internal/sensors/peripheral_handler_test.go
@@ -1,0 +1,257 @@
+package sensors_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+)
+
+func newPeripheral(name string) sensors.Peripheral {
+	return sensors.Peripheral{
+		ID:        "pid-1",
+		DeviceID:  "dev-1",
+		Name:      name,
+		Kind:      "relay",
+		Pin:       5,
+		Schedule:  nil,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+// ── ListPeripheralsHandler ────────────────────────────────────────────────────
+
+func TestListPeripheralsHandler(t *testing.T) {
+	t.Run("returns 200 with peripheral list", func(t *testing.T) {
+		store := &stubPeripheralStore{listed: []sensors.Peripheral{newPeripheral("light")}}
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.ListPeripheralsHandler{Service: svc}
+
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			"id", "dev-1",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp []map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp) != 1 || resp[0]["name"] != "light" {
+			t.Errorf("unexpected response: %v", resp)
+		}
+	})
+
+	t.Run("device not found returns 404", func(t *testing.T) {
+		store := &stubPeripheralStore{listErr: sensors.ErrDeviceNotFound}
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.ListPeripheralsHandler{Service: svc}
+
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			"id", "dev-1",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("no auth returns 401", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.ListPeripheralsHandler{Service: svc}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+}
+
+// ── SetPeripheralScheduleHandler ─────────────────────────────────────────────
+
+func TestSetPeripheralScheduleHandler(t *testing.T) {
+	schedule := `[{"from":"08:00","to":"18:00","value":1.0}]`
+
+	t.Run("returns 200 with updated peripheral", func(t *testing.T) {
+		p := newPeripheral("light")
+		p.Schedule = []sensors.ScheduleWindow{{From: "08:00", To: "18:00", Value: 1.0}}
+		store := &stubPeripheralStore{scheduled: p}
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetPeripheralScheduleHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(schedule)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "light"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["name"] != "light" {
+			t.Errorf("unexpected name: %v", resp["name"])
+		}
+	})
+
+	t.Run("peripheral not found returns 404", func(t *testing.T) {
+		store := &stubPeripheralStore{schedErr: sensors.ErrPeripheralNotFound}
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetPeripheralScheduleHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(schedule)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "ghost"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("invalid body returns 400", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetPeripheralScheduleHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPut, "/", strings.NewReader("not json")), "user-1"),
+			map[string]string{"id": "dev-1", "name": "light"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+}
+
+// ── CreatePeripheralHandler ───────────────────────────────────────────────────
+
+func TestCreatePeripheralHandler(t *testing.T) {
+	t.Run("invalid body returns 400", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.CreatePeripheralHandler{Service: svc}
+
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json")), "user-1"),
+			"id", "dev-1",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("missing name returns 400", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.CreatePeripheralHandler{Service: svc}
+
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"kind":"relay","pin":5}`)), "user-1"),
+			"id", "dev-1",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("no auth returns 401", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.CreatePeripheralHandler{Service: svc}
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("already exists returns 409", func(t *testing.T) {
+		db := testutil.NewTestDB(t)
+		store := &stubPeripheralStore{createErr: sensors.ErrPeripheralAlreadyExists}
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.CreatePeripheralHandler{Service: svc}
+
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`)), "user-1"),
+			"id", "dev-1",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusConflict {
+			t.Errorf("expected 409, got %d", rec.Code)
+		}
+	})
+
+	t.Run("device not found returns 404", func(t *testing.T) {
+		db := testutil.NewTestDB(t)
+		store := &stubPeripheralStore{createErr: sensors.ErrDeviceNotFound}
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.CreatePeripheralHandler{Service: svc}
+
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`)), "user-1"),
+			"id", "dev-x",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+}
+
+// ── DeletePeripheralHandler ───────────────────────────────────────────────────
+
+func TestDeletePeripheralHandler(t *testing.T) {
+	t.Run("no auth returns 401", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.DeletePeripheralHandler{Service: svc}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/", nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("peripheral not found returns 404", func(t *testing.T) {
+		db := testutil.NewTestDB(t)
+		store := &stubPeripheralStore{deleteErr: sensors.ErrPeripheralNotFound}
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.DeletePeripheralHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodDelete, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "name": "ghost"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+}
+

--- a/internal/sensors/peripheral_handler_test.go
+++ b/internal/sensors/peripheral_handler_test.go
@@ -52,20 +52,27 @@ func TestListPeripheralsHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("device not found returns 404", func(t *testing.T) {
-		store := &stubPeripheralStore{listErr: sensors.ErrDeviceNotFound}
+	t.Run("unknown device returns 200 with empty list", func(t *testing.T) {
+		store := &stubPeripheralStore{listed: []sensors.Peripheral{}}
 		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
 		h := &sensors.ListPeripheralsHandler{Service: svc}
 
 		req := withChiParam(
 			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
-			"id", "dev-1",
+			"id", "unknown-device",
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+		var resp []any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp) != 0 {
+			t.Errorf("expected empty list, got %v", resp)
 		}
 	})
 

--- a/internal/sensors/peripheral_service.go
+++ b/internal/sensors/peripheral_service.go
@@ -1,0 +1,144 @@
+package sensors
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+)
+
+// PeripheralService orchestrates peripheral registration, listing, schedule updates, and deletion.
+type PeripheralService struct {
+	db        *sql.DB
+	store     PeripheralStore
+	outbox    outbox.Store
+	publisher mqtt.Publisher
+	logger    *slog.Logger
+}
+
+func NewPeripheralService(
+	db *sql.DB,
+	store PeripheralStore,
+	outboxStore outbox.Store,
+	publisher mqtt.Publisher,
+	logger *slog.Logger,
+) *PeripheralService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PeripheralService{
+		db:        db,
+		store:     store,
+		outbox:    outboxStore,
+		publisher: publisher,
+		logger:    logger,
+	}
+}
+
+// Register creates a new peripheral and enqueues a peripheral.push outbox event atomically.
+func (s *PeripheralService) Register(ctx context.Context, deviceID, userID, name, kind string, pin int) (Peripheral, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("register peripheral: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, pin)
+	if err != nil {
+		if !errors.Is(err, ErrDeviceNotFound) && !errors.Is(err, ErrPeripheralAlreadyExists) {
+			s.logger.Error("register peripheral: create", "device_id", deviceID, "name", name, "error", err)
+		}
+		return Peripheral{}, err
+	}
+
+	if err := s.outbox.Insert(ctx, tx, EventTypePeripheralPush, PeripheralPushPayload{
+		DeviceID: deviceID,
+		Name:     name,
+		Op:       "create",
+		Kind:     kind,
+		Pin:      pin,
+	}, peripheralPushClaimTimeoutSeconds); err != nil {
+		s.logger.Error("register peripheral: enqueue push", "device_id", deviceID, "name", name, "error", err)
+		return Peripheral{}, fmt.Errorf("register peripheral: enqueue push: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("register peripheral: commit", "device_id", deviceID, "name", name, "error", err)
+		return Peripheral{}, fmt.Errorf("register peripheral: commit: %w", err)
+	}
+
+	return p, nil
+}
+
+// List returns active peripherals for the device.
+func (s *PeripheralService) List(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
+	peripherals, err := s.store.ListPeripherals(ctx, deviceID, userID)
+	if err != nil && !errors.Is(err, ErrDeviceNotFound) {
+		s.logger.Error("list peripherals", "device_id", deviceID, "error", err)
+	}
+	return peripherals, err
+}
+
+// SetSchedule persists the schedule to DB and publishes it synchronously via MQTT.
+func (s *PeripheralService) SetSchedule(ctx context.Context, deviceID, userID, name string, schedule []ScheduleWindow) (Peripheral, error) {
+	p, err := s.store.SetPeripheralSchedule(ctx, deviceID, userID, name, schedule)
+	if err != nil {
+		if !errors.Is(err, ErrPeripheralNotFound) {
+			s.logger.Error("set peripheral schedule: store", "device_id", deviceID, "name", name, "error", err)
+		}
+		return Peripheral{}, err
+	}
+
+	msg, err := json.Marshal(map[string]any{
+		"action":  "schedule",
+		"windows": schedule,
+	})
+	if err != nil {
+		s.logger.Error("set peripheral schedule: marshal mqtt payload", "device_id", deviceID, "name", name, "error", err)
+		return p, nil
+	}
+
+	topic := fmt.Sprintf("fishhub/%s/commands/%s", deviceID, name)
+	if err := s.publisher.Publish(ctx, topic, msg); err != nil {
+		s.logger.Warn("set peripheral schedule: mqtt publish failed", "device_id", deviceID, "name", name, "error", err)
+	}
+
+	return p, nil
+}
+
+// Delete soft-deletes the peripheral and enqueues a peripheral.push delete event atomically.
+func (s *PeripheralService) Delete(ctx context.Context, deviceID, userID, name string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("delete peripheral: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if err := s.store.DeletePeripheral(ctx, tx, deviceID, userID, name); err != nil {
+		if !errors.Is(err, ErrPeripheralNotFound) {
+			s.logger.Error("delete peripheral: store", "device_id", deviceID, "name", name, "error", err)
+		}
+		return err
+	}
+
+	if err := s.outbox.Insert(ctx, tx, EventTypePeripheralPush, PeripheralPushPayload{
+		DeviceID: deviceID,
+		Name:     name,
+		Op:       "delete",
+	}, peripheralPushClaimTimeoutSeconds); err != nil {
+		s.logger.Error("delete peripheral: enqueue push", "device_id", deviceID, "name", name, "error", err)
+		return fmt.Errorf("delete peripheral: enqueue push: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("delete peripheral: commit", "device_id", deviceID, "name", name, "error", err)
+		return fmt.Errorf("delete peripheral: commit: %w", err)
+	}
+
+	return nil
+}

--- a/internal/sensors/peripheral_service.go
+++ b/internal/sensors/peripheral_service.go
@@ -76,9 +76,10 @@ func (s *PeripheralService) Register(ctx context.Context, deviceID, userID, name
 }
 
 // List returns active peripherals for the device.
+// Returns an empty slice if the device does not exist or is not owned by userID.
 func (s *PeripheralService) List(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
 	peripherals, err := s.store.ListPeripherals(ctx, deviceID, userID)
-	if err != nil && !errors.Is(err, ErrDeviceNotFound) {
+	if err != nil {
 		s.logger.Error("list peripherals", "device_id", deviceID, "error", err)
 	}
 	return peripherals, err

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -42,7 +42,7 @@ type PeripheralStore interface {
 	// Returns ErrPeripheralAlreadyExists if an active peripheral with the same name exists.
 	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind string, pin int) (Peripheral, error)
 	// ListPeripherals returns active (non-deleted) peripherals for the device owned by userID.
-	// Returns ErrDeviceNotFound if the device does not exist or is not owned by userID.
+	// Returns an empty slice if the device does not exist or is not owned by userID.
 	ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error)
 	// SetPeripheralSchedule persists the schedule and returns the updated peripheral.
 	// Returns ErrPeripheralNotFound if the peripheral does not exist or is not reachable by userID.

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -36,6 +36,22 @@ type DeviceStore interface {
 	GetActivationStatus(ctx context.Context, deviceID string) (ActivationStatus, error)
 }
 
+type PeripheralStore interface {
+	// CreatePeripheral inserts a new peripheral for the device owned by userID.
+	// Returns ErrDeviceNotFound if the device does not exist or is not owned by userID.
+	// Returns ErrPeripheralAlreadyExists if an active peripheral with the same name exists.
+	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind string, pin int) (Peripheral, error)
+	// ListPeripherals returns active (non-deleted) peripherals for the device owned by userID.
+	// Returns ErrDeviceNotFound if the device does not exist or is not owned by userID.
+	ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error)
+	// SetPeripheralSchedule persists the schedule and returns the updated peripheral.
+	// Returns ErrPeripheralNotFound if the peripheral does not exist or is not reachable by userID.
+	SetPeripheralSchedule(ctx context.Context, deviceID, userID, name string, schedule []ScheduleWindow) (Peripheral, error)
+	// DeletePeripheral soft-deletes the peripheral (sets deleted_at).
+	// Returns ErrPeripheralNotFound if the peripheral does not exist or is not reachable by userID.
+	DeletePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name string) error
+}
+
 type ProvisioningStore interface {
 	// GetOrCreateCode returns the existing unused code for the user, or creates one.
 	GetOrCreateCode(ctx context.Context, userID string) (code string, err error)

--- a/internal/sensors/store_peripheral_integration_test.go
+++ b/internal/sensors/store_peripheral_integration_test.go
@@ -1,0 +1,177 @@
+package sensors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/platform"
+	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+)
+
+func TestPeripheralStore_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewPeripheralStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	// insert a device owned by the seed user
+	var deviceID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+	).Scan(&deviceID); err != nil {
+		t.Fatalf("insert device: %v", err)
+	}
+
+	t.Run("create peripheral", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", 5)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		if p.ID == "" {
+			t.Error("expected non-empty ID")
+		}
+		if p.Name != "light" || p.Kind != "relay" || p.Pin != 5 {
+			t.Errorf("unexpected peripheral: %+v", p)
+		}
+	})
+
+	t.Run("list returns created peripheral", func(t *testing.T) {
+		peripherals, err := store.ListPeripherals(ctx, deviceID, userID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(peripherals) == 0 {
+			t.Fatal("expected at least one peripheral")
+		}
+		if peripherals[0].Name != "light" {
+			t.Errorf("expected 'light', got %q", peripherals[0].Name)
+		}
+	})
+
+	t.Run("create duplicate name returns ErrPeripheralAlreadyExists", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", 6)
+		if !errors.Is(err, sensors.ErrPeripheralAlreadyExists) {
+			t.Errorf("expected ErrPeripheralAlreadyExists, got %v", err)
+		}
+	})
+
+	t.Run("create with unknown device returns ErrDeviceNotFound", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", 7)
+		if !errors.Is(err, sensors.ErrDeviceNotFound) {
+			t.Errorf("expected ErrDeviceNotFound, got %v", err)
+		}
+	})
+
+	t.Run("set peripheral schedule", func(t *testing.T) {
+		schedule := []sensors.ScheduleWindow{
+			{From: "08:00", To: "18:00", Value: 1.0},
+		}
+		p, err := store.SetPeripheralSchedule(ctx, deviceID, userID, "light", schedule)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(p.Schedule) != 1 || p.Schedule[0].From != "08:00" {
+			t.Errorf("unexpected schedule: %+v", p.Schedule)
+		}
+	})
+
+	t.Run("set schedule on unknown peripheral returns ErrPeripheralNotFound", func(t *testing.T) {
+		_, err := store.SetPeripheralSchedule(ctx, deviceID, userID, "nope", nil)
+		if !errors.Is(err, sensors.ErrPeripheralNotFound) {
+			t.Errorf("expected ErrPeripheralNotFound, got %v", err)
+		}
+	})
+
+	t.Run("list does not return peripheral of another user's device", func(t *testing.T) {
+		var otherUserID string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO users (email, provider, provider_sub) VALUES ('other@test.com','test','sub-other') RETURNING id`,
+		).Scan(&otherUserID); err != nil {
+			t.Fatalf("insert other user: %v", err)
+		}
+		_, err := store.ListPeripherals(ctx, deviceID, otherUserID)
+		if !errors.Is(err, sensors.ErrDeviceNotFound) {
+			t.Errorf("expected ErrDeviceNotFound for wrong user, got %v", err)
+		}
+	})
+
+	t.Run("delete peripheral", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		if err := store.DeletePeripheral(ctx, tx, deviceID, userID, "light"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+
+		// should no longer appear in list
+		peripherals, err := store.ListPeripherals(ctx, deviceID, userID)
+		if err != nil {
+			t.Fatalf("list after delete: %v", err)
+		}
+		for _, p := range peripherals {
+			if p.Name == "light" {
+				t.Error("deleted peripheral still appears in list")
+			}
+		}
+	})
+
+	t.Run("delete non-existent peripheral returns ErrPeripheralNotFound", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		err = store.DeletePeripheral(ctx, tx, deviceID, userID, "ghost")
+		if !errors.Is(err, sensors.ErrPeripheralNotFound) {
+			t.Errorf("expected ErrPeripheralNotFound, got %v", err)
+		}
+	})
+
+	t.Run("same name can be re-created after soft-delete", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", 5)
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("re-create after delete: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		if p.Name != "light" {
+			t.Errorf("expected 'light', got %q", p.Name)
+		}
+	})
+}

--- a/internal/sensors/store_peripheral_integration_test.go
+++ b/internal/sensors/store_peripheral_integration_test.go
@@ -105,16 +105,19 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 	})
 
-	t.Run("list does not return peripheral of another user's device", func(t *testing.T) {
+	t.Run("list returns empty slice for another user's device", func(t *testing.T) {
 		var otherUserID string
 		if err := db.QueryRowContext(ctx,
 			`INSERT INTO users (email, provider, provider_sub) VALUES ('other@test.com','test','sub-other') RETURNING id`,
 		).Scan(&otherUserID); err != nil {
 			t.Fatalf("insert other user: %v", err)
 		}
-		_, err := store.ListPeripherals(ctx, deviceID, otherUserID)
-		if !errors.Is(err, sensors.ErrDeviceNotFound) {
-			t.Errorf("expected ErrDeviceNotFound for wrong user, got %v", err)
+		peripherals, err := store.ListPeripherals(ctx, deviceID, otherUserID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(peripherals) != 0 {
+			t.Errorf("expected empty list for wrong user, got %d peripherals", len(peripherals))
 		}
 	})
 

--- a/internal/sensors/store_peripheral_postgres.go
+++ b/internal/sensors/store_peripheral_postgres.go
@@ -48,24 +48,16 @@ func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.
 }
 
 func (s *postgresPeripheralStore) ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
-	var exists bool
-	err := s.db.QueryRowContext(ctx,
-		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL)`,
-		deviceID, userID,
-	).Scan(&exists)
-	if err != nil {
-		return nil, fmt.Errorf("list peripherals: check device: %w", err)
-	}
-	if !exists {
-		return nil, ErrDeviceNotFound
-	}
-
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, device_id, name, kind, pin, schedule, created_at, updated_at
-		FROM peripherals
-		WHERE device_id = $1 AND deleted_at IS NULL
-		ORDER BY created_at ASC
-	`, deviceID)
+		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.schedule, p.created_at, p.updated_at
+		FROM peripherals p
+		JOIN devices d ON d.id = p.device_id
+		WHERE p.device_id = $1
+		  AND d.user_id = $2
+		  AND p.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+		ORDER BY p.created_at ASC
+	`, deviceID, userID)
 	if err != nil {
 		return nil, fmt.Errorf("list peripherals: query: %w", err)
 	}

--- a/internal/sensors/store_peripheral_postgres.go
+++ b/internal/sensors/store_peripheral_postgres.go
@@ -1,0 +1,151 @@
+package sensors
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type postgresPeripheralStore struct {
+	db *sql.DB
+}
+
+func NewPeripheralStore(db *sql.DB) PeripheralStore {
+	return &postgresPeripheralStore{db: db}
+}
+
+func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind string, pin int) (Peripheral, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL)`,
+		deviceID, userID,
+	).Scan(&exists)
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("create peripheral: check device: %w", err)
+	}
+	if !exists {
+		return Peripheral{}, ErrDeviceNotFound
+	}
+
+	var p Peripheral
+	err = tx.QueryRowContext(ctx, `
+		INSERT INTO peripherals (device_id, name, kind, pin)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, device_id, name, kind, pin, created_at, updated_at
+	`, deviceID, name, kind, pin).Scan(
+		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &p.CreatedAt, &p.UpdatedAt,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return Peripheral{}, ErrPeripheralAlreadyExists
+		}
+		return Peripheral{}, fmt.Errorf("create peripheral: insert: %w", err)
+	}
+	return p, nil
+}
+
+func (s *postgresPeripheralStore) ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL)`,
+		deviceID, userID,
+	).Scan(&exists)
+	if err != nil {
+		return nil, fmt.Errorf("list peripherals: check device: %w", err)
+	}
+	if !exists {
+		return nil, ErrDeviceNotFound
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, device_id, name, kind, pin, schedule, created_at, updated_at
+		FROM peripherals
+		WHERE device_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at ASC
+	`, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("list peripherals: query: %w", err)
+	}
+	defer rows.Close()
+
+	peripherals := []Peripheral{}
+	for rows.Next() {
+		var p Peripheral
+		var scheduleJSON []byte
+		if err := rows.Scan(&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &scheduleJSON, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("list peripherals: scan: %w", err)
+		}
+		if scheduleJSON != nil {
+			if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
+				return nil, fmt.Errorf("list peripherals: unmarshal schedule: %w", err)
+			}
+		}
+		peripherals = append(peripherals, p)
+	}
+	return peripherals, rows.Err()
+}
+
+func (s *postgresPeripheralStore) SetPeripheralSchedule(ctx context.Context, deviceID, userID, name string, schedule []ScheduleWindow) (Peripheral, error) {
+	scheduleJSON, err := json.Marshal(schedule)
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("set peripheral schedule: marshal: %w", err)
+	}
+
+	var p Peripheral
+	err = s.db.QueryRowContext(ctx, `
+		UPDATE peripherals p
+		SET schedule = $1, updated_at = now()
+		FROM devices d
+		WHERE p.device_id = d.id
+		  AND d.user_id = $2
+		  AND p.device_id = $3
+		  AND p.name = $4
+		  AND p.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.schedule, p.created_at, p.updated_at
+	`, scheduleJSON, userID, deviceID, name).Scan(
+		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &scheduleJSON, &p.CreatedAt, &p.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Peripheral{}, ErrPeripheralNotFound
+	}
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("set peripheral schedule: update: %w", err)
+	}
+	if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
+		return Peripheral{}, fmt.Errorf("set peripheral schedule: unmarshal: %w", err)
+	}
+	return p, nil
+}
+
+func (s *postgresPeripheralStore) DeletePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name string) error {
+	result, err := tx.ExecContext(ctx, `
+		UPDATE peripherals p
+		SET deleted_at = now()
+		FROM devices d
+		WHERE p.device_id = d.id
+		  AND d.user_id = $1
+		  AND p.device_id = $2
+		  AND p.name = $3
+		  AND p.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+	`, userID, deviceID, name)
+	if err != nil {
+		return fmt.Errorf("delete peripheral: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete peripheral: rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrPeripheralNotFound
+	}
+	return nil
+}
+
+func isUniqueViolation(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "23505")
+}

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
@@ -143,6 +144,13 @@ func (s *stubPublisher) Publish(_ context.Context, topic string, payload []byte)
 	return s.err
 }
 
+func (s *stubPublisher) PublishRetained(_ context.Context, topic string, payload []byte) error {
+	s.publishedTopic = topic
+	s.publishedPayload = payload
+	s.called = true
+	return s.err
+}
+
 // ── ActivationStatusStore ─────────────────────────────────────────────────────
 
 type stubActivationStatusStore struct {
@@ -155,8 +163,35 @@ func (s *stubActivationStatusStore) GetActivationStatus(_ context.Context, _ str
 	return s.status, s.err
 }
 
+// ── PeripheralStore ───────────────────────────────────────────────────────────
+
+type stubPeripheralStore struct {
+	created    sensors.Peripheral
+	createErr  error
+	listed     []sensors.Peripheral
+	listErr    error
+	scheduled  sensors.Peripheral
+	schedErr   error
+	deleteErr  error
+}
+
+func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _ string, _ int) (sensors.Peripheral, error) {
+	return s.created, s.createErr
+}
+func (s *stubPeripheralStore) ListPeripherals(_ context.Context, _, _ string) ([]sensors.Peripheral, error) {
+	return s.listed, s.listErr
+}
+func (s *stubPeripheralStore) SetPeripheralSchedule(_ context.Context, _, _, _ string, _ []sensors.ScheduleWindow) (sensors.Peripheral, error) {
+	return s.scheduled, s.schedErr
+}
+func (s *stubPeripheralStore) DeletePeripheral(_ context.Context, _ *sql.Tx, _, _, _ string) error {
+	return s.deleteErr
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 func newDevice(id string) sensors.Device {
 	return sensors.Device{ID: id, Name: "Tank", CreatedAt: time.Now()}
 }
+
+var errSentinel = errors.New("store error")

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func main() {
 	}
 
 	// ── MQTT publisher ────────────────────────────────────────────────────────
-	var mqttPublisher sensors.CommandPublisher = mqtt.NewNoOpPublisher()
+	var mqttPublisher mqtt.Publisher = mqtt.NewNoOpPublisher()
 	if cfg.HiveMQHost != "" {
 		p, err := mqtt.NewPublisher(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass, logger)
 		if err != nil {
@@ -210,10 +210,12 @@ func main() {
 
 	// ── Stores & services ─────────────────────────────────────────────────────
 	deviceStore := sensors.NewDeviceStore(db)
+	peripheralStore := sensors.NewPeripheralStore(db)
 	provisioningStore := sensors.NewProvisioningStore(db)
 	outboxStore := outbox.NewPostgresStore(db)
 	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
 	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
+	peripheralSvc := sensors.NewPeripheralService(db, peripheralStore, outboxStore, mqttPublisher, logger)
 	provisioningSvc := sensors.NewProvisioningService(provisioningStore, logger)
 	activationSvc := sensors.NewActivationService(db, provisioningStore, outboxStore, deviceSigner, logger)
 
@@ -222,6 +224,7 @@ func main() {
 		outboxStore,
 		[]outbox.EventProcessor{
 			sensors.NewHiveMQProvisionProcessor(hivemqClient, logger),
+			sensors.NewPeripheralPushProcessor(mqttPublisher, logger),
 		},
 		10*time.Second,
 		5,
@@ -264,6 +267,10 @@ func main() {
 		r.Patch("/api/devices/{id}", (&sensors.PatchDeviceHandler{Service: deviceSvc}).ServeHTTP)
 		r.Delete("/api/devices/{id}", (&sensors.DeleteDeviceHandler{Service: deviceSvc}).ServeHTTP)
 		r.Get("/api/devices/{id}/readings", (&sensors.ReadingsQueryHandler{Service: readingsSvc}).List)
+		r.Post("/api/devices/{id}/peripherals", (&sensors.CreatePeripheralHandler{Service: peripheralSvc}).ServeHTTP)
+		r.Get("/api/devices/{id}/peripherals", (&sensors.ListPeripheralsHandler{Service: peripheralSvc}).ServeHTTP)
+		r.Put("/api/devices/{id}/peripherals/{name}/schedule", (&sensors.SetPeripheralScheduleHandler{Service: peripheralSvc}).ServeHTTP)
+		r.Delete("/api/devices/{id}/peripherals/{name}", (&sensors.DeletePeripheralHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Post("/api/devices/{id}/peripherals/{name}/commands", (&sensors.CommandHandler{Service: deviceSvc}).ServeHTTP)
 	})
 


### PR DESCRIPTION
## Summary

- Adds a `peripherals` table (migration 015) with soft-delete and a partial unique index on `(device_id, name) WHERE deleted_at IS NULL`
- `PeripheralStore` interface + Postgres implementation (create, list, set schedule, soft-delete)
- `PeripheralPushProcessor`: publishes retained MQTT to `fishhub/{device_id}/peripherals/{name}` on create/delete via the outbox (reliable delivery)
- `PeripheralService`: `Register`/`Delete` go through the outbox; `SetSchedule` is fire-and-forget MQTT publish
- Four new session-auth endpoints: `POST`, `GET` `/api/devices/{id}/peripherals`; `PUT` `.../peripherals/{name}/schedule`; `DELETE` `.../peripherals/{name}`
- `mqtt.Publisher` gains `PublishRetained` for retained MQTT messages
- Integration tests for the store, handler tests, and processor unit tests

## Test plan

- [ ] `go test ./...` passes
- [ ] `POST /api/devices/{id}/peripherals` creates a peripheral and outbox event
- [ ] `GET /api/devices/{id}/peripherals` lists only active peripherals
- [ ] `PUT .../schedule` persists the schedule and publishes MQTT command
- [ ] `DELETE .../peripherals/{name}` soft-deletes and enqueues outbox push with `op: "delete"`
- [ ] Re-creating the same name after delete succeeds (partial unique index allows it)
- [ ] Outbox runner calls `PublishRetained` with correct topic and payload

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)