### PR TITLE
Fix Dockerfile working directory so migrations path resolves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN go build -o /app/fishhub-server .
 
 FROM alpine:3.21
 
-COPY --from=builder /app/fishhub-server /app/fishhub-server
-COPY --from=builder /src/db/migrations /app/db/migrations
+WORKDIR /app
+COPY --from=builder /app/fishhub-server .
+COPY --from=builder /src/db/migrations ./db/migrations
 
 CMD ["/app/fishhub-server"]


### PR DESCRIPTION
Without `WORKDIR` in the final stage the binary runs with `/` as the working directory, so the relative path `"db/migrations"` resolves to `/db/migrations` instead of `/app/db/migrations`.

## Fix

Add `WORKDIR /app` to the final stage. The `COPY` instructions are updated to use relative destinations that land in the right place.

```
WORKDIR /app
COPY --from=builder /app/fishhub-server .
COPY --from=builder /src/db/migrations ./db/migrations
```

Closes #95