### PR TITLE
Remove deprecated POST /readings HTTP endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -45,45 +45,6 @@ Health check. No authentication required.
 
 ---
 
-## POST /readings
-
-> **Deprecated:** devices should publish readings via MQTT to `fishhub/{device_id}/readings` instead (see fishhub-oss/fishhub-firmware#46). This endpoint remains functional as a fallback.
-
-Accepts a SenML reading from an authenticated device.
-
-**Headers**
-```
-Authorization: Bearer <device-jwt>
-Content-Type: application/json
-```
-
-**Request body** — SenML JSON (RFC 8428)
-```json
-[{
-  "bn": "fishhub/device/",
-  "bt": 1713000000,
-  "e": [{"n": "temperature", "u": "Cel", "v": 23.4}]
-}]
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `bn` | string | Base name |
-| `bt` | int64 | Base time — Unix UTC timestamp of the reading |
-| `e[*].n` | string | Measurement name (e.g. `"temperature"`) |
-| `e[*].u` | string | Unit (e.g. `"Cel"`) |
-| `e[*].v` | float | Measurement value |
-
-**Response `201`** — `{}`
-
-**Response `400`** — malformed JSON, missing `bt`, or empty entries
-
-**Response `401`** — missing or invalid device JWT
-
-**Response `500`** — InfluxDB write failure
-
----
-
 ## POST /auth/verify
 
 Verifies a Google OIDC ID token and issues a session JWT + refresh token. Called by the web frontend after the OAuth callback.

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -49,43 +49,6 @@ func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, resp)
 }
 
-// ReadingsHandler handles POST /readings (device JWT auth).
-type ReadingsHandler struct {
-	Service *ReadingsService
-}
-
-func (h *ReadingsHandler) Create(w http.ResponseWriter, r *http.Request) {
-	device, ok := DeviceFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		apierr.Write(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
-		return
-	}
-
-	if err := h.Service.Write(r.Context(), device, body); err != nil {
-		if errors.Is(err, ErrEmptyPayload) ||
-			errors.Is(err, ErrMissingBaseTime) ||
-			errors.Is(err, ErrEmptyEntries) {
-			apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
-			return
-		}
-		if errors.Is(err, ErrInfluxWrite) {
-			apierr.Write(w, http.StatusInternalServerError, "internal_error", "failed to persist reading")
-			return
-		}
-		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid payload")
-		return
-	}
-
-	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, map[string]string{})
-}
-
 // ReadingsQueryHandler handles GET /api/devices/{id}/readings (session auth).
 type ReadingsQueryHandler struct {
 	Service *ReadingsService

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-const validSenML = `[{"bn":"fishhub/device/","bt":1713000000},{"n":"temperature","u":"Cel","v":23.4}]`
-const multiSenML = `[{"bn":"fishhub/device/","bt":1713000000},{"n":"temperature","u":"Cel","v":23.4},{"n":"ph","u":"pH","v":7.2}]`
-
 func withDevice(r *http.Request, info sensors.DeviceInfo) *http.Request {
 	ctx := context.WithValue(r.Context(), sensors.DeviceContextKey, info)
 	return r.WithContext(ctx)
@@ -49,93 +46,6 @@ func newReadingsService(writer *stubReadingWriter, querier *stubReadingQuerier, 
 		w = writer
 	}
 	return sensors.NewReadingsService(store, querier, w, discardLogger)
-}
-
-// ── ReadingsHandler ───────────────────────────────────────────────────────────
-
-func TestReadingsHandler_Create(t *testing.T) {
-	device := sensors.DeviceInfo{DeviceID: "device-uuid", UserID: "user-uuid"}
-
-	t.Run("valid payload with writer returns 201 and calls writer", func(t *testing.T) {
-		w := &stubReadingWriter{}
-		h := &sensors.ReadingsHandler{Service: newReadingsService(w, nil, &stubDeviceStore{})}
-		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML)), device)
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		if rec.Code != http.StatusCreated {
-			t.Errorf("expected 201, got %d", rec.Code)
-		}
-		if !w.called {
-			t.Error("expected writer to be called")
-		}
-		if w.reading.DeviceID != "device-uuid" {
-			t.Errorf("expected device_id 'device-uuid', got %q", w.reading.DeviceID)
-		}
-		if w.reading.UserID != "user-uuid" {
-			t.Errorf("expected user_id 'user-uuid', got %q", w.reading.UserID)
-		}
-		if v, ok := w.reading.Measurements["temperature"].(float64); !ok || v != 23.4 {
-			t.Errorf("expected temperature 23.4, got %v", w.reading.Measurements["temperature"])
-		}
-	})
-
-	t.Run("multi-sensor payload writes all fields", func(t *testing.T) {
-		w := &stubReadingWriter{}
-		h := &sensors.ReadingsHandler{Service: newReadingsService(w, nil, &stubDeviceStore{})}
-		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(multiSenML)), device)
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		if rec.Code != http.StatusCreated {
-			t.Errorf("expected 201, got %d", rec.Code)
-		}
-		if len(w.reading.Measurements) != 2 {
-			t.Errorf("expected 2 measurements, got %d", len(w.reading.Measurements))
-		}
-	})
-
-	t.Run("writer error returns 500", func(t *testing.T) {
-		w := &stubReadingWriter{err: errors.New("influx down")}
-		h := &sensors.ReadingsHandler{Service: newReadingsService(w, nil, &stubDeviceStore{})}
-		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML)), device)
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
-	})
-
-	t.Run("nil writer returns 201 (degraded mode)", func(t *testing.T) {
-		h := &sensors.ReadingsHandler{Service: newReadingsService(nil, nil, &stubDeviceStore{})}
-		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML)), device)
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		if rec.Code != http.StatusCreated {
-			t.Errorf("expected 201, got %d", rec.Code)
-		}
-	})
-
-	t.Run("malformed JSON returns 400", func(t *testing.T) {
-		h := &sensors.ReadingsHandler{Service: newReadingsService(nil, nil, &stubDeviceStore{})}
-		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(`not json`)), device)
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("missing base time returns 400", func(t *testing.T) {
-		h := &sensors.ReadingsHandler{Service: newReadingsService(nil, nil, &stubDeviceStore{})}
-		body := `[{"bn":"fishhub/device/"},{"n":"temperature","v":23.4}]`
-		req := withDevice(httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(body)), device)
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("no device in context returns 401", func(t *testing.T) {
-		h := &sensors.ReadingsHandler{Service: newReadingsService(nil, nil, &stubDeviceStore{})}
-		req := httptest.NewRequest(http.MethodPost, "/readings", strings.NewReader(validSenML))
-		rec := httptest.NewRecorder()
-		h.Create(rec, req)
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
 }
 
 // ── ReadingsQueryHandler ──────────────────────────────────────────────────────

--- a/main.go
+++ b/main.go
@@ -230,7 +230,7 @@ func main() {
 	// ── MQTT readings subscription ────────────────────────────────────────────
 	readingsMQTTHandler := sensors.NewReadingsMQTTHandler(deviceStore, readingsSvc, logger)
 	if err := mqttSubscriber.Subscribe(ctx, "fishhub/+/readings", readingsMQTTHandler.Handle); err != nil {
-		logger.Warn("mqtt readings subscription failed — falling back to HTTP only", "error", err)
+		logger.Error("mqtt readings subscription failed", "error", err)
 	}
 
 	// ── Outbox runner ─────────────────────────────────────────────────────────
@@ -265,7 +265,6 @@ func main() {
 
 	r.Group(func(r chi.Router) {
 		r.Use(platform.DeviceAuthenticator(deviceSigner))
-		r.Post("/readings", (&sensors.ReadingsHandler{Service: readingsSvc}).Create)
 		r.Get("/devices/{id}/status", (&sensors.ActivationStatusHandler{
 			Store:    deviceStore,
 			MQTTHost: cfg.HiveMQHost,


### PR DESCRIPTION
## Summary

- Removes `ReadingsHandler` and its `Create` method from `internal/sensors/handler.go`
- Removes `r.Post("/readings", ...)` route registration from `main.go`
- Upgrades the MQTT subscription failure log from `Warn` to `Error` (no HTTP fallback exists anymore)
- Deletes `TestReadingsHandler_Create` and the now-unused `validSenML`/`multiSenML` constants
- Removes the `POST /readings` section from `docs/api.md`

`DeviceAuthenticator` and its tests are untouched — `GET /devices/{id}/status` still uses it.

Depends on fishhub-oss/fishhub-firmware#46 being fully rolled out.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/sensors/... ./internal/platform/...` — all pass

Closes #77