### PR TITLE
Add last_reading to peripherals endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Go HTTP backend for FishHub. Receives temperature readings from ESP32 devices, a
 2. Discuss the plan with the user before executing.
 3. Implement only after the user approves.
 4. Never commit directly to `main`. Always create a feature branch, commit there, and open a PR.
-5. After completing an issue, move the corresponding GitHub issue to the Done column on the FishHub PoC project (`org: fishhub-oss`, project ID 1).
+5. After completing an issue, move the corresponding GitHub issue to the Done column on the FishHub project (`org: fishhub-oss`, project ID 1).
 
 ## Git conventions
 

--- a/internal/sensors/device_service_test.go
+++ b/internal/sensors/device_service_test.go
@@ -35,7 +35,7 @@ func TestDeviceService_Delete_HiveMQErrorIsLogged(t *testing.T) {
 
 func newPeripheralSvcForCommand(t *testing.T, pStore *stubPeripheralStore, pub *stubPublisher) *sensors.PeripheralService {
 	t.Helper()
-	return sensors.NewPeripheralService(testutil.NewTestDB(t), pStore, &stubOutboxStore{}, pub, discardLogger)
+	return sensors.NewPeripheralService(testutil.NewTestDB(t), pStore, &stubOutboxStore{}, nil, pub, discardLogger)
 }
 
 func TestPeripheralService_SendCommand_HappyPath(t *testing.T) {

--- a/internal/sensors/handler.go
+++ b/internal/sensors/handler.go
@@ -326,23 +326,36 @@ type CommandPublisher interface {
 	Publish(ctx context.Context, topic string, payload []byte) error
 }
 
+type LastReadingResponse struct {
+	Timestamp string         `json:"timestamp"`
+	Values    map[string]any `json:"values"`
+}
+
 type PeripheralResponse struct {
-	ID          string           `json:"id"`
-	DeviceID    string           `json:"device_id"`
-	Name        string           `json:"name"`
-	Kind        string           `json:"kind"`
-	Pin         int              `json:"pin"`
-	Category    string           `json:"category"`
-	ControlMode *string          `json:"control_mode"`
-	Schedule    []ScheduleWindow `json:"schedule"`
-	CreatedAt   string           `json:"created_at"`
-	UpdatedAt   string           `json:"updated_at"`
+	ID          string               `json:"id"`
+	DeviceID    string               `json:"device_id"`
+	Name        string               `json:"name"`
+	Kind        string               `json:"kind"`
+	Pin         int                  `json:"pin"`
+	Category    string               `json:"category"`
+	ControlMode *string              `json:"control_mode"`
+	Schedule    []ScheduleWindow     `json:"schedule"`
+	LastReading *LastReadingResponse `json:"last_reading"`
+	CreatedAt   string               `json:"created_at"`
+	UpdatedAt   string               `json:"updated_at"`
 }
 
 func peripheralResponse(p Peripheral) PeripheralResponse {
 	schedule := p.Schedule
 	if schedule == nil {
 		schedule = []ScheduleWindow{}
+	}
+	var lastReading *LastReadingResponse
+	if p.LastReading != nil {
+		lastReading = &LastReadingResponse{
+			Timestamp: p.LastReading.Timestamp.UTC().Format(time.RFC3339),
+			Values:    p.LastReading.Values,
+		}
 	}
 	return PeripheralResponse{
 		ID:          p.ID,
@@ -353,6 +366,7 @@ func peripheralResponse(p Peripheral) PeripheralResponse {
 		Category:    p.Category,
 		ControlMode: p.ControlMode,
 		Schedule:    schedule,
+		LastReading: lastReading,
 		CreatedAt:   p.CreatedAt.UTC().Format(time.RFC3339),
 		UpdatedAt:   p.UpdatedAt.UTC().Format(time.RFC3339),
 	}

--- a/internal/sensors/handler_test.go
+++ b/internal/sensors/handler_test.go
@@ -512,7 +512,7 @@ func TestActivationStatusHandler(t *testing.T) {
 func newCommandHandler(t *testing.T, pStore *stubPeripheralStore, pub *stubPublisher) *sensors.CommandHandler {
 	t.Helper()
 	return &sensors.CommandHandler{
-		Service: sensors.NewPeripheralService(testutil.NewTestDB(t), pStore, &stubOutboxStore{}, pub, discardLogger),
+		Service: sensors.NewPeripheralService(testutil.NewTestDB(t), pStore, &stubOutboxStore{}, nil, pub, discardLogger),
 	}
 }
 

--- a/internal/sensors/influx.go
+++ b/internal/sensors/influx.go
@@ -34,6 +34,7 @@ type ReadingWriter interface {
 
 type ReadingQuerier interface {
 	QueryReadings(ctx context.Context, q ReadingQuery) ([]ReadingPoint, error)
+	QueryLastReadings(ctx context.Context, deviceID string) (*ReadingPoint, error)
 }
 
 type InfluxClient interface {
@@ -73,6 +74,83 @@ func (c *influxDBClient) WriteReading(ctx context.Context, r Reading) error {
 		return fmt.Errorf("influx write: %w", err)
 	}
 	return nil
+}
+
+var reservedColumns = map[string]bool{"time": true, "device_id": true, "user_id": true}
+
+// QueryLastReadings returns a single ReadingPoint containing the last known non-null
+// value for every field the device has ever written. Returns nil if the device has no data.
+//
+// Two-step approach required by InfluxDB 3's schema-on-write model:
+//   1. SELECT * LIMIT 1 to discover which field columns actually exist.
+//   2. LAST_VALUE(field IGNORE NULLS) OVER () to get the latest value per field
+//      independently (different peripherals write at different timestamps).
+func (c *influxDBClient) QueryLastReadings(ctx context.Context, deviceID string) (*ReadingPoint, error) {
+	discoverSQL := fmt.Sprintf(
+		`SELECT * FROM sensors WHERE device_id = '%s' ORDER BY time DESC LIMIT 1`,
+		deviceID,
+	)
+	iter, err := c.client.Query(ctx, discoverSQL)
+	if err != nil {
+		return nil, fmt.Errorf("influx query last readings (discover): %w", err)
+	}
+
+	var fields []string
+	for iter.Next() {
+		for k := range iter.Value() {
+			if !reservedColumns[k] {
+				fields = append(fields, k)
+			}
+		}
+		break
+	}
+	if len(fields) == 0 {
+		return nil, nil
+	}
+
+	selectCols := ""
+	for _, f := range fields {
+		selectCols += fmt.Sprintf(`, LAST_VALUE("%s" IGNORE NULLS) OVER () AS "%s"`, f, f)
+	}
+	lastSQL := fmt.Sprintf(
+		`SELECT MAX(time) OVER () AS time%s FROM sensors WHERE device_id = '%s' LIMIT 1`,
+		selectCols,
+		deviceID,
+	)
+	iter2, err := c.client.Query(ctx, lastSQL)
+	if err != nil {
+		return nil, fmt.Errorf("influx query last readings: %w", err)
+	}
+
+	p := &ReadingPoint{Values: make(map[string]any)}
+	for iter2.Next() {
+		row := iter2.Value()
+		if t, ok := row["time"].(time.Time); ok {
+			p.Timestamp = t.UTC()
+		}
+		for k, v := range row {
+			if reservedColumns[k] {
+				continue
+			}
+			switch val := v.(type) {
+			case float64:
+				p.Values[k] = val
+			case bool:
+				if val {
+					p.Values[k] = 1
+				} else {
+					p.Values[k] = 0
+				}
+			case string:
+				p.Values[k] = val
+			}
+		}
+		break
+	}
+	if len(p.Values) == 0 {
+		return nil, nil
+	}
+	return p, nil
 }
 
 func (c *influxDBClient) QueryReadings(ctx context.Context, q ReadingQuery) ([]ReadingPoint, error) {

--- a/internal/sensors/influx.go
+++ b/internal/sensors/influx.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	influxdb3 "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
+	"github.com/apache/arrow-go/v18/arrow"
 )
 
 type Reading struct {
@@ -125,8 +126,13 @@ func (c *influxDBClient) QueryLastReadings(ctx context.Context, deviceID string)
 	p := &ReadingPoint{Values: make(map[string]any)}
 	for iter2.Next() {
 		row := iter2.Value()
-		if t, ok := row["time"].(time.Time); ok {
-			p.Timestamp = t.UTC()
+		// MAX(time) OVER () returns arrow.Timestamp (nanoseconds), not time.Time.
+		// The client only maps the literal "time" column to time.Time automatically.
+		switch tv := row["time"].(type) {
+		case time.Time:
+			p.Timestamp = tv.UTC()
+		case arrow.Timestamp:
+			p.Timestamp = tv.ToTime(arrow.Nanosecond).UTC()
 		}
 		for k, v := range row {
 			if reservedColumns[k] {

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -15,6 +15,7 @@ type Peripheral struct {
 	Category    string  // "sensor" | "actuator"
 	ControlMode *string // nil for sensors; "automatic"|"manual" for actuators
 	Schedule    []ScheduleWindow
+	LastReading *ReadingPoint
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }

--- a/internal/sensors/peripheral_handler_test.go
+++ b/internal/sensors/peripheral_handler_test.go
@@ -33,7 +33,7 @@ func newPeripheral(name string) sensors.Peripheral {
 func TestListPeripheralsHandler(t *testing.T) {
 	t.Run("returns 200 with peripheral list", func(t *testing.T) {
 		store := &stubPeripheralStore{listed: []sensors.Peripheral{newPeripheral("light")}}
-		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.ListPeripheralsHandler{Service: svc}
 
 		req := withChiParam(
@@ -57,7 +57,7 @@ func TestListPeripheralsHandler(t *testing.T) {
 
 	t.Run("unknown device returns 200 with empty list", func(t *testing.T) {
 		store := &stubPeripheralStore{listed: []sensors.Peripheral{}}
-		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.ListPeripheralsHandler{Service: svc}
 
 		req := withChiParam(
@@ -80,7 +80,7 @@ func TestListPeripheralsHandler(t *testing.T) {
 	})
 
 	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.ListPeripheralsHandler{Service: svc}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -97,7 +97,7 @@ func TestSetPeripheralScheduleHandler(t *testing.T) {
 		p := newPeripheral("light")
 		p.Schedule = []sensors.ScheduleWindow{{From: "08:00", To: "18:00", Value: 1.0}}
 		store := &stubPeripheralStore{scheduled: p}
-		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetPeripheralScheduleHandler{Service: svc}
 
 		req := withChiParams(
@@ -121,7 +121,7 @@ func TestSetPeripheralScheduleHandler(t *testing.T) {
 
 	t.Run("peripheral not found returns 404", func(t *testing.T) {
 		store := &stubPeripheralStore{schedErr: sensors.ErrPeripheralNotFound}
-		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetPeripheralScheduleHandler{Service: svc}
 
 		req := withChiParams(
@@ -134,7 +134,7 @@ func TestSetPeripheralScheduleHandler(t *testing.T) {
 	})
 
 	t.Run("invalid body returns 400", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetPeripheralScheduleHandler{Service: svc}
 
 		req := withChiParams(
@@ -151,7 +151,7 @@ func TestSetPeripheralScheduleHandler(t *testing.T) {
 
 func TestCreatePeripheralHandler(t *testing.T) {
 	t.Run("invalid body returns 400", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.CreatePeripheralHandler{Service: svc}
 
 		req := withChiParam(
@@ -164,7 +164,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 	})
 
 	t.Run("missing name returns 400", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.CreatePeripheralHandler{Service: svc}
 
 		req := withChiParam(
@@ -177,7 +177,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 	})
 
 	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.CreatePeripheralHandler{Service: svc}
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`))
 		rec := httptest.NewRecorder()
@@ -188,7 +188,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 	t.Run("already exists returns 409", func(t *testing.T) {
 		db := testutil.NewTestDB(t)
 		store := &stubPeripheralStore{createErr: sensors.ErrPeripheralAlreadyExists}
-		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.CreatePeripheralHandler{Service: svc}
 
 		req := withChiParam(
@@ -203,7 +203,7 @@ func TestCreatePeripheralHandler(t *testing.T) {
 	t.Run("device not found returns 404", func(t *testing.T) {
 		db := testutil.NewTestDB(t)
 		store := &stubPeripheralStore{createErr: sensors.ErrDeviceNotFound}
-		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.CreatePeripheralHandler{Service: svc}
 
 		req := withChiParam(
@@ -225,7 +225,7 @@ func TestSetControlModeHandler(t *testing.T) {
 		p.ControlMode = &mode
 		db := testutil.NewTestDB(t)
 		store := &stubPeripheralStore{controlModeP: p}
-		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetControlModeHandler{Service: svc}
 
 		req := withChiParams(
@@ -248,7 +248,7 @@ func TestSetControlModeHandler(t *testing.T) {
 	})
 
 	t.Run("invalid mode returns 400", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetControlModeHandler{Service: svc}
 
 		req := withChiParams(
@@ -261,7 +261,7 @@ func TestSetControlModeHandler(t *testing.T) {
 	})
 
 	t.Run("missing mode returns 400", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetControlModeHandler{Service: svc}
 
 		req := withChiParams(
@@ -276,7 +276,7 @@ func TestSetControlModeHandler(t *testing.T) {
 	t.Run("peripheral not found returns 404", func(t *testing.T) {
 		db := testutil.NewTestDB(t)
 		store := &stubPeripheralStore{controlModeErr: sensors.ErrPeripheralNotFound}
-		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetControlModeHandler{Service: svc}
 
 		req := withChiParams(
@@ -291,7 +291,7 @@ func TestSetControlModeHandler(t *testing.T) {
 	t.Run("sensor peripheral returns 422", func(t *testing.T) {
 		db := testutil.NewTestDB(t)
 		store := &stubPeripheralStore{controlModeErr: sensors.ErrNotAnActuator}
-		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetControlModeHandler{Service: svc}
 
 		req := withChiParams(
@@ -304,7 +304,7 @@ func TestSetControlModeHandler(t *testing.T) {
 	})
 
 	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.SetControlModeHandler{Service: svc}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"manual"}`)))
@@ -316,7 +316,7 @@ func TestSetControlModeHandler(t *testing.T) {
 
 func TestDeletePeripheralHandler(t *testing.T) {
 	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.DeletePeripheralHandler{Service: svc}
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/", nil))
@@ -326,7 +326,7 @@ func TestDeletePeripheralHandler(t *testing.T) {
 	t.Run("peripheral not found returns 404", func(t *testing.T) {
 		db := testutil.NewTestDB(t)
 		store := &stubPeripheralStore{deleteErr: sensors.ErrPeripheralNotFound}
-		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, &stubPublisher{}, discardLogger)
+		svc := sensors.NewPeripheralService(db, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &sensors.DeletePeripheralHandler{Service: svc}
 
 		req := withChiParams(

--- a/internal/sensors/peripheral_service.go
+++ b/internal/sensors/peripheral_service.go
@@ -19,6 +19,7 @@ type PeripheralService struct {
 	db        *sql.DB
 	store     PeripheralStore
 	outbox    outbox.Store
+	querier   ReadingQuerier
 	publisher mqtt.Publisher
 	logger    *slog.Logger
 }
@@ -27,6 +28,7 @@ func NewPeripheralService(
 	db *sql.DB,
 	store PeripheralStore,
 	outboxStore outbox.Store,
+	querier ReadingQuerier,
 	publisher mqtt.Publisher,
 	logger *slog.Logger,
 ) *PeripheralService {
@@ -37,6 +39,7 @@ func NewPeripheralService(
 		db:        db,
 		store:     store,
 		outbox:    outboxStore,
+		querier:   querier,
 		publisher: publisher,
 		logger:    logger,
 	}
@@ -77,14 +80,48 @@ func (s *PeripheralService) Register(ctx context.Context, deviceID, userID, name
 	return p, nil
 }
 
-// List returns active peripherals for the device.
+// List returns active peripherals for the device, each populated with its last known reading.
 // Returns an empty slice if the device does not exist or is not owned by userID.
 func (s *PeripheralService) List(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
 	peripherals, err := s.store.ListPeripherals(ctx, deviceID, userID)
 	if err != nil {
 		s.logger.Error("list peripherals", "device_id", deviceID, "error", err)
+		return peripherals, err
 	}
-	return peripherals, err
+
+	if s.querier != nil && len(peripherals) > 0 {
+		last, err := s.querier.QueryLastReadings(ctx, deviceID)
+		if err != nil {
+			s.logger.Error("list peripherals: query last readings", "device_id", deviceID, "error", err)
+			// Non-fatal: return peripherals without last_reading rather than failing the request.
+		} else if last != nil {
+			for i := range peripherals {
+				ns := fmt.Sprintf("%s-%d", peripherals[i].Kind, peripherals[i].Pin)
+				filtered := filterByNamespace(last, ns)
+				if filtered != nil {
+					peripherals[i].LastReading = filtered
+				}
+			}
+		}
+	}
+
+	return peripherals, nil
+}
+
+// filterByNamespace returns a ReadingPoint containing only the values whose keys
+// start with the given namespace prefix (e.g. "ds18b20-4"), or nil if none match.
+func filterByNamespace(p *ReadingPoint, ns string) *ReadingPoint {
+	prefix := ns + "/"
+	filtered := &ReadingPoint{Timestamp: p.Timestamp, Values: make(map[string]any)}
+	for k, v := range p.Values {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			filtered.Values[k] = v
+		}
+	}
+	if len(filtered.Values) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 // SetSchedule persists the schedule to DB and publishes it synchronously via MQTT.

--- a/internal/sensors/stubs_test.go
+++ b/internal/sensors/stubs_test.go
@@ -152,6 +152,10 @@ func (s *stubReadingQuerier) QueryReadings(_ context.Context, _ sensors.ReadingQ
 	return s.points, s.err
 }
 
+func (s *stubReadingQuerier) QueryLastReadings(_ context.Context, _ string) (*sensors.ReadingPoint, error) {
+	return nil, nil
+}
+
 // ── Publisher ─────────────────────────────────────────────────────────────────
 
 type stubPublisher struct {

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func main() {
 	outboxStore := outbox.NewPostgresStore(db)
 	readingsSvc := sensors.NewReadingsService(deviceStore, influxClient, influxClient, logger)
 	deviceSvc := sensors.NewDeviceService(deviceStore, hivemqClient, mqttPublisher, logger)
-	peripheralSvc := sensors.NewPeripheralService(db, peripheralStore, outboxStore, mqttPublisher, logger)
+	peripheralSvc := sensors.NewPeripheralService(db, peripheralStore, outboxStore, influxClient, mqttPublisher, logger)
 	provisioningSvc := sensors.NewProvisioningService(provisioningStore, logger)
 	activationSvc := sensors.NewActivationService(db, provisioningStore, outboxStore, deviceSigner, logger)
 


### PR DESCRIPTION
## Summary

- `GET /api/devices/:id/peripherals` now includes a `last_reading` field on each peripheral with the most recent non-null value per field and its timestamp
- `last_reading` is `null` if the device has never written any data, or if a peripheral's fields haven't been written yet
- InfluxDB errors are non-fatal — the peripheral list is still returned, just without `last_reading`

## How it works

InfluxDB 3 is schema-on-write: querying a field that has never been written returns a schema error, not null. A simple `LIMIT 1 DESC` also only returns the most recent row, missing fields from peripherals that wrote at different times.

Solution: two queries per request (not per peripheral):
1. `SELECT * ... ORDER BY time DESC LIMIT 1` to discover which field columns actually exist for this device
2. `LAST_VALUE(field IGNORE NULLS) OVER ()` for each discovered field — returns the last non-null value per field independently, regardless of write timestamp

Both queries confirmed working against InfluxDB 3 Core before implementation.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)