### PR TITLE
Add category and control_mode to peripherals

### DIFF
--- a/db/migrations/017_peripheral_category_control_mode.down.sql
+++ b/db/migrations/017_peripheral_category_control_mode.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE peripherals
+  DROP CONSTRAINT peripherals_control_mode_actuator_only,
+  DROP COLUMN control_mode,
+  DROP COLUMN category;

--- a/db/migrations/017_peripheral_category_control_mode.up.sql
+++ b/db/migrations/017_peripheral_category_control_mode.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE peripherals
+  ADD COLUMN category TEXT NOT NULL DEFAULT 'sensor'
+    CHECK (category IN ('sensor', 'actuator')),
+  ADD COLUMN control_mode TEXT
+    CHECK (control_mode IS NULL OR control_mode IN ('automatic', 'manual'));
+
+ALTER TABLE peripherals
+  ADD CONSTRAINT peripherals_control_mode_actuator_only
+    CHECK (category = 'actuator' OR control_mode IS NULL);
+
+UPDATE peripherals SET category = 'actuator', control_mode = 'automatic'
+WHERE kind = 'relay';

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -364,14 +364,16 @@ type CommandPublisher interface {
 }
 
 type PeripheralResponse struct {
-	ID        string           `json:"id"`
-	DeviceID  string           `json:"device_id"`
-	Name      string           `json:"name"`
-	Kind      string           `json:"kind"`
-	Pin       int              `json:"pin"`
-	Schedule  []ScheduleWindow `json:"schedule"`
-	CreatedAt string           `json:"created_at"`
-	UpdatedAt string           `json:"updated_at"`
+	ID          string           `json:"id"`
+	DeviceID    string           `json:"device_id"`
+	Name        string           `json:"name"`
+	Kind        string           `json:"kind"`
+	Pin         int              `json:"pin"`
+	Category    string           `json:"category"`
+	ControlMode *string          `json:"control_mode"`
+	Schedule    []ScheduleWindow `json:"schedule"`
+	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at"`
 }
 
 func peripheralResponse(p Peripheral) PeripheralResponse {
@@ -380,14 +382,16 @@ func peripheralResponse(p Peripheral) PeripheralResponse {
 		schedule = []ScheduleWindow{}
 	}
 	return PeripheralResponse{
-		ID:        p.ID,
-		DeviceID:  p.DeviceID,
-		Name:      p.Name,
-		Kind:      p.Kind,
-		Pin:       p.Pin,
-		Schedule:  schedule,
-		CreatedAt: p.CreatedAt.UTC().Format(time.RFC3339),
-		UpdatedAt: p.UpdatedAt.UTC().Format(time.RFC3339),
+		ID:          p.ID,
+		DeviceID:    p.DeviceID,
+		Name:        p.Name,
+		Kind:        p.Kind,
+		Pin:         p.Pin,
+		Category:    p.Category,
+		ControlMode: p.ControlMode,
+		Schedule:    schedule,
+		CreatedAt:   p.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   p.UpdatedAt.UTC().Format(time.RFC3339),
 	}
 }
 
@@ -397,9 +401,10 @@ type CreatePeripheralHandler struct {
 }
 
 type createPeripheralRequest struct {
-	Name string `json:"name"`
-	Kind string `json:"kind"`
-	Pin  int    `json:"pin"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	Pin      int    `json:"pin"`
+	Category string `json:"category"` // optional; defaults to "sensor"
 }
 
 func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -418,9 +423,16 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name and kind are required")
 		return
 	}
+	if req.Category == "" {
+		req.Category = "sensor"
+	}
+	if req.Category != "sensor" && req.Category != "actuator" {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "category must be 'sensor' or 'actuator'")
+		return
+	}
 
 	deviceID := chi.URLParam(r, "id")
-	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Pin)
+	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Category, req.Pin)
 	if err != nil {
 		if errors.Is(err, ErrDeviceNotFound) {
 			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
@@ -525,6 +537,51 @@ func (h *DeletePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// SetControlModeHandler handles PATCH /api/devices/{id}/peripherals/{name}/control-mode (session auth).
+type SetControlModeHandler struct {
+	Service *PeripheralService
+}
+
+type setControlModeRequest struct {
+	Mode string `json:"mode"`
+}
+
+func (h *SetControlModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.ClaimsFromContext(r.Context())
+	if !ok {
+		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
+		return
+	}
+
+	var req setControlModeRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	if req.Mode != "automatic" && req.Mode != "manual" {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "mode must be 'automatic' or 'manual'")
+		return
+	}
+
+	deviceID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	p, err := h.Service.SetControlMode(r.Context(), deviceID, claims.UserID, name, req.Mode)
+	if err != nil {
+		if errors.Is(err, ErrPeripheralNotFound) {
+			apierr.Write(w, http.StatusNotFound, "peripheral_not_found", "peripheral not found")
+			return
+		}
+		if errors.Is(err, ErrNotAnActuator) {
+			apierr.Write(w, http.StatusUnprocessableEntity, "not_an_actuator", "control mode is only supported for actuator peripherals")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	render.JSON(w, r, peripheralResponse(p))
 }
 
 // CommandHandler handles POST /api/devices/{id}/peripherals/{name}/commands (session auth).

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -7,14 +7,16 @@ import (
 )
 
 type Peripheral struct {
-	ID        string
-	DeviceID  string
-	Name      string
-	Kind      string
-	Pin       int
-	Schedule  []ScheduleWindow
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID          string
+	DeviceID    string
+	Name        string
+	Kind        string
+	Pin         int
+	Category    string  // "sensor" | "actuator"
+	ControlMode *string // nil for sensors; "automatic"|"manual" for actuators
+	Schedule    []ScheduleWindow
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type ScheduleWindow struct {
@@ -24,6 +26,7 @@ type ScheduleWindow struct {
 	Days  []int   `json:"days,omitempty"`
 }
 
+var ErrNotAnActuator           = errors.New("peripheral is not an actuator")
 var ErrDeviceNotFound          = errors.New("device not found")
 var ErrCodeNotFound            = errors.New("provisioning code not found")
 var ErrCodeAlreadyUsed         = errors.New("provisioning code already used")

--- a/internal/sensors/peripheral_handler_test.go
+++ b/internal/sensors/peripheral_handler_test.go
@@ -13,15 +13,18 @@ import (
 )
 
 func newPeripheral(name string) sensors.Peripheral {
+	mode := "automatic"
 	return sensors.Peripheral{
-		ID:        "pid-1",
-		DeviceID:  "dev-1",
-		Name:      name,
-		Kind:      "relay",
-		Pin:       5,
-		Schedule:  nil,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		ID:          "pid-1",
+		DeviceID:    "dev-1",
+		Name:        name,
+		Kind:        "relay",
+		Pin:         5,
+		Category:    "actuator",
+		ControlMode: &mode,
+		Schedule:    nil,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
 	}
 }
 
@@ -210,6 +213,102 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
+	})
+}
+
+// ── SetControlModeHandler ─────────────────────────────────────────────────────
+
+func TestSetControlModeHandler(t *testing.T) {
+	t.Run("returns 200 with updated peripheral", func(t *testing.T) {
+		p := newPeripheral("light")
+		mode := "manual"
+		p.ControlMode = &mode
+		db := testutil.NewTestDB(t)
+		store := &stubPeripheralStore{controlModeP: p}
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetControlModeHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"manual"}`)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "light"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["control_mode"] != "manual" {
+			t.Errorf("expected control_mode=manual, got %v", resp["control_mode"])
+		}
+	})
+
+	t.Run("invalid mode returns 400", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetControlModeHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"unknown"}`)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "light"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("missing mode returns 400", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetControlModeHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{}`)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "light"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("peripheral not found returns 404", func(t *testing.T) {
+		db := testutil.NewTestDB(t)
+		store := &stubPeripheralStore{controlModeErr: sensors.ErrPeripheralNotFound}
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetControlModeHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"manual"}`)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "ghost"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "peripheral_not_found")
+	})
+
+	t.Run("sensor peripheral returns 422", func(t *testing.T) {
+		db := testutil.NewTestDB(t)
+		store := &stubPeripheralStore{controlModeErr: sensors.ErrNotAnActuator}
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetControlModeHandler{Service: svc}
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"manual"}`)), "user-1"),
+			map[string]string{"id": "dev-1", "name": "temp"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusUnprocessableEntity, "not_an_actuator")
+	})
+
+	t.Run("no auth returns 401", func(t *testing.T) {
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		h := &sensors.SetControlModeHandler{Service: svc}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"manual"}`)))
+		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 }
 

--- a/internal/sensors/peripheral_service.go
+++ b/internal/sensors/peripheral_service.go
@@ -41,14 +41,14 @@ func NewPeripheralService(
 }
 
 // Register creates a new peripheral and enqueues a peripheral.push outbox event atomically.
-func (s *PeripheralService) Register(ctx context.Context, deviceID, userID, name, kind string, pin int) (Peripheral, error) {
+func (s *PeripheralService) Register(ctx context.Context, deviceID, userID, name, kind, category string, pin int) (Peripheral, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return Peripheral{}, fmt.Errorf("register peripheral: begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
-	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, pin)
+	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, category, pin)
 	if err != nil {
 		if !errors.Is(err, ErrDeviceNotFound) && !errors.Is(err, ErrPeripheralAlreadyExists) {
 			s.logger.Error("register peripheral: create", "device_id", deviceID, "name", name, "error", err)
@@ -107,6 +107,45 @@ func (s *PeripheralService) SetSchedule(ctx context.Context, deviceID, userID, n
 	topic := fmt.Sprintf("fishhub/%s/commands/%s", deviceID, name)
 	if err := s.publisher.Publish(ctx, topic, msg); err != nil {
 		s.logger.Warn("set peripheral schedule: mqtt publish failed", "device_id", deviceID, "name", name, "error", err)
+	}
+
+	return p, nil
+}
+
+// SetControlMode updates control_mode for an actuator peripheral.
+// Publishes the set_mode MQTT command before committing — rolls back on publish failure.
+func (s *PeripheralService) SetControlMode(ctx context.Context, deviceID, userID, name, mode string) (Peripheral, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("set control mode: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	p, err := s.store.SetControlMode(ctx, tx, deviceID, userID, name, mode)
+	if err != nil {
+		if !errors.Is(err, ErrPeripheralNotFound) && !errors.Is(err, ErrNotAnActuator) {
+			s.logger.Error("set control mode: store", "device_id", deviceID, "name", name, "error", err)
+		}
+		return Peripheral{}, err
+	}
+
+	msg, err := json.Marshal(map[string]any{
+		"action": "set_mode",
+		"mode":   mode,
+	})
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("set control mode: marshal mqtt payload: %w", err)
+	}
+
+	topic := fmt.Sprintf("fishhub/%s/commands/%s", deviceID, name)
+	if err := s.publisher.Publish(ctx, topic, msg); err != nil {
+		s.logger.Error("set control mode: mqtt publish failed", "device_id", deviceID, "name", name, "error", err)
+		return Peripheral{}, fmt.Errorf("set control mode: mqtt publish: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("set control mode: commit", "device_id", deviceID, "name", name, "error", err)
+		return Peripheral{}, fmt.Errorf("set control mode: commit: %w", err)
 	}
 
 	return p, nil

--- a/internal/sensors/peripheral_service.go
+++ b/internal/sensors/peripheral_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+	"github.com/google/uuid"
 )
 
 // PeripheralService orchestrates peripheral registration, listing, schedule updates, and deletion.
@@ -96,6 +97,7 @@ func (s *PeripheralService) SetSchedule(ctx context.Context, deviceID, userID, n
 	}
 
 	msg, err := json.Marshal(map[string]any{
+		"id":      uuid.NewString(),
 		"action":  "schedule",
 		"windows": schedule,
 	})
@@ -130,6 +132,7 @@ func (s *PeripheralService) SetControlMode(ctx context.Context, deviceID, userID
 	}
 
 	msg, err := json.Marshal(map[string]any{
+		"id":     uuid.NewString(),
 		"action": "set_mode",
 		"mode":   mode,
 	})

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -44,13 +44,19 @@ type PeripheralStore interface {
 	// CreatePeripheral inserts a new peripheral for the device owned by userID.
 	// Returns ErrDeviceNotFound if the device does not exist or is not owned by userID.
 	// Returns ErrPeripheralAlreadyExists if an active peripheral with the same name exists.
-	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind string, pin int) (Peripheral, error)
+	// Returns ErrPeripheralPinInUse if an active peripheral with the same pin exists.
+	// category must be "sensor" or "actuator"; actuators get control_mode defaulted to "automatic".
+	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, pin int) (Peripheral, error)
 	// ListPeripherals returns active (non-deleted) peripherals for the device owned by userID.
 	// Returns an empty slice if the device does not exist or is not owned by userID.
 	ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error)
 	// SetPeripheralSchedule persists the schedule and returns the updated peripheral.
 	// Returns ErrPeripheralNotFound if the peripheral does not exist or is not reachable by userID.
 	SetPeripheralSchedule(ctx context.Context, deviceID, userID, name string, schedule []ScheduleWindow) (Peripheral, error)
+	// SetControlMode updates control_mode for an actuator peripheral within the provided transaction.
+	// Returns ErrPeripheralNotFound if the peripheral does not exist or is not reachable by userID.
+	// Returns ErrNotAnActuator if the peripheral's category is not "actuator".
+	SetControlMode(ctx context.Context, tx *sql.Tx, deviceID, userID, name, mode string) (Peripheral, error)
 	// DeletePeripheral soft-deletes the peripheral (sets deleted_at).
 	// Returns ErrPeripheralNotFound if the peripheral does not exist or is not reachable by userID.
 	DeletePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name string) error

--- a/internal/sensors/store_peripheral_integration_test.go
+++ b/internal/sensors/store_peripheral_integration_test.go
@@ -24,14 +24,14 @@ func TestPeripheralStore_integration(t *testing.T) {
 		t.Fatalf("insert device: %v", err)
 	}
 
-	t.Run("create peripheral", func(t *testing.T) {
+	t.Run("create actuator peripheral", func(t *testing.T) {
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer tx.Rollback()
 
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", 5)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", 5)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -44,9 +44,37 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if p.Name != "light" || p.Kind != "relay" || p.Pin != 5 {
 			t.Errorf("unexpected peripheral: %+v", p)
 		}
+		if p.Category != "actuator" {
+			t.Errorf("expected category=actuator, got %q", p.Category)
+		}
+		if p.ControlMode == nil || *p.ControlMode != "automatic" {
+			t.Errorf("expected control_mode=automatic, got %v", p.ControlMode)
+		}
 	})
 
-	t.Run("list returns created peripheral", func(t *testing.T) {
+	t.Run("create sensor peripheral has nil control_mode", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "temp", "ds18b20", "sensor", 4)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		if p.Category != "sensor" {
+			t.Errorf("expected category=sensor, got %q", p.Category)
+		}
+		if p.ControlMode != nil {
+			t.Errorf("expected nil control_mode for sensor, got %v", p.ControlMode)
+		}
+	})
+
+	t.Run("list returns created peripherals with category and control_mode", func(t *testing.T) {
 		peripherals, err := store.ListPeripherals(ctx, deviceID, userID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -54,8 +82,20 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if len(peripherals) == 0 {
 			t.Fatal("expected at least one peripheral")
 		}
-		if peripherals[0].Name != "light" {
-			t.Errorf("expected 'light', got %q", peripherals[0].Name)
+		found := false
+		for _, p := range peripherals {
+			if p.Name == "light" {
+				found = true
+				if p.Category != "actuator" {
+					t.Errorf("expected actuator, got %q", p.Category)
+				}
+				if p.ControlMode == nil || *p.ControlMode != "automatic" {
+					t.Errorf("expected automatic control_mode, got %v", p.ControlMode)
+				}
+			}
+		}
+		if !found {
+			t.Error("light peripheral not found in list")
 		}
 	})
 
@@ -66,7 +106,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", 6)
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", 6)
 		if !errors.Is(err, sensors.ErrPeripheralAlreadyExists) {
 			t.Errorf("expected ErrPeripheralAlreadyExists, got %v", err)
 		}
@@ -80,7 +120,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		defer tx.Rollback()
 
 		// pin 5 is already used by the "light" peripheral created above
-		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", 5)
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", "actuator", 5)
 		if !errors.Is(err, sensors.ErrPeripheralPinInUse) {
 			t.Errorf("expected ErrPeripheralPinInUse, got %v", err)
 		}
@@ -93,7 +133,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", 7)
+		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", "actuator", 7)
 		if !errors.Is(err, sensors.ErrDeviceNotFound) {
 			t.Errorf("expected ErrDeviceNotFound, got %v", err)
 		}
@@ -114,6 +154,51 @@ func TestPeripheralStore_integration(t *testing.T) {
 
 	t.Run("set schedule on unknown peripheral returns ErrPeripheralNotFound", func(t *testing.T) {
 		_, err := store.SetPeripheralSchedule(ctx, deviceID, userID, "nope", nil)
+		if !errors.Is(err, sensors.ErrPeripheralNotFound) {
+			t.Errorf("expected ErrPeripheralNotFound, got %v", err)
+		}
+	})
+
+	t.Run("set control mode on actuator", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		p, err := store.SetControlMode(ctx, tx, deviceID, userID, "light", "manual")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		if p.ControlMode == nil || *p.ControlMode != "manual" {
+			t.Errorf("expected control_mode=manual, got %v", p.ControlMode)
+		}
+	})
+
+	t.Run("set control mode on sensor returns ErrNotAnActuator", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		_, err = store.SetControlMode(ctx, tx, deviceID, userID, "temp", "manual")
+		if !errors.Is(err, sensors.ErrNotAnActuator) {
+			t.Errorf("expected ErrNotAnActuator, got %v", err)
+		}
+	})
+
+	t.Run("set control mode on unknown peripheral returns ErrPeripheralNotFound", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		_, err = store.SetControlMode(ctx, tx, deviceID, userID, "ghost", "manual")
 		if !errors.Is(err, sensors.ErrPeripheralNotFound) {
 			t.Errorf("expected ErrPeripheralNotFound, got %v", err)
 		}
@@ -179,7 +264,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", 5)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", 5)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("re-create after delete: %v", err)

--- a/internal/sensors/store_peripheral_postgres.go
+++ b/internal/sensors/store_peripheral_postgres.go
@@ -17,7 +17,7 @@ func NewPeripheralStore(db *sql.DB) PeripheralStore {
 	return &postgresPeripheralStore{db: db}
 }
 
-func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind string, pin int) (Peripheral, error) {
+func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, pin int) (Peripheral, error) {
 	var exists bool
 	err := s.db.QueryRowContext(ctx,
 		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL)`,
@@ -31,12 +31,15 @@ func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.
 	}
 
 	var p Peripheral
+	var controlMode sql.NullString
 	err = tx.QueryRowContext(ctx, `
-		INSERT INTO peripherals (device_id, name, kind, pin)
-		VALUES ($1, $2, $3, $4)
-		RETURNING id, device_id, name, kind, pin, created_at, updated_at
-	`, deviceID, name, kind, pin).Scan(
-		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &p.CreatedAt, &p.UpdatedAt,
+		INSERT INTO peripherals (device_id, name, kind, pin, category, control_mode)
+		VALUES ($1, $2, $3, $4, $5,
+			CASE WHEN $5 = 'actuator' THEN 'automatic' ELSE NULL END)
+		RETURNING id, device_id, name, kind, pin, category, control_mode, created_at, updated_at
+	`, deviceID, name, kind, pin, category).Scan(
+		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
+		&p.Category, &controlMode, &p.CreatedAt, &p.UpdatedAt,
 	)
 	if err != nil {
 		switch uniqueViolationIndex(err) {
@@ -50,12 +53,16 @@ func (s *postgresPeripheralStore) CreatePeripheral(ctx context.Context, tx *sql.
 		}
 		return Peripheral{}, fmt.Errorf("create peripheral: insert: %w", err)
 	}
+	if controlMode.Valid {
+		p.ControlMode = &controlMode.String
+	}
 	return p, nil
 }
 
 func (s *postgresPeripheralStore) ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.schedule, p.created_at, p.updated_at
+		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
+		       p.schedule, p.created_at, p.updated_at
 		FROM peripherals p
 		JOIN devices d ON d.id = p.device_id
 		WHERE p.device_id = $1
@@ -72,9 +79,17 @@ func (s *postgresPeripheralStore) ListPeripherals(ctx context.Context, deviceID,
 	peripherals := []Peripheral{}
 	for rows.Next() {
 		var p Peripheral
+		var controlMode sql.NullString
 		var scheduleJSON []byte
-		if err := rows.Scan(&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &scheduleJSON, &p.CreatedAt, &p.UpdatedAt); err != nil {
+		if err := rows.Scan(
+			&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
+			&p.Category, &controlMode, &scheduleJSON,
+			&p.CreatedAt, &p.UpdatedAt,
+		); err != nil {
 			return nil, fmt.Errorf("list peripherals: scan: %w", err)
+		}
+		if controlMode.Valid {
+			p.ControlMode = &controlMode.String
 		}
 		if scheduleJSON != nil {
 			if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
@@ -93,6 +108,8 @@ func (s *postgresPeripheralStore) SetPeripheralSchedule(ctx context.Context, dev
 	}
 
 	var p Peripheral
+	var controlMode sql.NullString
+	var scheduleOut []byte
 	err = s.db.QueryRowContext(ctx, `
 		UPDATE peripherals p
 		SET schedule = $1, updated_at = now()
@@ -103,9 +120,12 @@ func (s *postgresPeripheralStore) SetPeripheralSchedule(ctx context.Context, dev
 		  AND p.name = $4
 		  AND p.deleted_at IS NULL
 		  AND d.deleted_at IS NULL
-		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.schedule, p.created_at, p.updated_at
+		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
+		          p.schedule, p.created_at, p.updated_at
 	`, scheduleJSON, userID, deviceID, name).Scan(
-		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin, &scheduleJSON, &p.CreatedAt, &p.UpdatedAt,
+		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
+		&p.Category, &controlMode, &scheduleOut,
+		&p.CreatedAt, &p.UpdatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Peripheral{}, ErrPeripheralNotFound
@@ -113,8 +133,68 @@ func (s *postgresPeripheralStore) SetPeripheralSchedule(ctx context.Context, dev
 	if err != nil {
 		return Peripheral{}, fmt.Errorf("set peripheral schedule: update: %w", err)
 	}
-	if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
+	if controlMode.Valid {
+		p.ControlMode = &controlMode.String
+	}
+	if err := json.Unmarshal(scheduleOut, &p.Schedule); err != nil {
 		return Peripheral{}, fmt.Errorf("set peripheral schedule: unmarshal: %w", err)
+	}
+	return p, nil
+}
+
+func (s *postgresPeripheralStore) SetControlMode(ctx context.Context, tx *sql.Tx, deviceID, userID, name, mode string) (Peripheral, error) {
+	var p Peripheral
+	var controlMode sql.NullString
+	var scheduleJSON []byte
+	err := tx.QueryRowContext(ctx, `
+		UPDATE peripherals p
+		SET control_mode = $1, updated_at = now()
+		FROM devices d
+		WHERE p.device_id = d.id
+		  AND d.user_id = $2
+		  AND p.device_id = $3
+		  AND p.name = $4
+		  AND p.category = 'actuator'
+		  AND p.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
+		          p.schedule, p.created_at, p.updated_at
+	`, mode, userID, deviceID, name).Scan(
+		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
+		&p.Category, &controlMode, &scheduleJSON,
+		&p.CreatedAt, &p.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Distinguish "not an actuator" from "not found".
+		var category string
+		lookupErr := s.db.QueryRowContext(ctx, `
+			SELECT p.category
+			FROM peripherals p
+			JOIN devices d ON d.id = p.device_id
+			WHERE p.device_id = $1
+			  AND d.user_id = $2
+			  AND p.name = $3
+			  AND p.deleted_at IS NULL
+			  AND d.deleted_at IS NULL
+		`, deviceID, userID, name).Scan(&category)
+		if errors.Is(lookupErr, sql.ErrNoRows) {
+			return Peripheral{}, ErrPeripheralNotFound
+		}
+		if lookupErr != nil {
+			return Peripheral{}, fmt.Errorf("set control mode: lookup: %w", lookupErr)
+		}
+		return Peripheral{}, ErrNotAnActuator
+	}
+	if err != nil {
+		return Peripheral{}, fmt.Errorf("set control mode: update: %w", err)
+	}
+	if controlMode.Valid {
+		p.ControlMode = &controlMode.String
+	}
+	if scheduleJSON != nil {
+		if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
+			return Peripheral{}, fmt.Errorf("set control mode: unmarshal schedule: %w", err)
+		}
 	}
 	return p, nil
 }
@@ -154,7 +234,6 @@ func uniqueViolationIndex(err error) string {
 	if !strings.Contains(msg, "23505") {
 		return ""
 	}
-	// pq error messages include the constraint name after "unique constraint"
 	const marker = `unique constraint "`
 	idx := strings.Index(msg, marker)
 	if idx < 0 {

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -190,16 +190,18 @@ func (s *stubActivationStatusStore) GetActivationStatus(_ context.Context, _ str
 // ── PeripheralStore ───────────────────────────────────────────────────────────
 
 type stubPeripheralStore struct {
-	created    sensors.Peripheral
-	createErr  error
-	listed     []sensors.Peripheral
-	listErr    error
-	scheduled  sensors.Peripheral
-	schedErr   error
-	deleteErr  error
+	created          sensors.Peripheral
+	createErr        error
+	listed           []sensors.Peripheral
+	listErr          error
+	scheduled        sensors.Peripheral
+	schedErr         error
+	controlModeP     sensors.Peripheral
+	controlModeErr   error
+	deleteErr        error
 }
 
-func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _ string, _ int) (sensors.Peripheral, error) {
+func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _, _ string, _ int) (sensors.Peripheral, error) {
 	return s.created, s.createErr
 }
 func (s *stubPeripheralStore) ListPeripherals(_ context.Context, _, _ string) ([]sensors.Peripheral, error) {
@@ -207,6 +209,9 @@ func (s *stubPeripheralStore) ListPeripherals(_ context.Context, _, _ string) ([
 }
 func (s *stubPeripheralStore) SetPeripheralSchedule(_ context.Context, _, _, _ string, _ []sensors.ScheduleWindow) (sensors.Peripheral, error) {
 	return s.scheduled, s.schedErr
+}
+func (s *stubPeripheralStore) SetControlMode(_ context.Context, _ *sql.Tx, _, _, _, _ string) (sensors.Peripheral, error) {
+	return s.controlModeP, s.controlModeErr
 }
 func (s *stubPeripheralStore) DeletePeripheral(_ context.Context, _ *sql.Tx, _, _, _ string) error {
 	return s.deleteErr

--- a/main.go
+++ b/main.go
@@ -285,6 +285,7 @@ func main() {
 		r.Get("/api/devices/{id}/peripherals", (&sensors.ListPeripheralsHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Put("/api/devices/{id}/peripherals/{name}/schedule", (&sensors.SetPeripheralScheduleHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Delete("/api/devices/{id}/peripherals/{name}", (&sensors.DeletePeripheralHandler{Service: peripheralSvc}).ServeHTTP)
+		r.Patch("/api/devices/{id}/peripherals/{name}/control-mode", (&sensors.SetControlModeHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Post("/api/devices/{id}/peripherals/{name}/commands", (&sensors.CommandHandler{Service: deviceSvc}).ServeHTTP)
 	})
 


### PR DESCRIPTION
## Summary

- Migration 017 adds \`category\` (\`sensor\`|\`actuator\`) and \`control_mode\` (\`automatic\`|\`manual\`|NULL) columns to \`peripherals\`, with a check constraint enforcing \`control_mode IS NULL\` for sensors; backfills existing relay rows to \`actuator\`/\`automatic\`
- \`Peripheral\` model gains \`Category\` and \`ControlMode\` fields; adds \`ErrNotAnActuator\`
- \`CreatePeripheral\` accepts an explicit \`category\`; actuators get \`control_mode\` defaulted to \`'automatic'\`
- New \`SetControlMode\` store method updates \`control_mode\` within a caller-supplied transaction, correctly distinguishing \`ErrNotAnActuator\` from \`ErrPeripheralNotFound\`
- \`PeripheralService.SetControlMode\` publishes the \`set_mode\` MQTT command **before** committing — rolls back on publish failure to keep DB and firmware in sync
- New \`PATCH /api/devices/{id}/peripherals/{name}/control-mode\` endpoint (400/401/404/422/500)
- All peripheral JSON responses now include \`category\` and \`control_mode\`

Closes #87