### PR TITLE
Ingest readings via MQTT subscription

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,8 @@ Health check. No authentication required.
 
 ## POST /readings
 
+> **Deprecated:** devices should publish readings via MQTT to `fishhub/{device_id}/readings` instead (see fishhub-oss/fishhub-firmware#46). This endpoint remains functional as a fallback.
+
 Accepts a SenML reading from an authenticated device.
 
 **Headers**

--- a/internal/mqtt/subscriber.go
+++ b/internal/mqtt/subscriber.go
@@ -1,0 +1,79 @@
+package mqtt
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+)
+
+// MessageHandler is called for each message received on a subscribed topic.
+type MessageHandler func(ctx context.Context, topic string, payload []byte)
+
+// Subscriber subscribes to MQTT topics and dispatches messages to a handler.
+type Subscriber interface {
+	Subscribe(ctx context.Context, topic string, handler MessageHandler) error
+}
+
+type pahoSubscriber struct {
+	client paho.Client
+}
+
+// NewSubscriber connects to the HiveMQ broker and returns a Subscriber.
+// Uses a separate client ID from the publisher so both can coexist.
+// CleanSession(false) ensures the subscription survives reconnects.
+func NewSubscriber(host string, port int, username, password string, logger *slog.Logger) (Subscriber, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	opts := paho.NewClientOptions().
+		AddBroker(fmt.Sprintf("tls://%s:%d", host, port)).
+		SetClientID("fishhub-server-sub").
+		SetUsername(username).
+		SetPassword(password).
+		SetTLSConfig(&tls.Config{}).
+		SetConnectTimeout(10 * time.Second).
+		SetKeepAlive(30 * time.Second).
+		SetAutoReconnect(true).
+		SetCleanSession(false).
+		SetConnectionLostHandler(func(_ paho.Client, err error) {
+			logger.Warn("mqtt subscriber connection lost", "error", err)
+		}).
+		SetOnConnectHandler(func(_ paho.Client) {
+			logger.Info("mqtt subscriber connected", "host", host, "port", port)
+		})
+
+	c := paho.NewClient(opts)
+	token := c.Connect()
+	if !token.WaitTimeout(10 * time.Second) {
+		return nil, fmt.Errorf("mqtt subscriber: connect timeout")
+	}
+	if err := token.Error(); err != nil {
+		return nil, fmt.Errorf("mqtt subscriber: connect: %w", err)
+	}
+
+	return &pahoSubscriber{client: c}, nil
+}
+
+func (s *pahoSubscriber) Subscribe(_ context.Context, topic string, handler MessageHandler) error {
+	token := s.client.Subscribe(topic, 1, func(_ paho.Client, msg paho.Message) {
+		handler(context.Background(), msg.Topic(), msg.Payload())
+	})
+	if !token.WaitTimeout(10 * time.Second) {
+		return fmt.Errorf("mqtt subscriber: subscribe timeout")
+	}
+	if err := token.Error(); err != nil {
+		return fmt.Errorf("mqtt subscriber: subscribe: %w", err)
+	}
+	return nil
+}
+
+type noopSubscriber struct{}
+
+func NewNoOpSubscriber() Subscriber { return &noopSubscriber{} }
+func (n *noopSubscriber) Subscribe(_ context.Context, _ string, _ MessageHandler) error {
+	return nil
+}

--- a/internal/sensors/mqtt_handler.go
+++ b/internal/sensors/mqtt_handler.go
@@ -1,0 +1,59 @@
+package sensors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+)
+
+// ReadingsMQTTHandler handles incoming readings published by devices to
+// fishhub/+/readings. It reuses the same pipeline as the HTTP handler.
+type ReadingsMQTTHandler struct {
+	store   DeviceStore
+	service *ReadingsService
+	logger  *slog.Logger
+}
+
+func NewReadingsMQTTHandler(store DeviceStore, service *ReadingsService, logger *slog.Logger) *ReadingsMQTTHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ReadingsMQTTHandler{store: store, service: service, logger: logger}
+}
+
+// Handle is the mqtt.MessageHandler callback. Topic shape: fishhub/{device_id}/readings.
+func (h *ReadingsMQTTHandler) Handle(ctx context.Context, topic string, payload []byte) {
+	deviceID, ok := deviceIDFromTopic(topic)
+	if !ok {
+		h.logger.Warn("mqtt readings: unexpected topic shape", "topic", topic)
+		return
+	}
+
+	device, err := h.store.FindByID(ctx, deviceID)
+	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			h.logger.Warn("mqtt readings: device not found", "device_id", deviceID)
+		} else {
+			h.logger.Error("mqtt readings: store lookup", "device_id", deviceID, "error", err)
+		}
+		return
+	}
+
+	if err := h.service.Write(ctx, DeviceInfo{DeviceID: device.ID, UserID: device.UserID}, payload); err != nil {
+		h.logger.Error("mqtt readings: write failed", "device_id", deviceID, "error", err)
+	}
+}
+
+// deviceIDFromTopic extracts the device ID from fishhub/{device_id}/readings.
+func deviceIDFromTopic(topic string) (string, bool) {
+	parts := strings.Split(topic, "/")
+	if len(parts) != 3 || parts[0] != "fishhub" || parts[2] != "readings" {
+		return "", false
+	}
+	id := parts[1]
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}

--- a/internal/sensors/mqtt_handler_test.go
+++ b/internal/sensors/mqtt_handler_test.go
@@ -1,0 +1,92 @@
+package sensors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/sensors"
+)
+
+const validReadingPayload = `[{"bn":"fishhub/device/","bt":1713000000},{"n":"temperature","u":"Cel","v":23.4}]`
+
+func newReadingsMQTTHandler(store *stubDeviceStore, writer *stubReadingWriter) *sensors.ReadingsMQTTHandler {
+	svc := sensors.NewReadingsService(store, nil, writer, discardLogger)
+	return sensors.NewReadingsMQTTHandler(store, svc, discardLogger)
+}
+
+func TestReadingsMQTTHandler_Handle(t *testing.T) {
+	device := sensors.Device{ID: "dev-1", UserID: "user-1"}
+
+	t.Run("valid topic and payload writes reading", func(t *testing.T) {
+		store := &stubDeviceStore{findByIDDevice: device}
+		writer := &stubReadingWriter{}
+		h := newReadingsMQTTHandler(store, writer)
+
+		h.Handle(context.Background(), "fishhub/dev-1/readings", []byte(validReadingPayload))
+
+		if !writer.called {
+			t.Error("expected writer to be called")
+		}
+		if writer.reading.DeviceID != "dev-1" {
+			t.Errorf("expected device_id 'dev-1', got %q", writer.reading.DeviceID)
+		}
+		if writer.reading.UserID != "user-1" {
+			t.Errorf("expected user_id 'user-1', got %q", writer.reading.UserID)
+		}
+	})
+
+	t.Run("device not found does not write", func(t *testing.T) {
+		store := &stubDeviceStore{findByIDErr: sensors.ErrDeviceNotFound}
+		writer := &stubReadingWriter{}
+		h := newReadingsMQTTHandler(store, writer)
+
+		h.Handle(context.Background(), "fishhub/dev-x/readings", []byte(validReadingPayload))
+
+		if writer.called {
+			t.Error("expected writer not to be called")
+		}
+	})
+
+	t.Run("malformed topic does not write", func(t *testing.T) {
+		store := &stubDeviceStore{findByIDDevice: device}
+		writer := &stubReadingWriter{}
+		h := newReadingsMQTTHandler(store, writer)
+
+		for _, topic := range []string{
+			"fishhub/readings",
+			"fishhub/dev-1/readings/extra",
+			"other/dev-1/readings",
+			"fishhub//readings",
+		} {
+			writer.called = false
+			h.Handle(context.Background(), topic, []byte(validReadingPayload))
+			if writer.called {
+				t.Errorf("topic %q: expected writer not to be called", topic)
+			}
+		}
+	})
+
+	t.Run("malformed SenML payload does not panic", func(t *testing.T) {
+		store := &stubDeviceStore{findByIDDevice: device}
+		writer := &stubReadingWriter{}
+		h := newReadingsMQTTHandler(store, writer)
+
+		h.Handle(context.Background(), "fishhub/dev-1/readings", []byte("not json"))
+
+		if writer.called {
+			t.Error("expected writer not to be called on bad payload")
+		}
+	})
+
+	t.Run("store error does not panic", func(t *testing.T) {
+		store := &stubDeviceStore{findByIDErr: errSentinel}
+		writer := &stubReadingWriter{}
+		h := newReadingsMQTTHandler(store, writer)
+
+		h.Handle(context.Background(), "fishhub/dev-1/readings", []byte(validReadingPayload))
+
+		if writer.called {
+			t.Error("expected writer not to be called on store error")
+		}
+	})
+}

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -8,6 +8,7 @@ import (
 
 type Device struct {
 	ID        string
+	UserID    string
 	Name      string
 	CreatedAt time.Time
 }
@@ -23,6 +24,9 @@ type ActivationStatus struct {
 
 type DeviceStore interface {
 	ListByUserID(ctx context.Context, userID string) ([]Device, error)
+	// FindByID looks up a device by its ID regardless of owner.
+	// Returns ErrDeviceNotFound if the device does not exist or is soft-deleted.
+	FindByID(ctx context.Context, deviceID string) (Device, error)
 	FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error)
 	// PatchDevice updates the name of the device owned by userID.
 	// Returns ErrDeviceNotFound if the device does not exist or is not owned by the user.

--- a/internal/sensors/store_postgres.go
+++ b/internal/sensors/store_postgres.go
@@ -38,13 +38,29 @@ func (s *postgresDeviceStore) ListByUserID(ctx context.Context, userID string) (
 	return devices, rows.Err()
 }
 
+func (s *postgresDeviceStore) FindByID(ctx context.Context, deviceID string) (Device, error) {
+	var d Device
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, COALESCE(name, ''), created_at
+		FROM devices
+		WHERE id = $1 AND deleted_at IS NULL
+	`, deviceID).Scan(&d.ID, &d.UserID, &d.Name, &d.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Device{}, ErrDeviceNotFound
+	}
+	if err != nil {
+		return Device{}, fmt.Errorf("find device by id: %w", err)
+	}
+	return d, nil
+}
+
 func (s *postgresDeviceStore) FindByIDAndUserID(ctx context.Context, deviceID, userID string) (Device, error) {
 	var d Device
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, COALESCE(name, ''), created_at
+		SELECT id, user_id, COALESCE(name, ''), created_at
 		FROM devices
 		WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
-	`, deviceID, userID).Scan(&d.ID, &d.Name, &d.CreatedAt)
+	`, deviceID, userID).Scan(&d.ID, &d.UserID, &d.Name, &d.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Device{}, ErrDeviceNotFound
 	}
@@ -108,8 +124,8 @@ func (s *postgresDeviceStore) PatchDevice(ctx context.Context, deviceID, userID,
 		UPDATE devices
 		SET name = $1
 		WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL
-		RETURNING id, COALESCE(name, ''), created_at
-	`, name, deviceID, userID).Scan(&d.ID, &d.Name, &d.CreatedAt)
+		RETURNING id, user_id, COALESCE(name, ''), created_at
+	`, name, deviceID, userID).Scan(&d.ID, &d.UserID, &d.Name, &d.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Device{}, ErrDeviceNotFound
 	}

--- a/internal/sensors/store_test.go
+++ b/internal/sensors/store_test.go
@@ -155,6 +155,40 @@ func TestGetActivationStatus_integration(t *testing.T) {
 	})
 }
 
+func TestFindByID_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := sensors.NewDeviceStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	var deviceID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+	).Scan(&deviceID); err != nil {
+		t.Fatalf("insert device: %v", err)
+	}
+
+	t.Run("returns device with user_id", func(t *testing.T) {
+		d, err := store.FindByID(ctx, deviceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if d.ID != deviceID {
+			t.Errorf("expected id %s, got %s", deviceID, d.ID)
+		}
+		if d.UserID != userID {
+			t.Errorf("expected user_id %s, got %s", userID, d.UserID)
+		}
+	})
+
+	t.Run("unknown id returns ErrDeviceNotFound", func(t *testing.T) {
+		_, err := store.FindByID(ctx, "00000000-0000-0000-0000-000000000000")
+		if !errors.Is(err, sensors.ErrDeviceNotFound) {
+			t.Errorf("expected ErrDeviceNotFound, got %v", err)
+		}
+	})
+}
+
 func contains(ss []string, s string) bool {
 	for _, v := range ss {
 		if v == s {

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -16,6 +16,8 @@ import (
 type stubDeviceStore struct {
 	device         sensors.Device
 	findErr        error
+	findByIDDevice sensors.Device
+	findByIDErr    error
 	listDevices    []sensors.Device
 	listErr        error
 	patchDevice    sensors.Device
@@ -26,6 +28,9 @@ type stubDeviceStore struct {
 
 func (s *stubDeviceStore) ListByUserID(_ context.Context, _ string) ([]sensors.Device, error) {
 	return s.listDevices, s.listErr
+}
+func (s *stubDeviceStore) FindByID(_ context.Context, _ string) (sensors.Device, error) {
+	return s.findByIDDevice, s.findByIDErr
 }
 func (s *stubDeviceStore) FindByIDAndUserID(_ context.Context, _, _ string) (sensors.Device, error) {
 	return s.device, s.findErr

--- a/main.go
+++ b/main.go
@@ -194,8 +194,9 @@ func main() {
 		logger.Warn("hivemq api not configured — mqtt credentials will not be provisioned at activation")
 	}
 
-	// ── MQTT publisher ────────────────────────────────────────────────────────
+	// ── MQTT publisher + subscriber ───────────────────────────────────────────
 	var mqttPublisher mqtt.Publisher = mqtt.NewNoOpPublisher()
+	var mqttSubscriber mqtt.Subscriber = mqtt.NewNoOpSubscriber()
 	if cfg.HiveMQHost != "" {
 		p, err := mqtt.NewPublisher(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass, logger)
 		if err != nil {
@@ -204,6 +205,13 @@ func main() {
 		}
 		mqttPublisher = p
 		logger.Info("mqtt publisher configured", "host", cfg.HiveMQHost)
+
+		sub, err := mqtt.NewSubscriber(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass, logger)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mqtt subscriber init: %v\n", err)
+			os.Exit(1)
+		}
+		mqttSubscriber = sub
 	} else {
 		logger.Warn("mqtt publishing disabled — HIVEMQ_HOST not set")
 	}
@@ -218,6 +226,12 @@ func main() {
 	peripheralSvc := sensors.NewPeripheralService(db, peripheralStore, outboxStore, mqttPublisher, logger)
 	provisioningSvc := sensors.NewProvisioningService(provisioningStore, logger)
 	activationSvc := sensors.NewActivationService(db, provisioningStore, outboxStore, deviceSigner, logger)
+
+	// ── MQTT readings subscription ────────────────────────────────────────────
+	readingsMQTTHandler := sensors.NewReadingsMQTTHandler(deviceStore, readingsSvc, logger)
+	if err := mqttSubscriber.Subscribe(ctx, "fishhub/+/readings", readingsMQTTHandler.Handle); err != nil {
+		logger.Warn("mqtt readings subscription failed — falling back to HTTP only", "error", err)
+	}
 
 	// ── Outbox runner ─────────────────────────────────────────────────────────
 	outboxRunner := outbox.NewRunner(


### PR DESCRIPTION
## Summary

- `Device` gains a `UserID` field; `DeviceStore` gets `FindByID` (owner-agnostic lookup needed since the device itself is the publisher, not a session-authenticated user)
- `internal/mqtt/subscriber.go` — `Subscriber` interface + `pahoSubscriber` using a separate client ID (`fishhub-server-sub`) and `CleanSession(false)` so subscriptions survive reconnects; `NewNoOpSubscriber` for unconfigured environments
- `internal/sensors/mqtt_handler.go` — `ReadingsMQTTHandler.Handle` extracts `device_id` from the topic, looks up `user_id` via `FindByID`, then calls `ReadingsService.Write` — identical pipeline to the HTTP handler; malformed topics, unknown devices, and bad payloads are logged and swallowed (never panic)
- `main.go` — subscriber constructed alongside publisher; subscription failure is logged as a warning, not fatal (HTTP fallback still works)
- `docs/api.md` — `POST /readings` marked deprecated

## Test plan

- [ ] `go test ./...` passes
- [ ] `ReadingsMQTTHandler.Handle` with valid topic + SenML calls the writer with correct device/user IDs
- [ ] Malformed topics (`fishhub/readings`, extra segments, wrong prefix) do not call the writer
- [ ] `ErrDeviceNotFound` and store errors do not panic
- [ ] `FindByID` integration test: returns correct `UserID`, returns `ErrDeviceNotFound` for unknown ID
- [ ] Server starts without HiveMQ configured (noop subscriber)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)