### PR TITLE
Enforce unique pin per device on peripheral creation

### DIFF
--- a/db/migrations/016_peripheral_pin_unique.down.sql
+++ b/db/migrations/016_peripheral_pin_unique.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS peripherals_device_pin_active_idx;

--- a/db/migrations/016_peripheral_pin_unique.up.sql
+++ b/db/migrations/016_peripheral_pin_unique.up.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX peripherals_device_pin_active_idx
+    ON peripherals (device_id, pin)
+    WHERE deleted_at IS NULL;

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -430,6 +430,10 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			http.Error(w, "peripheral already exists", http.StatusConflict)
 			return
 		}
+		if errors.Is(err, ErrPeripheralPinInUse) {
+			http.Error(w, "pin already in use by another peripheral", http.StatusConflict)
+			return
+		}
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -31,6 +31,7 @@ var ErrInvalidCommand          = errors.New("action must be 'set' or 'schedule'"
 var ErrInfluxWrite             = errors.New("failed to persist reading")
 var ErrPeripheralNotFound      = errors.New("peripheral not found")
 var ErrPeripheralAlreadyExists = errors.New("peripheral already exists")
+var ErrPeripheralPinInUse      = errors.New("peripheral pin already in use")
 
 type DeviceInfo struct {
 	DeviceID string

--- a/internal/sensors/store_peripheral_integration_test.go
+++ b/internal/sensors/store_peripheral_integration_test.go
@@ -72,6 +72,20 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 	})
 
+	t.Run("create with duplicate pin returns ErrPeripheralPinInUse", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		// pin 5 is already used by the "light" peripheral created above
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", 5)
+		if !errors.Is(err, sensors.ErrPeripheralPinInUse) {
+			t.Errorf("expected ErrPeripheralPinInUse, got %v", err)
+		}
+	})
+
 	t.Run("create with unknown device returns ErrDeviceNotFound", func(t *testing.T) {
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {

--- a/internal/sensors/store_peripheral_postgres.go
+++ b/internal/sensors/store_peripheral_postgres.go
@@ -39,7 +39,13 @@ func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &p.CreatedAt, &p.UpdatedAt,
 	)
 	if err != nil {
-		if isUniqueViolation(err) {
+		switch uniqueViolationIndex(err) {
+		case "peripherals_device_name_active_idx":
+			return Peripheral{}, ErrPeripheralAlreadyExists
+		case "peripherals_device_pin_active_idx":
+			return Peripheral{}, ErrPeripheralPinInUse
+		case "":
+		default:
 			return Peripheral{}, ErrPeripheralAlreadyExists
 		}
 		return Peripheral{}, fmt.Errorf("create peripheral: insert: %w", err)
@@ -138,6 +144,26 @@ func (s *postgresPeripheralStore) DeletePeripheral(ctx context.Context, tx *sql.
 	return nil
 }
 
-func isUniqueViolation(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "23505")
+// uniqueViolationIndex returns the index name from a Postgres unique-violation
+// error (SQLSTATE 23505), or "" if the error is not a unique violation.
+func uniqueViolationIndex(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "23505") {
+		return ""
+	}
+	// pq error messages include the constraint name after "unique constraint"
+	const marker = `unique constraint "`
+	idx := strings.Index(msg, marker)
+	if idx < 0 {
+		return "unknown"
+	}
+	rest := msg[idx+len(marker):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return "unknown"
+	}
+	return rest[:end]
 }


### PR DESCRIPTION
## Summary

- Migration 016 adds `peripherals_device_pin_active_idx` — a partial unique index on `(device_id, pin) WHERE deleted_at IS NULL`, preventing two active peripherals from sharing a GPIO pin on the same device
- New `ErrPeripheralPinInUse` sentinel in `model.go`; `CreatePeripheral` distinguishes the two unique constraints by extracting the index name from the Postgres error via `uniqueViolationIndex()`
- `CreatePeripheralHandler` maps `ErrPeripheralPinInUse` → `409 Conflict` with the message `"pin already in use by another peripheral"`
- Integration test asserts the new error path

## Test plan

- [x] `TestPeripheralStore_integration/create_with_duplicate_pin_returns_ErrPeripheralPinInUse` passes
- [ ] POST `/api/devices/:id/peripherals` with a duplicate pin returns `409` with the pin error message
- [ ] POST with a duplicate name still returns `409` (unchanged behaviour)

Closes #81