### PR TITLE
Parse and return string SenML values (vs)

### DIFF
--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -92,8 +92,8 @@ type ReadingsQueryHandler struct {
 }
 
 type ReadingPointResponse struct {
-	Timestamp string             `json:"timestamp"`
-	Values    map[string]float64 `json:"values"`
+	Timestamp string         `json:"timestamp"`
+	Values    map[string]any `json:"values"`
 }
 
 type ReadingsQueryResponse struct {

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -150,7 +150,7 @@ func TestReadingsHandler_Create(t *testing.T) {
 
 func TestReadingsQueryHandler_List(t *testing.T) {
 	ts := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
-	points := []sensors.ReadingPoint{{Timestamp: ts, Values: map[string]float64{"temperature": 25.4}}}
+	points := []sensors.ReadingPoint{{Timestamp: ts, Values: map[string]any{"temperature": 25.4}}}
 
 	makeReq := func(deviceID, query string) *http.Request {
 		req := httptest.NewRequest(http.MethodGet, "/api/devices/"+deviceID+"/readings"+query, nil)
@@ -179,7 +179,7 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 			t.Fatalf("expected 1 reading, got %d", len(body.Readings))
 		}
 		if body.Readings[0].Values["temperature"] != 25.4 {
-			t.Errorf("expected temperature 25.4, got %f", body.Readings[0].Values["temperature"])
+			t.Errorf("expected temperature 25.4, got %v", body.Readings[0].Values["temperature"])
 		}
 	})
 
@@ -220,6 +220,31 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 		}
 		if body.Readings == nil || len(body.Readings) != 0 {
 			t.Errorf("expected empty readings slice, got %v", body.Readings)
+		}
+	})
+
+	t.Run("string values are included in response", func(t *testing.T) {
+		stringPoints := []sensors.ReadingPoint{{
+			Timestamp: ts,
+			Values:    map[string]any{"light/source": "schedule", "temperature": 25.4},
+		}}
+		h := &sensors.ReadingsQueryHandler{
+			Service: newReadingsService(nil, &stubReadingQuerier{points: stringPoints}, &stubDeviceStore{device: newDevice("dev-1")}),
+		}
+		rec := httptest.NewRecorder()
+		h.List(rec, makeReq("dev-1", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var body sensors.ReadingsQueryResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(body.Readings) != 1 {
+			t.Fatalf("expected 1 reading, got %d", len(body.Readings))
+		}
+		if body.Readings[0].Values["light/source"] != "schedule" {
+			t.Errorf("expected light/source 'schedule', got %v", body.Readings[0].Values["light/source"])
 		}
 	})
 

--- a/internal/sensors/influx.go
+++ b/internal/sensors/influx.go
@@ -25,7 +25,7 @@ type ReadingQuery struct {
 
 type ReadingPoint struct {
 	Timestamp time.Time
-	Values    map[string]float64
+	Values    map[string]any
 }
 
 type ReadingWriter interface {
@@ -105,7 +105,7 @@ func (c *influxDBClient) QueryReadings(ctx context.Context, q ReadingQuery) ([]R
 	var points []ReadingPoint
 	for iter.Next() {
 		row := iter.Value()
-		p := ReadingPoint{Values: make(map[string]float64)}
+		p := ReadingPoint{Values: make(map[string]any)}
 		if t, ok := row["time"].(time.Time); ok {
 			p.Timestamp = t.UTC()
 		}
@@ -125,6 +125,8 @@ func (c *influxDBClient) QueryReadings(ctx context.Context, q ReadingQuery) ([]R
 				} else {
 					p.Values[k] = 0
 				}
+			case string:
+				p.Values[k] = val
 			}
 		}
 		if len(p.Values) == 0 {

--- a/internal/sensors/influx_test.go
+++ b/internal/sensors/influx_test.go
@@ -158,6 +158,48 @@ func TestWriteReading_Integration(t *testing.T) {
 	}
 }
 
+func TestWriteAndQueryStringField_Integration(t *testing.T) {
+	host := startInfluxDB(t)
+	createDatabase(t, host)
+
+	client, err := sensors.NewInfluxClient(host, testToken, testDatabase)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	ts := time.Unix(1713000001, 0).UTC()
+	err = client.WriteReading(context.Background(), sensors.Reading{
+		DeviceID:  "string-test-device",
+		UserID:    "test-user",
+		Timestamp: ts,
+		Measurements: map[string]any{
+			"light/source": "schedule",
+			"temperature":  float64(24.0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("write reading: %v", err)
+	}
+
+	points, err := client.QueryReadings(context.Background(), sensors.ReadingQuery{
+		DeviceID: "string-test-device",
+		From:     ts.Add(-time.Minute),
+		To:       ts.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("query readings: %v", err)
+	}
+	if len(points) == 0 {
+		t.Fatal("expected at least one reading, got none")
+	}
+	if v, ok := points[0].Values["light/source"].(string); !ok || v != "schedule" {
+		t.Errorf("expected light/source 'schedule', got %v", points[0].Values["light/source"])
+	}
+	if points[0].Values["temperature"] != float64(24.0) {
+		t.Errorf("expected temperature 24.0, got %v", points[0].Values["temperature"])
+	}
+}
+
 func TestQueryReadings_Integration(t *testing.T) {
 	host := startInfluxDB(t)
 	createDatabase(t, host)
@@ -193,6 +235,6 @@ func TestQueryReadings_Integration(t *testing.T) {
 		t.Fatal("expected at least one reading, got none")
 	}
 	if points[0].Values["temperature"] != 22.5 {
-		t.Errorf("expected temperature 22.5, got %f", points[0].Values["temperature"])
+		t.Errorf("expected temperature 22.5, got %v", points[0].Values["temperature"])
 	}
 }

--- a/internal/sensors/readings_service_test.go
+++ b/internal/sensors/readings_service_test.go
@@ -15,7 +15,7 @@ var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 func TestReadingsService_Query_HappyPath(t *testing.T) {
 	now := time.Now()
-	expected := []sensors.ReadingPoint{{Timestamp: now, Values: map[string]float64{"temperature": 25.5}}}
+	expected := []sensors.ReadingPoint{{Timestamp: now, Values: map[string]any{"temperature": 25.5}}}
 	svc := sensors.NewReadingsService(&stubDeviceStore{}, &stubReadingQuerier{points: expected}, nil, discardLogger)
 	points, err := svc.Query(context.Background(), "usr-1", sensors.ReadingQuery{DeviceID: "dev-1"})
 	if err != nil {

--- a/internal/sensors/senml.go
+++ b/internal/sensors/senml.go
@@ -13,12 +13,13 @@ var (
 )
 
 type senmlRecord struct {
-	BaseName  string   `json:"bn"`
-	BaseTime  int64    `json:"bt"`
-	Name      string   `json:"n"`
-	Unit      string   `json:"u"`
-	Value     *float64 `json:"v"`
-	BoolValue *bool    `json:"vb"`
+	BaseName    string   `json:"bn"`
+	BaseTime    int64    `json:"bt"`
+	Name        string   `json:"n"`
+	Unit        string   `json:"u"`
+	Value       *float64 `json:"v"`
+	BoolValue   *bool    `json:"vb"`
+	StringValue *string  `json:"vs"`
 }
 
 type Measurement struct {
@@ -56,6 +57,8 @@ func ParseSenML(body []byte) (SenMLReading, error) {
 			measurements = append(measurements, Measurement{Name: r.Name, Unit: r.Unit, Value: *r.Value})
 		case r.BoolValue != nil:
 			measurements = append(measurements, Measurement{Name: r.Name, Unit: r.Unit, Value: *r.BoolValue})
+		case r.StringValue != nil:
+			measurements = append(measurements, Measurement{Name: r.Name, Unit: r.Unit, Value: *r.StringValue})
 		}
 	}
 

--- a/internal/sensors/senml_test.go
+++ b/internal/sensors/senml_test.go
@@ -68,14 +68,34 @@ func TestParseSenML(t *testing.T) {
 		}
 	})
 
-	t.Run("records with unknown value type are skipped", func(t *testing.T) {
-		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"label","vs":"hello"},{"n":"temperature","v":25.3}]`
+	t.Run("string value (vs) alongside float", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"light/source","vs":"schedule"},{"n":"temperature","v":25.3}]`
+		r, err := sensors.ParseSenML([]byte(body))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.Measurements) != 2 {
+			t.Fatalf("expected 2 measurements, got %d", len(r.Measurements))
+		}
+		if r.Measurements[0].Name != "light/source" {
+			t.Errorf("expected first measurement 'light/source', got %q", r.Measurements[0].Name)
+		}
+		if v, ok := r.Measurements[0].Value.(string); !ok || v != "schedule" {
+			t.Errorf("expected string 'schedule', got %v", r.Measurements[0].Value)
+		}
+		if r.Measurements[1].Name != "temperature" {
+			t.Errorf("expected second measurement 'temperature', got %q", r.Measurements[1].Name)
+		}
+	})
+
+	t.Run("records with no supported value type are skipped", func(t *testing.T) {
+		body := `[{"bn":"fishhub/device/","bt":1745000000},{"n":"empty"},{"n":"temperature","v":25.3}]`
 		r, err := sensors.ParseSenML([]byte(body))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(r.Measurements) != 1 {
-			t.Fatalf("expected 1 measurement (label skipped), got %d", len(r.Measurements))
+			t.Fatalf("expected 1 measurement (empty skipped), got %d", len(r.Measurements))
 		}
 		if r.Measurements[0].Name != "temperature" {
 			t.Errorf("expected 'temperature', got %q", r.Measurements[0].Name)
@@ -117,8 +137,21 @@ func TestParseSenML(t *testing.T) {
 		}
 	})
 
+	t.Run("string-only pack parses successfully", func(t *testing.T) {
+		r, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1745000000},{"n":"light/source","vs":"heartbeat"}]`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.Measurements) != 1 {
+			t.Fatalf("expected 1 measurement, got %d", len(r.Measurements))
+		}
+		if v, ok := r.Measurements[0].Value.(string); !ok || v != "heartbeat" {
+			t.Errorf("expected string 'heartbeat', got %v", r.Measurements[0].Value)
+		}
+	})
+
 	t.Run("all measurement records have no supported value type", func(t *testing.T) {
-		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1745000000},{"n":"label","vs":"hello"}]`))
+		_, err := sensors.ParseSenML([]byte(`[{"bn":"fishhub/device/","bt":1745000000},{"n":"empty"}]`))
 		if !errors.Is(err, sensors.ErrEmptyEntries) {
 			t.Errorf("expected ErrEmptyEntries, got %v", err)
 		}


### PR DESCRIPTION
## Summary

- **`senml.go`** — adds `StringValue *string \`json:"vs"\`` to `senmlRecord` and a third `case` in the switch so `"vs"` entries are included in `Reading.Measurements` as `string`
- **`influx.go`** — `ReadingPoint.Values` widened from `map[string]float64` to `map[string]any`; `string` case added to `QueryReadings` so string fields survive the query path
- **`handler.go`** — `ReadingPointResponse.Values` widened to `map[string]any` so string fields are serialised in the JSON response

Prerequisite for fishhub-oss/fishhub-firmware#45 (heartbeat tagging via `light/source` string field).

## Test plan

- [ ] `go test ./...` passes
- [ ] `ParseSenML` with a `"vs"` entry returns a `string` measurement value
- [ ] `QueryReadings` returns string fields alongside float fields in `Values`
- [ ] `GET /api/devices/{id}/readings` response includes string values in the `values` map
- [ ] InfluxDB integration test writes a string field and reads it back correctly

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)