### PR TITLE
Eliminate claims extraction boilerplate with MustClaimsFromContext

### DIFF
--- a/internal/account/handler.go
+++ b/internal/account/handler.go
@@ -22,11 +22,7 @@ type meResponse struct {
 }
 
 func (h *MeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	account, err := h.Service.Me(r.Context(), claims.UserID)
 	if err != nil {

--- a/internal/account/handler_test.go
+++ b/internal/account/handler_test.go
@@ -75,14 +75,6 @@ func TestMeHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("returns 401 when no claims in context", func(t *testing.T) {
-		h := &account.MeHandler{Service: &account.AccountService{Store: &stubAccountStore{account: validAccount}}}
-		req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
-		w := httptest.NewRecorder()
-		h.ServeHTTP(w, req)
-		assertErrorCode(t, w, http.StatusUnauthorized, "unauthorized")
-	})
-
 	t.Run("returns 404 when account not found", func(t *testing.T) {
 		h := &account.MeHandler{Service: &account.AccountService{Store: &stubAccountStore{err: account.ErrAccountNotFound}}}
 		w := httptest.NewRecorder()

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -29,11 +29,7 @@ type DevicesHandler struct {
 }
 
 func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	devices, err := h.Service.List(r.Context(), claims.UserID)
 	if err != nil {
@@ -70,11 +66,7 @@ type ReadingsQueryResponse struct {
 }
 
 func (h *ReadingsQueryHandler) List(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	deviceID := chi.URLParam(r, "id")
 
@@ -145,11 +137,7 @@ type DeleteDeviceHandler struct {
 }
 
 func (h *DeleteDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	deviceID := chi.URLParam(r, "id")
 	if err := h.Service.Delete(r.Context(), deviceID, claims.UserID); err != nil {
@@ -174,11 +162,7 @@ type patchDeviceRequest struct {
 }
 
 func (h *PatchDeviceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	var req patchDeviceRequest
 	if err := render.DecodeJSON(r.Body, &req); err != nil || req.Name == "" {
@@ -214,11 +198,7 @@ type provisionResponse struct {
 }
 
 func (h *ProvisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	code, err := h.Service.Provision(r.Context(), claims.UserID)
 	if err != nil {
@@ -383,11 +363,7 @@ type createPeripheralRequest struct {
 }
 
 func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	var req createPeripheralRequest
 	if err := render.DecodeJSON(r.Body, &req); err != nil {
@@ -435,11 +411,7 @@ type ListPeripheralsHandler struct {
 }
 
 func (h *ListPeripheralsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	deviceID := chi.URLParam(r, "id")
 	peripherals, err := h.Service.List(r.Context(), deviceID, claims.UserID)
@@ -461,11 +433,7 @@ type SetPeripheralScheduleHandler struct {
 }
 
 func (h *SetPeripheralScheduleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	var schedule []peripheral.ScheduleWindow
 	if err := render.DecodeJSON(r.Body, &schedule); err != nil {
@@ -494,11 +462,7 @@ type DeletePeripheralHandler struct {
 }
 
 func (h *DeletePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	deviceID := chi.URLParam(r, "id")
 	peripheralID := chi.URLParam(r, "peripheralId")
@@ -524,11 +488,7 @@ type setControlModeRequest struct {
 }
 
 func (h *SetControlModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	var req setControlModeRequest
 	if err := render.DecodeJSON(r.Body, &req); err != nil {
@@ -565,11 +525,7 @@ type CommandHandler struct {
 }
 
 func (h *CommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	claims, ok := auth.ClaimsFromContext(r.Context())
-	if !ok {
-		apierr.Write(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-		return
-	}
+	claims := auth.MustClaimsFromContext(r.Context())
 
 	deviceID := chi.URLParam(r, "id")
 	peripheralName := chi.URLParam(r, "peripheralId")

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -194,13 +194,6 @@ func TestDevicesHandler_List(t *testing.T) {
 		}
 	})
 
-	t.Run("missing claims returns 401", func(t *testing.T) {
-		h := &api.DevicesHandler{Service: newSvc(&stubDeviceStore{})}
-		rec := httptest.NewRecorder()
-		h.List(rec, httptest.NewRequest(http.MethodGet, "/api/devices", nil))
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
-
 	t.Run("store error returns 500", func(t *testing.T) {
 		h := &api.DevicesHandler{Service: newSvc(&stubDeviceStore{listErr: errors.New("db down")})}
 		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/devices", nil), "usr-1")
@@ -267,14 +260,6 @@ func TestPatchDeviceHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 
-	t.Run("missing claims returns 401", func(t *testing.T) {
-		h := &api.PatchDeviceHandler{Service: newPatchSvc(&stubDeviceStore{})}
-		req := httptest.NewRequest(http.MethodPatch, "/api/devices/dev-1", strings.NewReader(`{"name":"Tank A"}`))
-		req = withChiParam(req, "id", "dev-1")
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
 }
 
 // ── ProvisionHandler ──────────────────────────────────────────────────────────
@@ -304,14 +289,6 @@ func TestProvisionHandler(t *testing.T) {
 		if _, ok := body["device_id"]; ok {
 			t.Error("device_id should not be present in provision response")
 		}
-	})
-
-	t.Run("missing claims returns 401", func(t *testing.T) {
-		h := &api.ProvisionHandler{Service: newProvSvc(&stubProvisioningStore{})}
-		req := httptest.NewRequest(http.MethodPost, "/api/devices/provision", nil)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("store error returns 500", func(t *testing.T) {
@@ -578,9 +555,7 @@ func newDeleteHandler(store *stubDeviceStore, mq *stubHiveMQClient) *api.DeleteD
 func TestDeleteDeviceHandler(t *testing.T) {
 	makeReq := func(deviceID, userID string) *http.Request {
 		req := httptest.NewRequest(http.MethodDelete, "/api/devices/"+deviceID, nil)
-		if userID != "" {
-			req = withClaims(req, userID)
-		}
+		req = withClaims(req, userID)
 		req = withChiParam(req, "id", deviceID)
 		return req
 	}
@@ -626,10 +601,4 @@ func TestDeleteDeviceHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
 	})
 
-	t.Run("401 when no claims", func(t *testing.T) {
-		h := newDeleteHandler(&stubDeviceStore{}, &stubHiveMQClient{})
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, makeReq("dev-uuid", ""))
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
 }

--- a/internal/api/peripheral_handler_test.go
+++ b/internal/api/peripheral_handler_test.go
@@ -86,13 +86,6 @@ func TestListPeripheralsHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := peripheral.NewService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
-		h := &api.ListPeripheralsHandler{Service: svc}
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
 }
 
 // ── SetPeripheralScheduleHandler ─────────────────────────────────────────────
@@ -181,15 +174,6 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := peripheral.NewService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
-		h := &api.CreatePeripheralHandler{Service: svc}
-		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`))
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
 	})
 
 	t.Run("already exists returns 409", func(t *testing.T) {
@@ -305,26 +289,11 @@ func TestSetControlModeHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusUnprocessableEntity, "not_an_actuator")
 	})
 
-	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := peripheral.NewService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
-		h := &api.SetControlModeHandler{Service: svc}
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"mode":"manual"}`)))
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
 }
 
 // ── DeletePeripheralHandler ───────────────────────────────────────────────────
 
 func TestDeletePeripheralHandler(t *testing.T) {
-	t.Run("no auth returns 401", func(t *testing.T) {
-		svc := peripheral.NewService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
-		h := &api.DeletePeripheralHandler{Service: svc}
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/", nil))
-		assertErrorCode(t, rec, http.StatusUnauthorized, "unauthorized")
-	})
-
 	t.Run("peripheral not found returns 404", func(t *testing.T) {
 		store := &stubPeripheralStore{deleteErr: peripheral.ErrNotFound}
 		svc := newPeripheralService(t, store, &stubPublisher{})

--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -26,6 +26,16 @@ func ClaimsFromContext(ctx context.Context) (Claims, bool) {
 	return c, ok
 }
 
+// MustClaimsFromContext returns the Claims stored by SessionAuthenticator middleware.
+// It panics if claims are absent — this indicates a misconfigured route (missing middleware).
+func MustClaimsFromContext(ctx context.Context) Claims {
+	c, ok := ctx.Value(claimsContextKey).(Claims)
+	if !ok {
+		panic("auth: claims missing from context — is SessionAuthenticator middleware applied?")
+	}
+	return c
+}
+
 func ContextWithClaims(ctx context.Context, c Claims) context.Context {
 	return context.WithValue(ctx, claimsContextKey, c)
 }


### PR DESCRIPTION
## Summary

- Adds `auth.MustClaimsFromContext(ctx)` — panics on missing claims, signalling a misconfigured route rather than a user error
- Replaces the 6-line `ClaimsFromContext + !ok → 401` block in all 12 session-authenticated handlers with a single-line call
- Removes the corresponding dead test cases that asserted the now-unreachable 401 path

## Why panic?

The `!ok` branch was already dead code — `SessionAuthenticator` middleware returns 401 before any handler runs. A panic is the right signal for a programming error (missing middleware on a route), not a user-visible 401. chi's `middleware.Recoverer` converts it to 500 if it ever fires.

Closes #86