### PR TITLE
Standardise error response format across all endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,36 @@ Base URL: `http://localhost:8080` (development)
 
 ---
 
+## Error responses
+
+All error responses return JSON with a consistent structure:
+
+```json
+{
+  "code": "snake_case_error_code",
+  "message": "Human-readable description"
+}
+```
+
+`code` is a stable machine-readable identifier — clients should switch on this, never on `message`. `message` is for humans (logs, dev tools) and may change without notice.
+
+| HTTP status | `code` | Situation |
+|---|---|---|
+| 400 | `invalid_request` | Malformed JSON, missing required fields, or invalid query params |
+| 401 | `unauthorized` | Missing or invalid auth |
+| 403 | `forbidden` | Authenticated but not allowed (e.g. JWT sub mismatch) |
+| 404 | `device_not_found` | Device does not exist or is not owned by the caller |
+| 404 | `peripheral_not_found` | Peripheral does not exist |
+| 404 | `account_not_found` | Account does not exist |
+| 404 | `provisioning_code_not_found` | Provisioning code does not exist |
+| 409 | `peripheral_name_conflict` | Active peripheral with the same name already exists |
+| 409 | `peripheral_pin_conflict` | Active peripheral with the same pin already exists |
+| 409 | `provisioning_code_conflict` | Provisioning code has already been used |
+| 422 | `invalid_request` | Unsupported OIDC provider |
+| 500 | `internal_error` | Unexpected server error |
+
+---
+
 ## GET /health
 
 Health check. No authentication required.

--- a/internal/account/handler.go
+++ b/internal/account/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/go-chi/render"
 )
@@ -23,17 +24,17 @@ type meResponse struct {
 func (h *MeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	account, err := h.Service.Me(r.Context(), claims.UserID)
 	if err != nil {
 		if errors.Is(err, ErrAccountNotFound) {
-			http.Error(w, "account not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "account_not_found", "account not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 

--- a/internal/account/handler_test.go
+++ b/internal/account/handler_test.go
@@ -13,6 +13,22 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 )
 
+func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, wantCode string) {
+	t.Helper()
+	if rec.Code != wantStatus {
+		t.Fatalf("status: got %d, want %d", rec.Code, wantStatus)
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.Code != wantCode {
+		t.Errorf("code: got %q, want %q", body.Code, wantCode)
+	}
+}
+
 type stubAccountStore struct {
 	account account.Account
 	err     error
@@ -64,29 +80,20 @@ func TestMeHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-
-		if w.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("returns 404 when account not found", func(t *testing.T) {
 		h := &account.MeHandler{Service: &account.AccountService{Store: &stubAccountStore{err: account.ErrAccountNotFound}}}
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, requestWithClaims("user-uuid"))
-
-		if w.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusNotFound, "account_not_found")
 	})
 
 	t.Run("returns 500 on store error", func(t *testing.T) {
 		h := &account.MeHandler{Service: &account.AccountService{Store: &stubAccountStore{err: errors.New("db error")}}}
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, requestWithClaims("user-uuid"))
-
-		if w.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusInternalServerError, "internal_error")
 	})
 }

--- a/internal/apierr/apierr.go
+++ b/internal/apierr/apierr.go
@@ -1,0 +1,17 @@
+package apierr
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type body struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func Write(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(body{Code: code, Message: message}) //nolint:errcheck
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
 	"github.com/go-chi/render"
 )
 
@@ -29,40 +30,40 @@ type verifyRequest struct {
 func (h *VerifyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req verifyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
 		return
 	}
 	if req.Provider == "" || req.IDToken == "" {
-		http.Error(w, "provider and id_token are required", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "provider and id_token are required")
 		return
 	}
 
 	user, err := h.service.VerifyAndUpsert(r.Context(), req.Provider, req.IDToken)
 	if err != nil {
 		if errors.Is(err, ErrUnsupportedProvider) {
-			http.Error(w, "unsupported provider", http.StatusUnprocessableEntity)
+			apierr.Write(w, http.StatusUnprocessableEntity, "invalid_request", "unsupported provider")
 			return
 		}
 		if errors.Is(err, ErrInvalidIDToken) {
-			http.Error(w, "invalid id token", http.StatusUnauthorized)
+			apierr.Write(w, http.StatusUnauthorized, "unauthorized", "invalid id token")
 			return
 		}
 		h.logger.Error("auth verify", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
 	sessionToken, err := h.service.IssueSessionJWT(user.ID)
 	if err != nil {
 		h.logger.Error("auth verify: issue session jwt", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
 	refreshToken, err := h.service.IssueRefreshToken(r.Context(), user.ID)
 	if err != nil {
 		h.logger.Error("auth verify: issue refresh token", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -91,22 +92,22 @@ type refreshRequest struct {
 func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req refreshRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
 		return
 	}
 	if req.RefreshToken == "" {
-		http.Error(w, "refresh_token is required", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "refresh_token is required")
 		return
 	}
 
 	newRaw, sessionJWT, err := h.service.RotateRefreshToken(r.Context(), req.RefreshToken)
 	if err != nil {
 		if errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrTokenRevoked) {
-			http.Error(w, "invalid or expired refresh token", http.StatusUnauthorized)
+			apierr.Write(w, http.StatusUnauthorized, "unauthorized", "invalid or expired refresh token")
 			return
 		}
 		h.logger.Error("auth refresh", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 )
 
+func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, wantCode string) {
+	t.Helper()
+	if rec.Code != wantStatus {
+		t.Fatalf("status: got %d, want %d", rec.Code, wantStatus)
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.Code != wantCode {
+		t.Errorf("code: got %q, want %q", body.Code, wantCode)
+	}
+}
+
 type stubAuthService struct {
 	user           auth.User
 	upsertErr      error
@@ -78,9 +94,7 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("missing provider returns 400", func(t *testing.T) {
@@ -89,9 +103,7 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("unsupported provider returns 422", func(t *testing.T) {
@@ -100,9 +112,7 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusUnprocessableEntity {
-			t.Errorf("expected 422, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusUnprocessableEntity, "invalid_request")
 	})
 
 	t.Run("invalid id token returns 401", func(t *testing.T) {
@@ -111,9 +121,7 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("malformed JSON returns 400", func(t *testing.T) {
@@ -121,9 +129,7 @@ func TestVerifyHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader([]byte("not json")))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusBadRequest, "invalid_request")
 	})
 }
 
@@ -157,9 +163,7 @@ func TestRefreshHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("malformed JSON returns 400", func(t *testing.T) {
@@ -167,9 +171,7 @@ func TestRefreshHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader([]byte("not json")))
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", w.Code)
-		}
+		assertErrorCode(t, w, http.StatusBadRequest, "invalid_request")
 	})
 
 	for _, tc := range []struct {
@@ -186,9 +188,7 @@ func TestRefreshHandler(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewReader(body))
 			w := httptest.NewRecorder()
 			h.ServeHTTP(w, req)
-			if w.Code != http.StatusUnauthorized {
-				t.Errorf("expected 401, got %d", w.Code)
-			}
+			assertErrorCode(t, w, http.StatusUnauthorized, "unauthorized")
 		})
 	}
 }

--- a/internal/platform/middleware.go
+++ b/internal/platform/middleware.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
@@ -48,14 +49,14 @@ func DeviceAuthenticator(signer devicejwt.Signer) func(http.Handler) http.Handle
 			raw := bearerToken(r)
 			if raw == "" {
 				slog.Warn("device auth failure", "reason", "missing bearer token", "path", r.URL.Path)
-				http.Error(w, "missing or malformed authorization header", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or malformed authorization header")
 				return
 			}
 
 			pub := signer.PublicKey()
 			if pub == nil {
 				slog.Warn("device auth failure", "reason", "signer not configured", "path", r.URL.Path)
-				http.Error(w, "device auth not configured", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "device auth not configured")
 				return
 			}
 
@@ -67,14 +68,14 @@ func DeviceAuthenticator(signer devicejwt.Signer) func(http.Handler) http.Handle
 			}, jwt.WithValidMethods([]string{"RS256"}))
 			if err != nil || !token.Valid {
 				slog.Warn("device auth failure", "reason", "invalid token", "path", r.URL.Path, "error", err)
-				http.Error(w, "invalid token", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "invalid token")
 				return
 			}
 
 			claims, ok := token.Claims.(jwt.MapClaims)
 			if !ok {
 				slog.Warn("device auth failure", "reason", "invalid claims type", "path", r.URL.Path)
-				http.Error(w, "invalid token claims", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "invalid token claims")
 				return
 			}
 
@@ -82,7 +83,7 @@ func DeviceAuthenticator(signer devicejwt.Signer) func(http.Handler) http.Handle
 			userID, _ := claims["user_id"].(string)
 			if deviceID == "" || userID == "" {
 				slog.Warn("device auth failure", "reason", "missing claims", "path", r.URL.Path)
-				http.Error(w, "invalid token claims", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "invalid token claims")
 				return
 			}
 
@@ -115,14 +116,14 @@ func SessionAuthenticator(svc auth.AuthService) func(http.Handler) http.Handler 
 			}
 			if token == "" {
 				slog.Warn("session auth failure", "reason", "missing token", "path", r.URL.Path)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 				return
 			}
 
 			userID, err := svc.ValidateSessionJWT(token)
 			if err != nil {
 				slog.Warn("session auth failure", "reason", "invalid token", "path", r.URL.Path, "error", err)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 				return
 			}
 

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -27,13 +28,13 @@ type DevicesHandler struct {
 func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	devices, err := h.Service.List(r.Context(), claims.UserID)
 	if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -56,13 +57,13 @@ type ReadingsHandler struct {
 func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	device, ok := DeviceFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "failed to read body", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
 		return
 	}
 
@@ -70,15 +71,14 @@ func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, ErrEmptyPayload) ||
 			errors.Is(err, ErrMissingBaseTime) ||
 			errors.Is(err, ErrEmptyEntries) {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
 		if errors.Is(err, ErrInfluxWrite) {
-			http.Error(w, "failed to persist reading", http.StatusInternalServerError)
+			apierr.Write(w, http.StatusInternalServerError, "internal_error", "failed to persist reading")
 			return
 		}
-		// JSON parse errors and other malformed payload errors.
-		http.Error(w, "invalid payload", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid payload")
 		return
 	}
 
@@ -106,7 +106,7 @@ type ReadingsQueryResponse struct {
 func (h *ReadingsQueryHandler) List(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
@@ -120,7 +120,7 @@ func (h *ReadingsQueryHandler) List(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("from"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			http.Error(w, "invalid 'from' param: must be RFC3339", http.StatusBadRequest)
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid 'from' param: must be RFC3339")
 			return
 		}
 		from = t
@@ -128,7 +128,7 @@ func (h *ReadingsQueryHandler) List(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("to"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			http.Error(w, "invalid 'to' param: must be RFC3339", http.StatusBadRequest)
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid 'to' param: must be RFC3339")
 			return
 		}
 		to = t
@@ -151,10 +151,10 @@ func (h *ReadingsQueryHandler) List(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -181,17 +181,17 @@ type DeleteDeviceHandler struct {
 func (h *DeleteDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	deviceID := chi.URLParam(r, "id")
 	if err := h.Service.Delete(r.Context(), deviceID, claims.UserID); err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -210,13 +210,13 @@ type patchDeviceRequest struct {
 func (h *PatchDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	var req patchDeviceRequest
 	if err := render.DecodeJSON(r.Body, &req); err != nil || req.Name == "" {
-		http.Error(w, "name is required", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name is required")
 		return
 	}
 
@@ -224,10 +224,10 @@ func (h *PatchDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	device, err := h.Service.Patch(r.Context(), deviceID, claims.UserID, req.Name)
 	if err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -250,13 +250,13 @@ type provisionResponse struct {
 func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	code, err := h.Service.Provision(r.Context(), claims.UserID)
 	if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -281,21 +281,21 @@ type activateResponse struct {
 func (h *ActivateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req activateRequest
 	if err := render.DecodeJSON(r.Body, &req); err != nil || req.Code == "" {
-		http.Error(w, "code is required", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "code is required")
 		return
 	}
 
 	result, err := h.Service.Activate(r.Context(), req.Code)
 	if err != nil {
 		if errors.Is(err, ErrCodeNotFound) {
-			http.Error(w, "provisioning code not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "provisioning_code_not_found", "provisioning code not found")
 			return
 		}
 		if errors.Is(err, ErrCodeAlreadyUsed) {
-			http.Error(w, "provisioning code already used", http.StatusConflict)
+			apierr.Write(w, http.StatusConflict, "provisioning_code_conflict", "provisioning code already used")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -324,23 +324,23 @@ type activationStatusResponse struct {
 func (h *ActivationStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	device, ok := DeviceFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	deviceID := chi.URLParam(r, "id")
 	if deviceID != device.DeviceID {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		apierr.Write(w, http.StatusForbidden, "forbidden", "access denied")
 		return
 	}
 
 	status, err := h.Store.GetActivationStatus(r.Context(), deviceID)
 	if err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "device not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -405,17 +405,17 @@ type createPeripheralRequest struct {
 func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	var req createPeripheralRequest
 	if err := render.DecodeJSON(r.Body, &req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
 		return
 	}
 	if req.Name == "" || req.Kind == "" {
-		http.Error(w, "name and kind are required", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name and kind are required")
 		return
 	}
 
@@ -423,18 +423,18 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Pin)
 	if err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
 			return
 		}
 		if errors.Is(err, ErrPeripheralAlreadyExists) {
-			http.Error(w, "peripheral already exists", http.StatusConflict)
+			apierr.Write(w, http.StatusConflict, "peripheral_name_conflict", "a peripheral with that name already exists")
 			return
 		}
 		if errors.Is(err, ErrPeripheralPinInUse) {
-			http.Error(w, "pin already in use by another peripheral", http.StatusConflict)
+			apierr.Write(w, http.StatusConflict, "peripheral_pin_conflict", "pin already in use by another peripheral")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -450,14 +450,14 @@ type ListPeripheralsHandler struct {
 func (h *ListPeripheralsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	deviceID := chi.URLParam(r, "id")
 	peripherals, err := h.Service.List(r.Context(), deviceID, claims.UserID)
 	if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -476,13 +476,13 @@ type SetPeripheralScheduleHandler struct {
 func (h *SetPeripheralScheduleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
 	var schedule []ScheduleWindow
 	if err := render.DecodeJSON(r.Body, &schedule); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
 		return
 	}
 
@@ -491,10 +491,10 @@ func (h *SetPeripheralScheduleHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	p, err := h.Service.SetSchedule(r.Context(), deviceID, claims.UserID, name, schedule)
 	if err != nil {
 		if errors.Is(err, ErrPeripheralNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "peripheral_not_found", "peripheral not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -509,7 +509,7 @@ type DeletePeripheralHandler struct {
 func (h *DeletePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
@@ -517,10 +517,10 @@ func (h *DeletePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	name := chi.URLParam(r, "name")
 	if err := h.Service.Delete(r.Context(), deviceID, claims.UserID, name); err != nil {
 		if errors.Is(err, ErrPeripheralNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "peripheral_not_found", "peripheral not found")
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
@@ -535,7 +535,7 @@ type CommandHandler struct {
 func (h *CommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	claims, ok := auth.ClaimsFromContext(r.Context())
 	if !ok {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
 		return
 	}
 
@@ -544,20 +544,20 @@ func (h *CommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "failed to read body", http.StatusBadRequest)
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
 		return
 	}
 
 	if err := h.Service.SendCommand(r.Context(), deviceID, claims.UserID, peripheralName, body); err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
 			return
 		}
 		if errors.Is(err, ErrInvalidCommand) {
-			http.Error(w, ErrInvalidCommand.Error(), http.StatusBadRequest)
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", ErrInvalidCommand.Error())
 			return
 		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -99,9 +99,7 @@ func TestReadingsHandler_Create(t *testing.T) {
 		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML)), device)
 		rec := httptest.NewRecorder()
 		h.Create(rec, req)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 
 	t.Run("nil writer returns 201 (degraded mode)", func(t *testing.T) {
@@ -119,9 +117,7 @@ func TestReadingsHandler_Create(t *testing.T) {
 		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(`not json`)), device)
 		rec := httptest.NewRecorder()
 		h.Create(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("missing base time returns 400", func(t *testing.T) {
@@ -130,9 +126,7 @@ func TestReadingsHandler_Create(t *testing.T) {
 		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(body)), device)
 		rec := httptest.NewRecorder()
 		h.Create(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("no device in context returns 401", func(t *testing.T) {
@@ -140,9 +134,7 @@ func TestReadingsHandler_Create(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML))
 		rec := httptest.NewRecorder()
 		h.Create(rec, req)
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 }
 
@@ -189,9 +181,7 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 		h.List(rec, makeReq("dev-other", ""))
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
 	})
 
 	t.Run("invalid from param returns 400", func(t *testing.T) {
@@ -200,9 +190,7 @@ func TestReadingsQueryHandler_List(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 		h.List(rec, makeReq("dev-1", "?from=not-a-date"))
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("empty readings returns 200 with empty array", func(t *testing.T) {
@@ -296,9 +284,7 @@ func TestDevicesHandler_List(t *testing.T) {
 		h := &sensors.DevicesHandler{Service: newSvc(&stubDeviceStore{})}
 		rec := httptest.NewRecorder()
 		h.List(rec, httptest.NewRequest(http.MethodGet, "/api/devices", nil))
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("store error returns 500", func(t *testing.T) {
@@ -306,9 +292,7 @@ func TestDevicesHandler_List(t *testing.T) {
 		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/devices", nil), "usr-1")
 		rec := httptest.NewRecorder()
 		h.List(rec, req)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 }
 
@@ -352,27 +336,21 @@ func TestPatchDeviceHandler(t *testing.T) {
 		h := &sensors.PatchDeviceHandler{Service: newPatchSvc(&stubDeviceStore{})}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-1", `{"name":""}`))
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("device not found returns 404", func(t *testing.T) {
 		h := &sensors.PatchDeviceHandler{Service: newPatchSvc(&stubDeviceStore{patchErr: sensors.ErrDeviceNotFound})}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-x", `{"name":"Tank A"}`))
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
 	})
 
 	t.Run("store error returns 500", func(t *testing.T) {
 		h := &sensors.PatchDeviceHandler{Service: newPatchSvc(&stubDeviceStore{patchErr: errors.New("db down")})}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-1", `{"name":"Tank A"}`))
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 
 	t.Run("missing claims returns 401", func(t *testing.T) {
@@ -381,9 +359,7 @@ func TestPatchDeviceHandler(t *testing.T) {
 		req = withChiParam(req, "id", "dev-1")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 }
 
@@ -421,9 +397,7 @@ func TestProvisionHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("store error returns 500", func(t *testing.T) {
@@ -433,9 +407,7 @@ func TestProvisionHandler(t *testing.T) {
 		req := withClaims(httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil), "user-uuid")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 }
 
@@ -486,9 +458,7 @@ func TestActivateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 
 	t.Run("missing code returns 400", func(t *testing.T) {
@@ -496,9 +466,7 @@ func TestActivateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(`{}`))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("unknown code returns 404", func(t *testing.T) {
@@ -509,9 +477,7 @@ func TestActivateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "provisioning_code_not_found")
 	})
 
 	t.Run("already used code returns 409", func(t *testing.T) {
@@ -522,9 +488,7 @@ func TestActivateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusConflict {
-			t.Errorf("expected 409, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusConflict, "provisioning_code_conflict")
 	})
 
 	t.Run("activate error returns 500", func(t *testing.T) {
@@ -535,9 +499,7 @@ func TestActivateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/devices/activate", strings.NewReader(validBody))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 }
 
@@ -612,22 +574,17 @@ func TestActivationStatusHandler(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-x", sensors.DeviceInfo{DeviceID: "dev-x", UserID: "usr-1"}))
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
 	})
 
 	t.Run("device ID mismatch returns 403", func(t *testing.T) {
 		h := &sensors.ActivationStatusHandler{Store: &stubDeviceStore{}}
 		rec := httptest.NewRecorder()
-		// JWT claims dev-1 but URL param is dev-2
 		req := httptest.NewRequest(http.MethodGet, "/devices/dev-2/status", nil)
 		req = withDevice(req, sensors.DeviceInfo{DeviceID: "dev-1", UserID: "usr-1"})
 		req = withChiParam(req, "id", "dev-2")
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusForbidden {
-			t.Errorf("expected 403, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusForbidden, "forbidden")
 	})
 
 	t.Run("no device in context returns 401", func(t *testing.T) {
@@ -636,9 +593,7 @@ func TestActivationStatusHandler(t *testing.T) {
 		req = withChiParam(req, "id", "dev-1")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 }
 
@@ -677,27 +632,21 @@ func TestCommandHandler(t *testing.T) {
 		h := newCommandHandler(&stubDeviceStore{findErr: sensors.ErrDeviceNotFound}, &stubPublisher{})
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq(body, "user-1"))
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
 	})
 
 	t.Run("400 on invalid action", func(t *testing.T) {
 		h := newCommandHandler(&stubDeviceStore{}, &stubPublisher{})
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq(`{"action":"invalid"}`, "user-1"))
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("500 on publisher error", func(t *testing.T) {
 		h := newCommandHandler(&stubDeviceStore{}, &stubPublisher{err: errors.New("broker down")})
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq(body, "user-1"))
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 }
 
@@ -750,26 +699,20 @@ func TestDeleteDeviceHandler(t *testing.T) {
 		h := newDeleteHandler(&stubDeviceStore{deleteErr: sensors.ErrDeviceNotFound}, &stubHiveMQClient{})
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-x", "user-uuid"))
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
 	})
 
 	t.Run("500 on store error", func(t *testing.T) {
 		h := newDeleteHandler(&stubDeviceStore{deleteErr: errors.New("db down")}, &stubHiveMQClient{})
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-uuid", "user-uuid"))
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 
 	t.Run("401 when no claims", func(t *testing.T) {
 		h := newDeleteHandler(&stubDeviceStore{}, &stubHiveMQClient{})
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, makeReq("dev-uuid", ""))
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 }

--- a/internal/sensors/peripheral_handler_test.go
+++ b/internal/sensors/peripheral_handler_test.go
@@ -81,9 +81,7 @@ func TestListPeripheralsHandler(t *testing.T) {
 		h := &sensors.ListPeripheralsHandler{Service: svc}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 }
 
@@ -129,10 +127,7 @@ func TestSetPeripheralScheduleHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "peripheral_not_found")
 	})
 
 	t.Run("invalid body returns 400", func(t *testing.T) {
@@ -145,10 +140,7 @@ func TestSetPeripheralScheduleHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 }
 
@@ -165,9 +157,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("missing name returns 400", func(t *testing.T) {
@@ -180,9 +170,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("no auth returns 401", func(t *testing.T) {
@@ -191,9 +179,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`))
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("already exists returns 409", func(t *testing.T) {
@@ -208,9 +194,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusConflict {
-			t.Errorf("expected 409, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusConflict, "peripheral_name_conflict")
 	})
 
 	t.Run("device not found returns 404", func(t *testing.T) {
@@ -225,9 +209,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
 	})
 }
 
@@ -239,9 +221,7 @@ func TestDeletePeripheralHandler(t *testing.T) {
 		h := &sensors.DeletePeripheralHandler{Service: svc}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/", nil))
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("peripheral not found returns 404", func(t *testing.T) {
@@ -256,9 +236,7 @@ func TestDeletePeripheralHandler(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-		if rec.Code != http.StatusNotFound {
-			t.Errorf("expected 404, got %d", rec.Code)
-		}
+		assertErrorCode(t, rec, http.StatusNotFound, "peripheral_not_found")
 	})
 }
 

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -4,12 +4,31 @@ import (
 	"context"
 	"crypto/rsa"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"net/http/httptest"
+	"testing"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/sensors"
 )
+
+func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, wantCode string) {
+	t.Helper()
+	if rec.Code != wantStatus {
+		t.Fatalf("status: got %d, want %d", rec.Code, wantStatus)
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.Code != wantCode {
+		t.Errorf("code: got %q, want %q", body.Code, wantCode)
+	}
+}
 
 // ── DeviceStore ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Introduces `internal/apierr` package with a single `Write(w, status, code, message)` helper that returns `{"code":"...","message":"..."}` JSON on every error path
- Replaces all `http.Error` calls across `sensors/handler.go`, `auth/handler.go`, `account/handler.go`, and `platform/middleware.go`
- Updates all handler tests to assert on the `code` field (not body text) via a shared `assertErrorCode` helper per package
- Documents the full error response contract and code table in `docs/api.md`

Error codes: `unauthorized`, `forbidden`, `invalid_request`, `device_not_found`, `peripheral_not_found`, `peripheral_name_conflict`, `peripheral_pin_conflict`, `account_not_found`, `provisioning_code_not_found`, `provisioning_code_conflict`, `internal_error`

## Test plan

- [ ] `go test ./internal/sensors/... ./internal/auth/... ./internal/account/... ./internal/platform/...` — all pass
- [ ] Error responses on all endpoints now return `Content-Type: application/json` with a `code` field clients can switch on

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)