### PR TITLE
Extract internal/provisioning package from internal/sensors

### DIFF
--- a/internal/provisioning/errors.go
+++ b/internal/provisioning/errors.go
@@ -1,0 +1,8 @@
+package provisioning
+
+import "errors"
+
+var (
+	ErrCodeNotFound    = errors.New("provisioning code not found")
+	ErrCodeAlreadyUsed = errors.New("provisioning code already used")
+)

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -1,0 +1,171 @@
+package provisioning
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+var (
+	ErrCodeNotFound  = errors.New("provisioning code not found")
+	ErrCodeAlreadyUsed = errors.New("provisioning code already used")
+)
+
+// Store manages provisioning codes.
+type Store interface {
+	// GetOrCreateCode returns the existing unused code for the user, or creates one.
+	GetOrCreateCode(ctx context.Context, userID string) (code string, err error)
+	// ClaimCode marks the code used, creates a new device row, and returns the device ID and user ID.
+	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
+	ClaimCode(ctx context.Context, code string) (deviceID, userID string, err error)
+	// Activate stores MQTT credentials on the device row within the provided transaction.
+	Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error
+}
+
+// Service orchestrates device provisioning from the user side.
+type Service struct {
+	store  Store
+	logger *slog.Logger
+}
+
+func NewService(store Store, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{store: store, logger: logger}
+}
+
+// Provision returns an existing unused provisioning code or creates a new one.
+func (s *Service) Provision(ctx context.Context, userID string) (string, error) {
+	code, err := s.store.GetOrCreateCode(ctx, userID)
+	if err != nil {
+		s.logger.Error("provision: get or create code", "user_id", userID, "error", err)
+	}
+	return code, err
+}
+
+// postgresStore implements Store.
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) Store {
+	return &postgresStore{db: db}
+}
+
+const provisioningCodeCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func (s *postgresStore) GetOrCreateCode(ctx context.Context, userID string) (string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var code string
+	err = tx.QueryRowContext(ctx, `
+		SELECT code
+		FROM provisioning_codes
+		WHERE user_id = $1 AND used_at IS NULL
+		LIMIT 1
+		FOR UPDATE
+	`, userID).Scan(&code)
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("lookup code: %w", err)
+	}
+
+	if err == nil {
+		if err := tx.Commit(); err != nil {
+			return "", fmt.Errorf("commit tx: %w", err)
+		}
+		return code, nil
+	}
+
+	code, err = generateCode()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO provisioning_codes (code, user_id) VALUES ($1, $2)
+	`, code, userID); err != nil {
+		return "", fmt.Errorf("insert provisioning code: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit tx: %w", err)
+	}
+	return code, nil
+}
+
+func (s *postgresStore) ClaimCode(ctx context.Context, code string) (string, string, error) {
+	var usedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, `
+		SELECT used_at FROM provisioning_codes WHERE code = $1
+	`, code).Scan(&usedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", ErrCodeNotFound
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("lookup code: %w", err)
+	}
+	if usedAt.Valid {
+		return "", "", ErrCodeAlreadyUsed
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var userID string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT user_id FROM provisioning_codes WHERE code = $1 AND used_at IS NULL FOR UPDATE
+	`, code).Scan(&userID); errors.Is(err, sql.ErrNoRows) {
+		return "", "", ErrCodeAlreadyUsed
+	} else if err != nil {
+		return "", "", fmt.Errorf("lock code: %w", err)
+	}
+
+	var deviceID string
+	if err := tx.QueryRowContext(ctx, `
+		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
+	`, userID).Scan(&deviceID); err != nil {
+		return "", "", fmt.Errorf("insert device: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE provisioning_codes SET used_at = now(), device_id = $2 WHERE code = $1
+	`, code, deviceID); err != nil {
+		return "", "", fmt.Errorf("claim code: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", "", fmt.Errorf("commit tx: %w", err)
+	}
+	return deviceID, userID, nil
+}
+
+func (s *postgresStore) Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error {
+	_, err := tx.ExecContext(ctx, `
+		UPDATE devices SET mqtt_username = $2, mqtt_password = $3 WHERE id = $1
+	`, deviceID, mqttUsername, mqttPassword)
+	return err
+}
+
+func generateCode() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate code: %w", err)
+	}
+	code := make([]byte, 6)
+	for i, v := range b {
+		code[i] = provisioningCodeCharset[int(v)%len(provisioningCodeCharset)]
+	}
+	return string(code), nil
+}

--- a/internal/provisioning/service.go
+++ b/internal/provisioning/service.go
@@ -1,0 +1,28 @@
+package provisioning
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Service orchestrates device provisioning from the user side.
+type Service struct {
+	store  Store
+	logger *slog.Logger
+}
+
+func NewService(store Store, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{store: store, logger: logger}
+}
+
+// Provision returns an existing unused provisioning code or creates a new one.
+func (s *Service) Provision(ctx context.Context, userID string) (string, error) {
+	code, err := s.store.GetOrCreateCode(ctx, userID)
+	if err != nil {
+		s.logger.Error("provision: get or create code", "user_id", userID, "error", err)
+	}
+	return code, err
+}

--- a/internal/provisioning/store.go
+++ b/internal/provisioning/store.go
@@ -6,12 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
-)
-
-var (
-	ErrCodeNotFound  = errors.New("provisioning code not found")
-	ErrCodeAlreadyUsed = errors.New("provisioning code already used")
 )
 
 // Store manages provisioning codes.
@@ -25,29 +19,6 @@ type Store interface {
 	Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error
 }
 
-// Service orchestrates device provisioning from the user side.
-type Service struct {
-	store  Store
-	logger *slog.Logger
-}
-
-func NewService(store Store, logger *slog.Logger) *Service {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	return &Service{store: store, logger: logger}
-}
-
-// Provision returns an existing unused provisioning code or creates a new one.
-func (s *Service) Provision(ctx context.Context, userID string) (string, error) {
-	code, err := s.store.GetOrCreateCode(ctx, userID)
-	if err != nil {
-		s.logger.Error("provision: get or create code", "user_id", userID, "error", err)
-	}
-	return code, err
-}
-
-// postgresStore implements Store.
 type postgresStore struct {
 	db *sql.DB
 }

--- a/internal/sensors/model.go
+++ b/internal/sensors/model.go
@@ -1,11 +1,10 @@
 package sensors
 
 import (
-	"errors"
-
 	"github.com/fishhub-oss/fishhub-server/internal/device"
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
+	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 )
 
 // Peripheral types aliased from internal/peripheral for backward compat.
@@ -22,8 +21,8 @@ type ReadingQuerier = measurement.Querier
 // Error sentinels.
 var ErrNotAnActuator           = peripheral.ErrNotAnActuator
 var ErrDeviceNotFound          = device.ErrNotFound
-var ErrCodeNotFound            = errors.New("provisioning code not found")
-var ErrCodeAlreadyUsed         = errors.New("provisioning code already used")
+var ErrCodeNotFound            = provisioning.ErrCodeNotFound
+var ErrCodeAlreadyUsed         = provisioning.ErrCodeAlreadyUsed
 var ErrInvalidCommand          = peripheral.ErrInvalidCommand
 var ErrInfluxWrite             = measurement.ErrInfluxWrite
 var ErrPeripheralNotFound      = peripheral.ErrNotFound

--- a/internal/sensors/provisioning_service.go
+++ b/internal/sensors/provisioning_service.go
@@ -1,29 +1,14 @@
 package sensors
 
 import (
-	"context"
 	"log/slog"
+
+	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 )
 
-// ProvisioningService orchestrates device provisioning from the user side.
-type ProvisioningService struct {
-	store  ProvisioningStore
-	logger *slog.Logger
-}
+// ProvisioningService is an alias for provisioning.Service kept for backward compatibility.
+type ProvisioningService = provisioning.Service
 
 func NewProvisioningService(store ProvisioningStore, logger *slog.Logger) *ProvisioningService {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	return &ProvisioningService{store: store, logger: logger}
-}
-
-// Provision returns an existing unused provisioning code for the user or
-// creates a new one.
-func (s *ProvisioningService) Provision(ctx context.Context, userID string) (code string, err error) {
-	code, err = s.store.GetOrCreateCode(ctx, userID)
-	if err != nil {
-		s.logger.Error("provision: get or create code", "user_id", userID, "error", err)
-	}
-	return code, err
+	return provisioning.NewService(store, logger)
 }

--- a/internal/sensors/store.go
+++ b/internal/sensors/store.go
@@ -1,11 +1,9 @@
 package sensors
 
 import (
-	"context"
-	"database/sql"
-
 	"github.com/fishhub-oss/fishhub-server/internal/device"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
+	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 )
 
 // DeviceStore is an alias for device.Store kept for backward compatibility within this package.
@@ -14,13 +12,5 @@ type DeviceStore = device.Store
 // PeripheralStore is an alias for peripheral.Store kept for backward compatibility within this package.
 type PeripheralStore = peripheral.Store
 
-type ProvisioningStore interface {
-	// GetOrCreateCode returns the existing unused code for the user, or creates one.
-	GetOrCreateCode(ctx context.Context, userID string) (code string, err error)
-	// ClaimCode marks the code used, creates a new device row, and returns the device ID and user ID.
-	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
-	ClaimCode(ctx context.Context, code string) (deviceID, userID string, err error)
-	// Activate stores MQTT credentials on the device row within the provided transaction.
-	// The caller owns the transaction boundary.
-	Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error
-}
+// ProvisioningStore is an alias for provisioning.Store kept for backward compatibility within this package.
+type ProvisioningStore = provisioning.Store

--- a/internal/sensors/store_provisioning_postgres.go
+++ b/internal/sensors/store_provisioning_postgres.go
@@ -1,131 +1,13 @@
 package sensors
 
 import (
-	"context"
-	"crypto/rand"
 	"database/sql"
-	"errors"
-	"fmt"
+
+	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 )
 
-const provisioningCodeCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-type postgresProvisioningStore struct {
-	db *sql.DB
-}
-
+// NewProvisioningStore returns a provisioning.Store backed by Postgres.
+// Kept here for backward compatibility with callers that import sensors.
 func NewProvisioningStore(db *sql.DB) ProvisioningStore {
-	return &postgresProvisioningStore{db: db}
-}
-
-func (s *postgresProvisioningStore) GetOrCreateCode(ctx context.Context, userID string) (string, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return "", fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	var code string
-	err = tx.QueryRowContext(ctx, `
-		SELECT code
-		FROM provisioning_codes
-		WHERE user_id = $1 AND used_at IS NULL
-		LIMIT 1
-		FOR UPDATE
-	`, userID).Scan(&code)
-
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("lookup code: %w", err)
-	}
-
-	if err == nil {
-		if err := tx.Commit(); err != nil {
-			return "", fmt.Errorf("commit tx: %w", err)
-		}
-		return code, nil
-	}
-
-	code, err = generateCode()
-	if err != nil {
-		return "", err
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO provisioning_codes (code, user_id) VALUES ($1, $2)
-	`, code, userID); err != nil {
-		return "", fmt.Errorf("insert provisioning code: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return "", fmt.Errorf("commit tx: %w", err)
-	}
-	return code, nil
-}
-
-func (s *postgresProvisioningStore) ClaimCode(ctx context.Context, code string) (string, string, error) {
-	var usedAt sql.NullTime
-	err := s.db.QueryRowContext(ctx, `
-		SELECT used_at FROM provisioning_codes WHERE code = $1
-	`, code).Scan(&usedAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", "", ErrCodeNotFound
-	}
-	if err != nil {
-		return "", "", fmt.Errorf("lookup code: %w", err)
-	}
-	if usedAt.Valid {
-		return "", "", ErrCodeAlreadyUsed
-	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return "", "", fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	var userID string
-	if err := tx.QueryRowContext(ctx, `
-		SELECT user_id FROM provisioning_codes WHERE code = $1 AND used_at IS NULL FOR UPDATE
-	`, code).Scan(&userID); errors.Is(err, sql.ErrNoRows) {
-		return "", "", ErrCodeAlreadyUsed
-	} else if err != nil {
-		return "", "", fmt.Errorf("lock code: %w", err)
-	}
-
-	var deviceID string
-	if err := tx.QueryRowContext(ctx, `
-		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
-	`, userID).Scan(&deviceID); err != nil {
-		return "", "", fmt.Errorf("insert device: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE provisioning_codes SET used_at = now(), device_id = $2 WHERE code = $1
-	`, code, deviceID); err != nil {
-		return "", "", fmt.Errorf("claim code: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return "", "", fmt.Errorf("commit tx: %w", err)
-	}
-	return deviceID, userID, nil
-}
-
-func (s *postgresProvisioningStore) Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error {
-	_, err := tx.ExecContext(ctx, `
-		UPDATE devices SET mqtt_username = $2, mqtt_password = $3 WHERE id = $1
-	`, deviceID, mqttUsername, mqttPassword)
-	return err
-}
-
-func generateCode() (string, error) {
-	b := make([]byte, 6)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("generate code: %w", err)
-	}
-	code := make([]byte, 6)
-	for i, v := range b {
-		code[i] = provisioningCodeCharset[int(v)%len(provisioningCodeCharset)]
-	}
-	return string(code), nil
+	return provisioning.NewStore(db)
 }


### PR DESCRIPTION
Moves provisioning code out of `internal/sensors` into a new `internal/provisioning` package.

## Changes
- `internal/provisioning/provisioning.go`: `ErrCodeNotFound`, `ErrCodeAlreadyUsed`, `Store` interface, Postgres implementation, `Service`
- `internal/sensors/store.go`: `ProvisioningStore = provisioning.Store`
- `internal/sensors/provisioning_service.go`: `ProvisioningService = provisioning.Service`, `NewProvisioningService` delegates to provisioning
- `internal/sensors/store_provisioning_postgres.go`: `NewProvisioningStore` delegates to `provisioning.NewStore`
- `internal/sensors/model.go`: `ErrCodeNotFound`/`ErrCodeAlreadyUsed` aliased from provisioning

Closes #100