### PR TITLE
Fix missing db/migrations in Dockerfile final stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN go build -o /app/fishhub-server .
 FROM alpine:3.21
 
 COPY --from=builder /app/fishhub-server /app/fishhub-server
+COPY --from=builder /src/db/migrations /app/db/migrations
 
 CMD ["/app/fishhub-server"]


### PR DESCRIPTION
The multi-stage Dockerfile introduced in #112 only copied the compiled binary to the runtime image, leaving the SQL migration files in the builder stage. The server calls `platform.Migrate(db, "db/migrations")` at startup and crashes immediately when the directory is absent, causing the Railway healthcheck on `/health` to time out.

## Fix

Copy `db/migrations` from the builder stage into `/app/db/migrations` in the final image. The binary resolves the path relative to its working directory (`/app`), so this matches exactly.

Closes #95