### PR TITLE
chore: migrate Railway build from Nixpacks to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+docker-compose.yml
+grafana/
+docs/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o /app/fishhub-server .
+
+FROM alpine:3.21
+
+COPY --from=builder /app/fishhub-server /app/fishhub-server
+
+CMD ["/app/fishhub-server"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,7 +1,3 @@
-[build]
-builder = "nixpacks"
-buildCommand = "go build -o /app/fishhub-server ."
-
 [deploy]
 startCommand = "/app/fishhub-server"
 healthcheckPath = "/health"


### PR DESCRIPTION
Nixpacks is deprecated on Railway. Add a multi-stage Dockerfile
(golang:1.25-alpine build → alpine:3.21 final) and remove the
[build] section from railway.toml so Railway infers the builder
from the Dockerfile. Add .dockerignore to keep the build context lean.

Closes #95