### PR TITLE
feat: triggers CRUD, MQTT push via outbox

### DIFF
--- a/db/migrations/019_create_triggers.down.sql
+++ b/db/migrations/019_create_triggers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS triggers;

--- a/db/migrations/019_create_triggers.up.sql
+++ b/db/migrations/019_create_triggers.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE triggers (
+    id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id            UUID         NOT NULL REFERENCES devices(id),
+    name                 TEXT         NOT NULL,
+    enabled              BOOL         NOT NULL DEFAULT true,
+    condition            JSONB        NOT NULL,
+    target_peripheral_id UUID         NOT NULL REFERENCES peripherals(id),
+    action               JSONB        NOT NULL,
+    cooldown_s           INT          NOT NULL DEFAULT 60,
+    deleted_at           TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX triggers_device_id_idx ON triggers (device_id) WHERE deleted_at IS NULL;

--- a/internal/api/stubs_test.go
+++ b/internal/api/stubs_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
 )
 
 var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -248,3 +249,35 @@ func newDevice(id string) device.Device {
 }
 
 var errSentinel = errors.New("store error")
+
+// ── TriggerStore ──────────────────────────────────────────────────────────────
+
+type stubTriggerStore struct {
+	created       trigger.Trigger
+	createKindPin string
+	createErr     error
+	listed        []trigger.Trigger
+	listErr       error
+	got           trigger.Trigger
+	getErr        error
+	updated       trigger.Trigger
+	updateKindPin string
+	updateErr     error
+	deletedErr    error
+}
+
+func (s *stubTriggerStore) Create(_ context.Context, _ *sql.Tx, _, _ string, _ trigger.TriggerCreate) (trigger.Trigger, string, error) {
+	return s.created, s.createKindPin, s.createErr
+}
+func (s *stubTriggerStore) List(_ context.Context, _, _ string) ([]trigger.Trigger, error) {
+	return s.listed, s.listErr
+}
+func (s *stubTriggerStore) Get(_ context.Context, _, _, _ string) (trigger.Trigger, error) {
+	return s.got, s.getErr
+}
+func (s *stubTriggerStore) Update(_ context.Context, _ *sql.Tx, _, _, _ string, _ trigger.TriggerUpdate) (trigger.Trigger, string, error) {
+	return s.updated, s.updateKindPin, s.updateErr
+}
+func (s *stubTriggerStore) Delete(_ context.Context, _ *sql.Tx, _, _, _ string) (trigger.Trigger, error) {
+	return s.created, s.deletedErr
+}

--- a/internal/api/trigger_handler.go
+++ b/internal/api/trigger_handler.go
@@ -1,0 +1,258 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+type TriggerResponse struct {
+	ID                 string          `json:"id"`
+	Name               string          `json:"name"`
+	Enabled            bool            `json:"enabled"`
+	Condition          json.RawMessage `json:"condition"`
+	TargetPeripheralID string          `json:"target_peripheral_id"`
+	Action             json.RawMessage `json:"action"`
+	CooldownSeconds    int             `json:"cooldown_s"`
+	CreatedAt          string          `json:"created_at"`
+}
+
+func triggerResponse(t trigger.Trigger) TriggerResponse {
+	return TriggerResponse{
+		ID:                 t.ID,
+		Name:               t.Name,
+		Enabled:            t.Enabled,
+		Condition:          t.Condition,
+		TargetPeripheralID: t.TargetPeripheralID,
+		Action:             t.Action,
+		CooldownSeconds:    t.CooldownSeconds,
+		CreatedAt:          t.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+type createTriggerRequest struct {
+	Name               string          `json:"name"`
+	Condition          json.RawMessage `json:"condition"`
+	TargetPeripheralID string          `json:"target_peripheral_id"`
+	Action             json.RawMessage `json:"action"`
+	CooldownSeconds    int             `json:"cooldown_s"`
+}
+
+// CreateTriggerHandler handles POST /api/devices/{id}/triggers (session auth).
+type CreateTriggerHandler struct {
+	Service *trigger.Service
+}
+
+func (h *CreateTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+
+	var req createTriggerRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name is required")
+		return
+	}
+	if len(req.Condition) == 0 {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "condition is required")
+		return
+	}
+	if req.TargetPeripheralID == "" {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "target_peripheral_id is required")
+		return
+	}
+	if len(req.Action) == 0 {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "action is required")
+		return
+	}
+	if err := validateTriggerAction(req.Action); err != nil {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if req.CooldownSeconds < 0 {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "cooldown_s must be >= 0")
+		return
+	}
+
+	t, err := h.Service.Create(r.Context(), deviceID, claims.UserID, trigger.TriggerCreate{
+		Name:               req.Name,
+		Condition:          req.Condition,
+		TargetPeripheralID: req.TargetPeripheralID,
+		Action:             req.Action,
+		CooldownSeconds:    req.CooldownSeconds,
+	})
+	if err != nil {
+		if errors.Is(err, device.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
+			return
+		}
+		if errors.Is(err, trigger.ErrInvalidPeripheral) {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", trigger.ErrInvalidPeripheral.Error())
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, triggerResponse(t))
+}
+
+// ListTriggersHandler handles GET /api/devices/{id}/triggers (session auth).
+type ListTriggersHandler struct {
+	Service *trigger.Service
+}
+
+func (h *ListTriggersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+
+	triggers, err := h.Service.List(r.Context(), deviceID, claims.UserID)
+	if err != nil {
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	resp := make([]TriggerResponse, len(triggers))
+	for i, t := range triggers {
+		resp[i] = triggerResponse(t)
+	}
+	render.JSON(w, r, resp)
+}
+
+// GetTriggerHandler handles GET /api/devices/{id}/triggers/{tid} (session auth).
+type GetTriggerHandler struct {
+	Service *trigger.Service
+}
+
+func (h *GetTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+	triggerID := chi.URLParam(r, "tid")
+
+	t, err := h.Service.Get(r.Context(), deviceID, claims.UserID, triggerID)
+	if err != nil {
+		if errors.Is(err, trigger.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "trigger_not_found", "trigger not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	render.JSON(w, r, triggerResponse(t))
+}
+
+type patchTriggerRequest struct {
+	Name            *string         `json:"name"`
+	Condition       json.RawMessage `json:"condition"`
+	Action          json.RawMessage `json:"action"`
+	CooldownSeconds *int            `json:"cooldown_s"`
+	Enabled         *bool           `json:"enabled"`
+}
+
+// PatchTriggerHandler handles PATCH /api/devices/{id}/triggers/{tid} (session auth).
+type PatchTriggerHandler struct {
+	Service *trigger.Service
+}
+
+func (h *PatchTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+	triggerID := chi.URLParam(r, "tid")
+
+	var req patchTriggerRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	if req.Name != nil && *req.Name == "" {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name must not be empty")
+		return
+	}
+	if len(req.Action) > 0 {
+		if err := validateTriggerAction(req.Action); err != nil {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+	}
+	if req.CooldownSeconds != nil && *req.CooldownSeconds < 0 {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "cooldown_s must be >= 0")
+		return
+	}
+
+	// Treat JSON null as absent for JSONB fields.
+	condition := req.Condition
+	if string(condition) == "null" {
+		condition = nil
+	}
+	action := req.Action
+	if string(action) == "null" {
+		action = nil
+	}
+
+	t, err := h.Service.Update(r.Context(), deviceID, claims.UserID, triggerID, trigger.TriggerPatch{
+		Name:            req.Name,
+		Condition:       condition,
+		Action:          action,
+		CooldownSeconds: req.CooldownSeconds,
+		Enabled:         req.Enabled,
+	})
+	if err != nil {
+		if errors.Is(err, trigger.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "trigger_not_found", "trigger not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	render.JSON(w, r, triggerResponse(t))
+}
+
+// DeleteTriggerHandler handles DELETE /api/devices/{id}/triggers/{tid} (session auth).
+type DeleteTriggerHandler struct {
+	Service *trigger.Service
+}
+
+func (h *DeleteTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+	triggerID := chi.URLParam(r, "tid")
+
+	if err := h.Service.Delete(r.Context(), deviceID, claims.UserID, triggerID); err != nil {
+		if errors.Is(err, trigger.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "trigger_not_found", "trigger not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// validateTriggerAction checks that action.action is "set" or "set_mode".
+func validateTriggerAction(raw json.RawMessage) error {
+	var a struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return errors.New("action must be valid JSON")
+	}
+	if a.Action != "set" && a.Action != "set_mode" {
+		return errors.New(`action.action must be "set" or "set_mode"`)
+	}
+	return nil
+}

--- a/internal/api/trigger_handler_test.go
+++ b/internal/api/trigger_handler_test.go
@@ -1,0 +1,322 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/api"
+	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+)
+
+func newTrigger() trigger.Trigger {
+	return trigger.Trigger{
+		ID:                 "trig-1",
+		DeviceID:           "dev-1",
+		Name:               "Heater on cold",
+		Enabled:            true,
+		Condition:          json.RawMessage(`{"op":"lt"}`),
+		TargetPeripheralID: "peri-1",
+		Action:             json.RawMessage(`{"action":"set","value":1.0}`),
+		CooldownSeconds:    60,
+		CreatedAt:          time.Now(),
+	}
+}
+
+func newTriggerService(t *testing.T, store *stubTriggerStore) *trigger.Service {
+	t.Helper()
+	return trigger.NewService(testutil.NewTestDB(t), store, &stubOutboxStore{}, discardLogger)
+}
+
+// ── CreateTriggerHandler ──────────────────────────────────────────────────────
+
+func TestCreateTriggerHandler(t *testing.T) {
+	validBody := `{"name":"Heater on cold","condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"set","value":1.0},"cooldown_s":60}`
+
+	t.Run("invalid body returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json")), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("missing name returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		body := `{"condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"set","value":1.0}}`
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("missing condition returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		body := `{"name":"Heater","target_peripheral_id":"peri-1","action":{"action":"set","value":1.0}}`
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("missing target_peripheral_id returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		body := `{"name":"Heater","condition":{"op":"lt"},"action":{"action":"set","value":1.0}}`
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("missing action returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		body := `{"name":"Heater","condition":{"op":"lt"},"target_peripheral_id":"peri-1"}`
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("invalid action.action returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		body := `{"name":"Heater","condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"invalid"}}`
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("negative cooldown_s returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		body := `{"name":"Heater","condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"set","value":1.0},"cooldown_s":-1}`
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("device not found returns 404", func(t *testing.T) {
+		store := &stubTriggerStore{createErr: device.ErrNotFound}
+		svc := newTriggerService(t, store)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(validBody)), "user-1"), "id", "dev-x")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
+	})
+
+	t.Run("invalid peripheral returns 400", func(t *testing.T) {
+		store := &stubTriggerStore{createErr: trigger.ErrInvalidPeripheral}
+		svc := newTriggerService(t, store)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(validBody)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("store error returns 500", func(t *testing.T) {
+		store := &stubTriggerStore{createErr: errSentinel}
+		svc := newTriggerService(t, store)
+		h := &api.CreateTriggerHandler{Service: svc}
+
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(validBody)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
+	})
+}
+
+// ── ListTriggersHandler ───────────────────────────────────────────────────────
+
+func TestListTriggersHandler(t *testing.T) {
+	t.Run("returns 200 with trigger list", func(t *testing.T) {
+		store := &stubTriggerStore{listed: []trigger.Trigger{newTrigger()}}
+		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
+		h := &api.ListTriggersHandler{Service: svc}
+
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp []map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp) != 1 || resp[0]["name"] != "Heater on cold" {
+			t.Errorf("unexpected response: %v", resp)
+		}
+	})
+
+	t.Run("returns empty list when no triggers", func(t *testing.T) {
+		store := &stubTriggerStore{listed: []trigger.Trigger{}}
+		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
+		h := &api.ListTriggersHandler{Service: svc}
+
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp []any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if len(resp) != 0 {
+			t.Errorf("expected empty list, got %v", resp)
+		}
+	})
+}
+
+// ── GetTriggerHandler ─────────────────────────────────────────────────────────
+
+func TestGetTriggerHandler(t *testing.T) {
+	t.Run("returns 200 with trigger", func(t *testing.T) {
+		store := &stubTriggerStore{got: newTrigger()}
+		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
+		h := &api.GetTriggerHandler{Service: svc}
+
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["name"] != "Heater on cold" {
+			t.Errorf("unexpected name: %v", resp["name"])
+		}
+	})
+
+	t.Run("not found returns 404", func(t *testing.T) {
+		store := &stubTriggerStore{getErr: trigger.ErrNotFound}
+		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
+		h := &api.GetTriggerHandler{Service: svc}
+
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "ghost"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
+	})
+}
+
+// ── PatchTriggerHandler ───────────────────────────────────────────────────────
+
+func TestPatchTriggerHandler(t *testing.T) {
+	t.Run("invalid body returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.PatchTriggerHandler{Service: svc}
+
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader("not json")), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("empty name returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.PatchTriggerHandler{Service: svc}
+
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"name":""}`)), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("invalid action.action returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.PatchTriggerHandler{Service: svc}
+
+		body := `{"action":{"action":"invalid"}}`
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body)), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("negative cooldown_s returns 400", func(t *testing.T) {
+		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+		h := &api.PatchTriggerHandler{Service: svc}
+
+		body := `{"cooldown_s":-5}`
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body)), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("trigger not found returns 404", func(t *testing.T) {
+		store := &stubTriggerStore{getErr: trigger.ErrNotFound}
+		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
+		h := &api.PatchTriggerHandler{Service: svc}
+
+		body := `{"name":"new name"}`
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body)), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "ghost"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
+	})
+}
+
+// ── DeleteTriggerHandler ──────────────────────────────────────────────────────
+
+func TestDeleteTriggerHandler(t *testing.T) {
+	t.Run("trigger not found returns 404", func(t *testing.T) {
+		store := &stubTriggerStore{deletedErr: trigger.ErrNotFound}
+		svc := newTriggerService(t, store)
+		h := &api.DeleteTriggerHandler{Service: svc}
+
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodDelete, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "ghost"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
+	})
+
+	t.Run("store error returns 500", func(t *testing.T) {
+		store := &stubTriggerStore{deletedErr: errSentinel}
+		svc := newTriggerService(t, store)
+		h := &api.DeleteTriggerHandler{Service: svc}
+
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodDelete, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
+	})
+}

--- a/internal/trigger/errors.go
+++ b/internal/trigger/errors.go
@@ -1,0 +1,8 @@
+package trigger
+
+import "errors"
+
+var (
+	ErrNotFound          = errors.New("trigger not found")
+	ErrInvalidPeripheral = errors.New("target_peripheral_id must refer to an actuator peripheral owned by the device")
+)

--- a/internal/trigger/model.go
+++ b/internal/trigger/model.go
@@ -1,0 +1,44 @@
+package trigger
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type Trigger struct {
+	ID                 string
+	DeviceID           string
+	Name               string
+	Enabled            bool
+	Condition          json.RawMessage
+	TargetPeripheralID string
+	Action             json.RawMessage
+	CooldownSeconds    int
+	CreatedAt          time.Time
+}
+
+type TriggerCreate struct {
+	Name               string
+	Condition          json.RawMessage
+	TargetPeripheralID string
+	Action             json.RawMessage
+	CooldownSeconds    int
+}
+
+// TriggerUpdate holds fully-merged values for an update (all fields required).
+type TriggerUpdate struct {
+	Name            string
+	Condition       json.RawMessage
+	Action          json.RawMessage
+	CooldownSeconds int
+	Enabled         bool
+}
+
+// TriggerPatch holds the partial fields from a PATCH request (nil means no change).
+type TriggerPatch struct {
+	Name            *string
+	Condition       json.RawMessage
+	Action          json.RawMessage
+	CooldownSeconds *int
+	Enabled         *bool
+}

--- a/internal/trigger/outbox_processor.go
+++ b/internal/trigger/outbox_processor.go
@@ -1,0 +1,81 @@
+package trigger
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+)
+
+// TriggerPushProcessor publishes trigger config to the firmware via retained MQTT.
+type TriggerPushProcessor struct {
+	publisher mqtt.Publisher
+	logger    *slog.Logger
+}
+
+func NewTriggerPushProcessor(publisher mqtt.Publisher, logger *slog.Logger) *TriggerPushProcessor {
+	return &TriggerPushProcessor{publisher: publisher, logger: logger}
+}
+
+func (p *TriggerPushProcessor) EventType() string { return eventTypeTriggerPush }
+
+func (p *TriggerPushProcessor) Process(ctx context.Context, event outbox.Event) error {
+	var payload triggerPushPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal payload: %w", err)
+	}
+
+	topic := fmt.Sprintf("fishhub/%s/triggers/%s", payload.DeviceID, payload.ID)
+
+	if payload.Op == "delete" {
+		msg, err := json.Marshal(struct {
+			Op string `json:"op"`
+			ID string `json:"id"`
+		}{Op: "delete", ID: payload.ID})
+		if err != nil {
+			return fmt.Errorf("marshal delete message: %w", err)
+		}
+		if err := p.publisher.PublishRetained(ctx, topic, msg); err != nil {
+			p.logger.Error("trigger push: mqtt publish delete",
+				"device_id", payload.DeviceID, "trigger_id", payload.ID, "error", err)
+			return fmt.Errorf("mqtt publish delete: %w", err)
+		}
+		// Clear retained message (best effort — firmware acts on op:delete above).
+		if err := p.publisher.PublishRetained(ctx, topic, []byte{}); err != nil {
+			p.logger.Warn("trigger push: mqtt clear retained",
+				"device_id", payload.DeviceID, "trigger_id", payload.ID, "error", err)
+		}
+		return nil
+	}
+
+	msg, err := json.Marshal(struct {
+		Op               string          `json:"op"`
+		ID               string          `json:"id"`
+		Enabled          bool            `json:"enabled"`
+		Condition        json.RawMessage `json:"condition"`
+		TargetPeripheral string          `json:"target_peripheral"`
+		Action           json.RawMessage `json:"action"`
+		CooldownS        int             `json:"cooldown_s"`
+	}{
+		Op:               "upsert",
+		ID:               payload.ID,
+		Enabled:          payload.Enabled,
+		Condition:        payload.Condition,
+		TargetPeripheral: payload.TargetPeripheral,
+		Action:           payload.Action,
+		CooldownS:        payload.CooldownS,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal upsert message: %w", err)
+	}
+
+	if err := p.publisher.PublishRetained(ctx, topic, msg); err != nil {
+		p.logger.Error("trigger push: mqtt publish upsert",
+			"device_id", payload.DeviceID, "trigger_id", payload.ID, "error", err)
+		return fmt.Errorf("mqtt publish upsert: %w", err)
+	}
+	return nil
+}

--- a/internal/trigger/outbox_processor_test.go
+++ b/internal/trigger/outbox_processor_test.go
@@ -1,0 +1,195 @@
+package trigger_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+)
+
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+type stubPublisher struct {
+	calls    []publishCall
+	retainCalled bool
+	err      error
+}
+
+type publishCall struct {
+	topic   string
+	payload []byte
+	retain  bool
+}
+
+func (s *stubPublisher) Publish(_ context.Context, topic string, payload []byte) error {
+	s.calls = append(s.calls, publishCall{topic: topic, payload: payload, retain: false})
+	return s.err
+}
+
+func (s *stubPublisher) PublishRetained(_ context.Context, topic string, payload []byte) error {
+	s.calls = append(s.calls, publishCall{topic: topic, payload: payload, retain: true})
+	s.retainCalled = true
+	return s.err
+}
+
+func makeEvent(t *testing.T, payload any) outbox.Event {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal event payload: %v", err)
+	}
+	return outbox.Event{Payload: b}
+}
+
+type pushPayload struct {
+	Op               string          `json:"op"`
+	ID               string          `json:"id"`
+	DeviceID         string          `json:"device_id"`
+	Enabled          bool            `json:"enabled"`
+	Condition        json.RawMessage `json:"condition"`
+	TargetPeripheral string          `json:"target_peripheral"`
+	Action           json.RawMessage `json:"action"`
+	CooldownS        int             `json:"cooldown_s"`
+}
+
+func TestTriggerPushProcessor_EventType(t *testing.T) {
+	proc := trigger.NewTriggerPushProcessor(&stubPublisher{}, discardLogger)
+	if proc.EventType() != "trigger.push" {
+		t.Errorf("unexpected event type: %q", proc.EventType())
+	}
+}
+
+func TestTriggerPushProcessor_Upsert(t *testing.T) {
+	pub := &stubPublisher{}
+	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
+
+	payload := pushPayload{
+		Op:               "upsert",
+		ID:               "trig-1",
+		DeviceID:         "dev-1",
+		Enabled:          true,
+		Condition:        json.RawMessage(`{"op":"lt","left":{"op":"value","measurement":"ds18b20-4/temperature"},"right":{"op":"literal","value":19.0}}`),
+		TargetPeripheral: "relay-14",
+		Action:           json.RawMessage(`{"action":"set","value":1.0}`),
+		CooldownS:        60,
+	}
+
+	if err := proc.Process(context.Background(), makeEvent(t, payload)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pub.calls))
+	}
+	call := pub.calls[0]
+	if !call.retain {
+		t.Error("expected retained publish")
+	}
+	wantTopic := "fishhub/dev-1/triggers/trig-1"
+	if call.topic != wantTopic {
+		t.Errorf("topic: got %q, want %q", call.topic, wantTopic)
+	}
+
+	var msg pushPayload
+	if err := json.Unmarshal(call.payload, &msg); err != nil {
+		t.Fatalf("unmarshal published payload: %v", err)
+	}
+	if msg.Op != "upsert" {
+		t.Errorf("op: got %q, want %q", msg.Op, "upsert")
+	}
+	if msg.ID != "trig-1" {
+		t.Errorf("id: got %q, want %q", msg.ID, "trig-1")
+	}
+	if msg.TargetPeripheral != "relay-14" {
+		t.Errorf("target_peripheral: got %q, want %q", msg.TargetPeripheral, "relay-14")
+	}
+	if msg.CooldownS != 60 {
+		t.Errorf("cooldown_s: got %d, want 60", msg.CooldownS)
+	}
+	// device_id must NOT appear in the MQTT message
+	if msg.DeviceID != "" {
+		t.Errorf("device_id should not be in MQTT payload, got %q", msg.DeviceID)
+	}
+}
+
+func TestTriggerPushProcessor_Delete(t *testing.T) {
+	pub := &stubPublisher{}
+	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
+
+	payload := pushPayload{
+		Op:       "delete",
+		ID:       "trig-2",
+		DeviceID: "dev-1",
+	}
+
+	if err := proc.Process(context.Background(), makeEvent(t, payload)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pub.calls) != 2 {
+		t.Fatalf("expected 2 publish calls (delete + clear), got %d", len(pub.calls))
+	}
+
+	// First call: delete payload
+	deleteCall := pub.calls[0]
+	wantTopic := "fishhub/dev-1/triggers/trig-2"
+	if deleteCall.topic != wantTopic {
+		t.Errorf("delete topic: got %q, want %q", deleteCall.topic, wantTopic)
+	}
+	var msg struct {
+		Op string `json:"op"`
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(deleteCall.payload, &msg); err != nil {
+		t.Fatalf("unmarshal delete payload: %v", err)
+	}
+	if msg.Op != "delete" || msg.ID != "trig-2" {
+		t.Errorf("unexpected delete message: op=%q id=%q", msg.Op, msg.ID)
+	}
+
+	// Second call: empty payload to clear retained message
+	clearCall := pub.calls[1]
+	if clearCall.topic != wantTopic {
+		t.Errorf("clear topic: got %q, want %q", clearCall.topic, wantTopic)
+	}
+	if len(clearCall.payload) != 0 {
+		t.Errorf("expected empty clear payload, got %q", clearCall.payload)
+	}
+}
+
+func TestTriggerPushProcessor_PublishError(t *testing.T) {
+	pub := &stubPublisher{err: errors.New("broker down")}
+	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
+
+	payload := pushPayload{Op: "upsert", ID: "t1", DeviceID: "d1",
+		Condition: json.RawMessage(`{}`), Action: json.RawMessage(`{}`)}
+
+	if err := proc.Process(context.Background(), makeEvent(t, payload)); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestTriggerPushProcessor_DeletePublishError(t *testing.T) {
+	pub := &stubPublisher{err: errors.New("broker down")}
+	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
+
+	payload := pushPayload{Op: "delete", ID: "t1", DeviceID: "d1"}
+
+	if err := proc.Process(context.Background(), makeEvent(t, payload)); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestTriggerPushProcessor_InvalidPayload(t *testing.T) {
+	pub := &stubPublisher{}
+	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
+
+	if err := proc.Process(context.Background(), outbox.Event{Payload: []byte("not json")}); err == nil {
+		t.Fatal("expected error for invalid payload, got nil")
+	}
+}

--- a/internal/trigger/service.go
+++ b/internal/trigger/service.go
@@ -107,28 +107,7 @@ func (s *Service) Update(ctx context.Context, deviceID, userID, triggerID string
 		return Trigger{}, err
 	}
 
-	merged := TriggerUpdate{
-		Name:            current.Name,
-		Condition:       current.Condition,
-		Action:          current.Action,
-		CooldownSeconds: current.CooldownSeconds,
-		Enabled:         current.Enabled,
-	}
-	if patch.Name != nil {
-		merged.Name = *patch.Name
-	}
-	if len(patch.Condition) > 0 {
-		merged.Condition = patch.Condition
-	}
-	if len(patch.Action) > 0 {
-		merged.Action = patch.Action
-	}
-	if patch.CooldownSeconds != nil {
-		merged.CooldownSeconds = *patch.CooldownSeconds
-	}
-	if patch.Enabled != nil {
-		merged.Enabled = *patch.Enabled
-	}
+	merged := applyPatch(current, patch)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -163,6 +142,34 @@ func (s *Service) Update(ctx context.Context, deviceID, userID, triggerID string
 		return Trigger{}, fmt.Errorf("update trigger: commit: %w", err)
 	}
 	return updated, nil
+}
+
+// applyPatch merges a TriggerPatch onto current, returning the fully-merged TriggerUpdate.
+// Nil patch fields leave the current value unchanged.
+func applyPatch(current Trigger, patch TriggerPatch) TriggerUpdate {
+	u := TriggerUpdate{
+		Name:            current.Name,
+		Condition:       current.Condition,
+		Action:          current.Action,
+		CooldownSeconds: current.CooldownSeconds,
+		Enabled:         current.Enabled,
+	}
+	if patch.Name != nil {
+		u.Name = *patch.Name
+	}
+	if len(patch.Condition) > 0 {
+		u.Condition = patch.Condition
+	}
+	if len(patch.Action) > 0 {
+		u.Action = patch.Action
+	}
+	if patch.CooldownSeconds != nil {
+		u.CooldownSeconds = *patch.CooldownSeconds
+	}
+	if patch.Enabled != nil {
+		u.Enabled = *patch.Enabled
+	}
+	return u
 }
 
 // Delete soft-deletes a trigger and enqueues a trigger.push delete outbox event atomically.

--- a/internal/trigger/service.go
+++ b/internal/trigger/service.go
@@ -1,0 +1,198 @@
+package trigger
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+)
+
+const eventTypeTriggerPush = "trigger.push"
+const triggerPushClaimTimeoutSeconds = 30
+
+type triggerPushPayload struct {
+	Op               string          `json:"op"`
+	ID               string          `json:"id"`
+	DeviceID         string          `json:"device_id"`
+	Enabled          bool            `json:"enabled,omitempty"`
+	Condition        json.RawMessage `json:"condition,omitempty"`
+	TargetPeripheral string          `json:"target_peripheral,omitempty"`
+	Action           json.RawMessage `json:"action,omitempty"`
+	CooldownS        int             `json:"cooldown_s,omitempty"`
+}
+
+// Service orchestrates trigger CRUD and outbox event enqueuing.
+type Service struct {
+	db     *sql.DB
+	store  Store
+	outbox outbox.Store
+	logger *slog.Logger
+}
+
+func NewService(db *sql.DB, store Store, outboxStore outbox.Store, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		db:     db,
+		store:  store,
+		outbox: outboxStore,
+		logger: logger,
+	}
+}
+
+// Create inserts a trigger and enqueues a trigger.push outbox event atomically.
+func (s *Service) Create(ctx context.Context, deviceID, userID string, p TriggerCreate) (Trigger, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Trigger{}, fmt.Errorf("create trigger: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	t, kindPin, err := s.store.Create(ctx, tx, deviceID, userID, p)
+	if err != nil {
+		return Trigger{}, err
+	}
+
+	if err := s.outbox.Insert(ctx, tx, eventTypeTriggerPush, triggerPushPayload{
+		Op:               "upsert",
+		ID:               t.ID,
+		DeviceID:         t.DeviceID,
+		Enabled:          t.Enabled,
+		Condition:        json.RawMessage(t.Condition),
+		TargetPeripheral: kindPin,
+		Action:           json.RawMessage(t.Action),
+		CooldownS:        t.CooldownSeconds,
+	}, triggerPushClaimTimeoutSeconds); err != nil {
+		s.logger.Error("create trigger: enqueue push", "device_id", deviceID, "error", err)
+		return Trigger{}, fmt.Errorf("create trigger: enqueue push: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("create trigger: commit", "device_id", deviceID, "error", err)
+		return Trigger{}, fmt.Errorf("create trigger: commit: %w", err)
+	}
+	return t, nil
+}
+
+// List returns non-deleted triggers for the device.
+func (s *Service) List(ctx context.Context, deviceID, userID string) ([]Trigger, error) {
+	triggers, err := s.store.List(ctx, deviceID, userID)
+	if err != nil {
+		s.logger.Error("list triggers", "device_id", deviceID, "error", err)
+	}
+	return triggers, err
+}
+
+// Get returns a single trigger by ID.
+func (s *Service) Get(ctx context.Context, deviceID, userID, triggerID string) (Trigger, error) {
+	t, err := s.store.Get(ctx, deviceID, userID, triggerID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		s.logger.Error("get trigger", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+	}
+	return t, err
+}
+
+// Update applies partial changes to a trigger and enqueues a trigger.push outbox event atomically.
+func (s *Service) Update(ctx context.Context, deviceID, userID, triggerID string, patch TriggerPatch) (Trigger, error) {
+	current, err := s.store.Get(ctx, deviceID, userID, triggerID)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			s.logger.Error("update trigger: get current", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		}
+		return Trigger{}, err
+	}
+
+	merged := TriggerUpdate{
+		Name:            current.Name,
+		Condition:       current.Condition,
+		Action:          current.Action,
+		CooldownSeconds: current.CooldownSeconds,
+		Enabled:         current.Enabled,
+	}
+	if patch.Name != nil {
+		merged.Name = *patch.Name
+	}
+	if len(patch.Condition) > 0 {
+		merged.Condition = patch.Condition
+	}
+	if len(patch.Action) > 0 {
+		merged.Action = patch.Action
+	}
+	if patch.CooldownSeconds != nil {
+		merged.CooldownSeconds = *patch.CooldownSeconds
+	}
+	if patch.Enabled != nil {
+		merged.Enabled = *patch.Enabled
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Trigger{}, fmt.Errorf("update trigger: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	updated, kindPin, err := s.store.Update(ctx, tx, deviceID, userID, triggerID, merged)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			s.logger.Error("update trigger: store", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		}
+		return Trigger{}, err
+	}
+
+	if err := s.outbox.Insert(ctx, tx, eventTypeTriggerPush, triggerPushPayload{
+		Op:               "upsert",
+		ID:               updated.ID,
+		DeviceID:         updated.DeviceID,
+		Enabled:          updated.Enabled,
+		Condition:        json.RawMessage(updated.Condition),
+		TargetPeripheral: kindPin,
+		Action:           json.RawMessage(updated.Action),
+		CooldownS:        updated.CooldownSeconds,
+	}, triggerPushClaimTimeoutSeconds); err != nil {
+		s.logger.Error("update trigger: enqueue push", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		return Trigger{}, fmt.Errorf("update trigger: enqueue push: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("update trigger: commit", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		return Trigger{}, fmt.Errorf("update trigger: commit: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes a trigger and enqueues a trigger.push delete outbox event atomically.
+func (s *Service) Delete(ctx context.Context, deviceID, userID, triggerID string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("delete trigger: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	deleted, err := s.store.Delete(ctx, tx, deviceID, userID, triggerID)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			s.logger.Error("delete trigger: store", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		}
+		return err
+	}
+
+	if err := s.outbox.Insert(ctx, tx, eventTypeTriggerPush, triggerPushPayload{
+		Op:       "delete",
+		ID:       deleted.ID,
+		DeviceID: deleted.DeviceID,
+	}, triggerPushClaimTimeoutSeconds); err != nil {
+		s.logger.Error("delete trigger: enqueue push", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		return fmt.Errorf("delete trigger: enqueue push: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("delete trigger: commit", "device_id", deviceID, "trigger_id", triggerID, "error", err)
+		return fmt.Errorf("delete trigger: commit: %w", err)
+	}
+	return nil
+}

--- a/internal/trigger/service_test.go
+++ b/internal/trigger/service_test.go
@@ -1,0 +1,294 @@
+package trigger
+
+// White-box tests for unexported service helpers and service method behaviour
+// that can be exercised without a real database connection.
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/outbox"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+)
+
+// ── applyPatch ────────────────────────────────────────────────────────────────
+
+func baseTrigger() Trigger {
+	return Trigger{
+		ID:              "t1",
+		Name:            "original",
+		Enabled:         true,
+		Condition:       json.RawMessage(`{"op":"lt"}`),
+		Action:          json.RawMessage(`{"action":"set","value":1.0}`),
+		CooldownSeconds: 60,
+	}
+}
+
+func TestApplyPatch_noPatch_preservesAll(t *testing.T) {
+	cur := baseTrigger()
+	u := applyPatch(cur, TriggerPatch{})
+	if u.Name != "original" {
+		t.Errorf("name: got %q want %q", u.Name, "original")
+	}
+	if !u.Enabled {
+		t.Error("enabled changed")
+	}
+	if u.CooldownSeconds != 60 {
+		t.Errorf("cooldown_s: got %d want 60", u.CooldownSeconds)
+	}
+	if !bytes.Equal(u.Condition, cur.Condition) {
+		t.Error("condition changed")
+	}
+	if !bytes.Equal(u.Action, cur.Action) {
+		t.Error("action changed")
+	}
+}
+
+func TestApplyPatch_name(t *testing.T) {
+	name := "updated"
+	u := applyPatch(baseTrigger(), TriggerPatch{Name: &name})
+	if u.Name != "updated" {
+		t.Errorf("name: got %q want %q", u.Name, "updated")
+	}
+}
+
+func TestApplyPatch_enabled(t *testing.T) {
+	enabled := false
+	u := applyPatch(baseTrigger(), TriggerPatch{Enabled: &enabled})
+	if u.Enabled {
+		t.Error("expected enabled=false")
+	}
+}
+
+func TestApplyPatch_cooldown(t *testing.T) {
+	cd := 120
+	u := applyPatch(baseTrigger(), TriggerPatch{CooldownSeconds: &cd})
+	if u.CooldownSeconds != 120 {
+		t.Errorf("cooldown_s: got %d want 120", u.CooldownSeconds)
+	}
+}
+
+func TestApplyPatch_condition(t *testing.T) {
+	newCond := json.RawMessage(`{"op":"gt"}`)
+	u := applyPatch(baseTrigger(), TriggerPatch{Condition: newCond})
+	if !bytes.Equal(u.Condition, newCond) {
+		t.Errorf("condition: got %s want %s", u.Condition, newCond)
+	}
+}
+
+func TestApplyPatch_action(t *testing.T) {
+	newAction := json.RawMessage(`{"action":"set_mode","mode":"automatic"}`)
+	u := applyPatch(baseTrigger(), TriggerPatch{Action: newAction})
+	if !bytes.Equal(u.Action, newAction) {
+		t.Errorf("action: got %s want %s", u.Action, newAction)
+	}
+}
+
+func TestApplyPatch_nilCondition_unchanged(t *testing.T) {
+	// nil (absent) Condition must not clear the existing value.
+	u := applyPatch(baseTrigger(), TriggerPatch{Condition: nil})
+	if !bytes.Equal(u.Condition, baseTrigger().Condition) {
+		t.Error("condition was cleared by nil patch")
+	}
+}
+
+// ── service stubs ─────────────────────────────────────────────────────────────
+
+var svcDiscardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+type stubStore struct {
+	created       Trigger
+	createKindPin string
+	createErr     error
+	listed        []Trigger
+	listErr       error
+	got           Trigger
+	getErr        error
+	updated       Trigger
+	updateKindPin string
+	updateErr     error
+	deleteErr     error
+}
+
+func (s *stubStore) Create(_ context.Context, _ *sql.Tx, _, _ string, _ TriggerCreate) (Trigger, string, error) {
+	return s.created, s.createKindPin, s.createErr
+}
+func (s *stubStore) List(_ context.Context, _, _ string) ([]Trigger, error) {
+	return s.listed, s.listErr
+}
+func (s *stubStore) Get(_ context.Context, _, _, _ string) (Trigger, error) {
+	return s.got, s.getErr
+}
+func (s *stubStore) Update(_ context.Context, _ *sql.Tx, _, _, _ string, _ TriggerUpdate) (Trigger, string, error) {
+	return s.updated, s.updateKindPin, s.updateErr
+}
+func (s *stubStore) Delete(_ context.Context, _ *sql.Tx, _, _, _ string) (Trigger, error) {
+	return s.created, s.deleteErr
+}
+
+type stubOutbox struct{ insertErr error }
+
+func (o *stubOutbox) ClaimBatch(_ context.Context, _ int) ([]outbox.Event, error) { return nil, nil }
+func (o *stubOutbox) MarkCompleted(_ context.Context, _ string) error              { return nil }
+func (o *stubOutbox) RecordFailure(_ context.Context, _ string, _, _ int, _ string) error {
+	return nil
+}
+func (o *stubOutbox) Insert(_ context.Context, _ *sql.Tx, _ string, _ any, _ int) error {
+	return o.insertErr
+}
+
+// ── Service.List ──────────────────────────────────────────────────────────────
+
+func TestService_List_returnsFromStore(t *testing.T) {
+	triggers := []Trigger{baseTrigger()}
+	svc := NewService(nil, &stubStore{listed: triggers}, &stubOutbox{}, svcDiscardLogger)
+	got, err := svc.List(context.Background(), "dev-1", "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "original" {
+		t.Errorf("unexpected triggers: %+v", got)
+	}
+}
+
+func TestService_List_propagatesStoreError(t *testing.T) {
+	storeErr := errors.New("db down")
+	svc := NewService(nil, &stubStore{listErr: storeErr}, &stubOutbox{}, svcDiscardLogger)
+	_, err := svc.List(context.Background(), "dev-1", "user-1")
+	if !errors.Is(err, storeErr) {
+		t.Errorf("expected storeErr, got %v", err)
+	}
+}
+
+// ── Service.Get ───────────────────────────────────────────────────────────────
+
+func TestService_Get_returnsFromStore(t *testing.T) {
+	svc := NewService(nil, &stubStore{got: baseTrigger()}, &stubOutbox{}, svcDiscardLogger)
+	got, err := svc.Get(context.Background(), "dev-1", "user-1", "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "original" {
+		t.Errorf("name: got %q", got.Name)
+	}
+}
+
+func TestService_Get_notFoundPropagated(t *testing.T) {
+	svc := NewService(nil, &stubStore{getErr: ErrNotFound}, &stubOutbox{}, svcDiscardLogger)
+	_, err := svc.Get(context.Background(), "dev-1", "user-1", "ghost")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ── Service.Update (pre-BeginTx paths) ────────────────────────────────────────
+
+func TestService_Update_notFound_beforeBeginTx(t *testing.T) {
+	// store.Get returns ErrNotFound → service returns before touching db
+	svc := NewService(nil, &stubStore{getErr: ErrNotFound}, &stubOutbox{}, svcDiscardLogger)
+	_, err := svc.Update(context.Background(), "dev-1", "user-1", "ghost", TriggerPatch{})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestService_Update_storeGetError_beforeBeginTx(t *testing.T) {
+	storeErr := errors.New("db down")
+	svc := NewService(nil, &stubStore{getErr: storeErr}, &stubOutbox{}, svcDiscardLogger)
+	_, err := svc.Update(context.Background(), "dev-1", "user-1", "t1", TriggerPatch{})
+	if !errors.Is(err, storeErr) {
+		t.Errorf("expected storeErr, got %v", err)
+	}
+}
+
+// ── Service.Create/Update/Delete with real tx (outbox failure path) ────────────
+
+func TestService_Create_outboxFailure_rollsBack(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := &stubStore{created: baseTrigger(), createKindPin: "relay-14"}
+	outboxStore := &stubOutbox{insertErr: errors.New("outbox down")}
+	svc := NewService(db, store, outboxStore, svcDiscardLogger)
+
+	_, err := svc.Create(context.Background(), "dev-1", "user-1", TriggerCreate{
+		Name:      "test",
+		Condition: json.RawMessage(`{}`),
+		Action:    json.RawMessage(`{}`),
+	})
+	if err == nil {
+		t.Fatal("expected error from outbox failure, got nil")
+	}
+}
+
+func TestService_Update_mergeApplied_viaCapture(t *testing.T) {
+	db := testutil.NewTestDB(t)
+
+	cur := baseTrigger()
+	newName := "renamed"
+	cooldown := 30
+	capture := &captureUpdateStore{got: cur, updateResult: cur, updateKindPin: "relay-14"}
+	svc := NewService(db, capture, &stubOutbox{}, svcDiscardLogger)
+
+	_, err := svc.Update(context.Background(), "dev-1", "user-1", "t1", TriggerPatch{
+		Name:            &newName,
+		CooldownSeconds: &cooldown,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.lastUpdate.Name != "renamed" {
+		t.Errorf("name not applied: got %q", capture.lastUpdate.Name)
+	}
+	if capture.lastUpdate.CooldownSeconds != 30 {
+		t.Errorf("cooldown not applied: got %d", capture.lastUpdate.CooldownSeconds)
+	}
+	// unchanged fields preserved
+	if capture.lastUpdate.Enabled != cur.Enabled {
+		t.Error("enabled changed unexpectedly")
+	}
+	if !bytes.Equal(capture.lastUpdate.Condition, cur.Condition) {
+		t.Error("condition changed unexpectedly")
+	}
+}
+
+func TestService_Delete_outboxFailure_rollsBack(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := &stubStore{created: baseTrigger()}
+	outboxStore := &stubOutbox{insertErr: errors.New("outbox down")}
+	svc := NewService(db, store, outboxStore, svcDiscardLogger)
+
+	err := svc.Delete(context.Background(), "dev-1", "user-1", "t1")
+	if err == nil {
+		t.Fatal("expected error from outbox failure, got nil")
+	}
+}
+
+// captureUpdateStore records the TriggerUpdate passed to Update for assertion.
+type captureUpdateStore struct {
+	got           Trigger
+	lastUpdate    TriggerUpdate
+	updateResult  Trigger
+	updateKindPin string
+}
+
+func (c *captureUpdateStore) Create(_ context.Context, _ *sql.Tx, _, _ string, _ TriggerCreate) (Trigger, string, error) {
+	return Trigger{}, "", nil
+}
+func (c *captureUpdateStore) List(_ context.Context, _, _ string) ([]Trigger, error) {
+	return nil, nil
+}
+func (c *captureUpdateStore) Get(_ context.Context, _, _, _ string) (Trigger, error) {
+	return c.got, nil
+}
+func (c *captureUpdateStore) Update(_ context.Context, _ *sql.Tx, _, _, _ string, u TriggerUpdate) (Trigger, string, error) {
+	c.lastUpdate = u
+	return c.updateResult, c.updateKindPin, nil
+}
+func (c *captureUpdateStore) Delete(_ context.Context, _ *sql.Tx, _, _, _ string) (Trigger, error) {
+	return Trigger{}, nil
+}

--- a/internal/trigger/store.go
+++ b/internal/trigger/store.go
@@ -1,0 +1,202 @@
+package trigger
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/fishhub-oss/fishhub-server/internal/device"
+)
+
+// Store handles trigger persistence.
+type Store interface {
+	// Create inserts a new trigger for deviceID owned by userID.
+	// Validates that target_peripheral_id refers to an actuator peripheral on the same device.
+	// Returns device.ErrNotFound if the device does not exist or is not owned by userID.
+	// Returns ErrInvalidPeripheral if the peripheral is missing, deleted, or not an actuator.
+	// Returns (trigger, peripheralKindPin, error).
+	Create(ctx context.Context, tx *sql.Tx, deviceID, userID string, p TriggerCreate) (Trigger, string, error)
+	// List returns non-deleted triggers for the device owned by userID.
+	List(ctx context.Context, deviceID, userID string) ([]Trigger, error)
+	// Get returns a single non-deleted trigger. Returns ErrNotFound if not reachable.
+	Get(ctx context.Context, deviceID, userID, triggerID string) (Trigger, error)
+	// Update replaces trigger fields within tx, joining peripherals to return kind-pin.
+	// Returns ErrNotFound if the trigger does not exist or is not reachable by userID.
+	// Returns (trigger, peripheralKindPin, error).
+	Update(ctx context.Context, tx *sql.Tx, deviceID, userID, triggerID string, u TriggerUpdate) (Trigger, string, error)
+	// Delete soft-deletes the trigger (sets deleted_at). Returns ErrNotFound if not reachable.
+	Delete(ctx context.Context, tx *sql.Tx, deviceID, userID, triggerID string) (Trigger, error)
+}
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) Store {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) Create(ctx context.Context, tx *sql.Tx, deviceID, userID string, p TriggerCreate) (Trigger, string, error) {
+	var kindPin string
+	err := tx.QueryRowContext(ctx, `
+		SELECT concat(pr.kind, '-', pr.pin::text)
+		FROM peripherals pr
+		JOIN devices d ON d.id = pr.device_id
+		WHERE pr.id = $1
+		  AND pr.device_id = $2
+		  AND d.user_id = $3
+		  AND pr.category = 'actuator'
+		  AND pr.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+	`, p.TargetPeripheralID, deviceID, userID).Scan(&kindPin)
+	if errors.Is(err, sql.ErrNoRows) {
+		var deviceExists bool
+		_ = tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM devices WHERE id=$1 AND user_id=$2 AND deleted_at IS NULL)`,
+			deviceID, userID,
+		).Scan(&deviceExists)
+		if !deviceExists {
+			return Trigger{}, "", device.ErrNotFound
+		}
+		return Trigger{}, "", ErrInvalidPeripheral
+	}
+	if err != nil {
+		return Trigger{}, "", fmt.Errorf("create trigger: resolve peripheral: %w", err)
+	}
+
+	var t Trigger
+	err = tx.QueryRowContext(ctx, `
+		INSERT INTO triggers (device_id, name, condition, target_peripheral_id, action, cooldown_s)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, device_id, name, enabled, condition, target_peripheral_id, action, cooldown_s, created_at
+	`, deviceID, p.Name, p.Condition, p.TargetPeripheralID, p.Action, p.CooldownSeconds).Scan(
+		&t.ID, &t.DeviceID, &t.Name, &t.Enabled,
+		&t.Condition, &t.TargetPeripheralID, &t.Action, &t.CooldownSeconds, &t.CreatedAt,
+	)
+	if err != nil {
+		return Trigger{}, "", fmt.Errorf("create trigger: insert: %w", err)
+	}
+	return t, kindPin, nil
+}
+
+func (s *postgresStore) List(ctx context.Context, deviceID, userID string) ([]Trigger, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT tr.id, tr.device_id, tr.name, tr.enabled, tr.condition,
+		       tr.target_peripheral_id, tr.action, tr.cooldown_s, tr.created_at
+		FROM triggers tr
+		JOIN devices d ON d.id = tr.device_id
+		WHERE tr.device_id = $1
+		  AND d.user_id = $2
+		  AND tr.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+		ORDER BY tr.created_at ASC
+	`, deviceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list triggers: query: %w", err)
+	}
+	defer rows.Close()
+
+	triggers := []Trigger{}
+	for rows.Next() {
+		var t Trigger
+		if err := rows.Scan(
+			&t.ID, &t.DeviceID, &t.Name, &t.Enabled,
+			&t.Condition, &t.TargetPeripheralID, &t.Action, &t.CooldownSeconds, &t.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("list triggers: scan: %w", err)
+		}
+		triggers = append(triggers, t)
+	}
+	return triggers, rows.Err()
+}
+
+func (s *postgresStore) Get(ctx context.Context, deviceID, userID, triggerID string) (Trigger, error) {
+	var t Trigger
+	err := s.db.QueryRowContext(ctx, `
+		SELECT tr.id, tr.device_id, tr.name, tr.enabled, tr.condition,
+		       tr.target_peripheral_id, tr.action, tr.cooldown_s, tr.created_at
+		FROM triggers tr
+		JOIN devices d ON d.id = tr.device_id
+		WHERE tr.id = $1
+		  AND tr.device_id = $2
+		  AND d.user_id = $3
+		  AND tr.deleted_at IS NULL
+		  AND d.deleted_at IS NULL
+	`, triggerID, deviceID, userID).Scan(
+		&t.ID, &t.DeviceID, &t.Name, &t.Enabled,
+		&t.Condition, &t.TargetPeripheralID, &t.Action, &t.CooldownSeconds, &t.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Trigger{}, ErrNotFound
+	}
+	if err != nil {
+		return Trigger{}, fmt.Errorf("get trigger: %w", err)
+	}
+	return t, nil
+}
+
+func (s *postgresStore) Update(ctx context.Context, tx *sql.Tx, deviceID, userID, triggerID string, u TriggerUpdate) (Trigger, string, error) {
+	var t Trigger
+	var kindPin string
+	err := tx.QueryRowContext(ctx, `
+		UPDATE triggers tr
+		SET name       = $1,
+		    condition  = $2,
+		    action     = $3,
+		    cooldown_s = $4,
+		    enabled    = $5
+		FROM devices d,
+		     peripherals pr
+		WHERE tr.id        = $6
+		  AND tr.device_id = $7
+		  AND d.id         = tr.device_id
+		  AND d.user_id    = $8
+		  AND pr.id        = tr.target_peripheral_id
+		  AND tr.deleted_at IS NULL
+		  AND d.deleted_at  IS NULL
+		RETURNING tr.id, tr.device_id, tr.name, tr.enabled, tr.condition,
+		          tr.target_peripheral_id, tr.action, tr.cooldown_s, tr.created_at,
+		          concat(pr.kind, '-', pr.pin::text)
+	`, u.Name, u.Condition, u.Action, u.CooldownSeconds, u.Enabled,
+		triggerID, deviceID, userID,
+	).Scan(
+		&t.ID, &t.DeviceID, &t.Name, &t.Enabled,
+		&t.Condition, &t.TargetPeripheralID, &t.Action, &t.CooldownSeconds, &t.CreatedAt,
+		&kindPin,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Trigger{}, "", ErrNotFound
+	}
+	if err != nil {
+		return Trigger{}, "", fmt.Errorf("update trigger: %w", err)
+	}
+	return t, kindPin, nil
+}
+
+func (s *postgresStore) Delete(ctx context.Context, tx *sql.Tx, deviceID, userID, triggerID string) (Trigger, error) {
+	var t Trigger
+	err := tx.QueryRowContext(ctx, `
+		UPDATE triggers tr
+		SET deleted_at = now()
+		FROM devices d
+		WHERE tr.id        = $1
+		  AND tr.device_id = $2
+		  AND d.id         = tr.device_id
+		  AND d.user_id    = $3
+		  AND tr.deleted_at IS NULL
+		  AND d.deleted_at  IS NULL
+		RETURNING tr.id, tr.device_id, tr.name, tr.enabled, tr.condition,
+		          tr.target_peripheral_id, tr.action, tr.cooldown_s, tr.created_at
+	`, triggerID, deviceID, userID).Scan(
+		&t.ID, &t.DeviceID, &t.Name, &t.Enabled,
+		&t.Condition, &t.TargetPeripheralID, &t.Action, &t.CooldownSeconds, &t.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Trigger{}, ErrNotFound
+	}
+	if err != nil {
+		return Trigger{}, fmt.Errorf("delete trigger: %w", err)
+	}
+	return t, nil
+}

--- a/internal/trigger/store_integration_test.go
+++ b/internal/trigger/store_integration_test.go
@@ -1,0 +1,273 @@
+package trigger_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/platform"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+)
+
+func TestTriggerStore_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := trigger.NewStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	// Insert a device.
+	var deviceID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+	).Scan(&deviceID); err != nil {
+		t.Fatalf("insert device: %v", err)
+	}
+
+	// Insert an actuator peripheral.
+	var peripheralID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO peripherals (device_id, name, kind, pin, category, control_mode)
+		 VALUES ($1, 'heater', 'relay', 14, 'actuator', 'automatic') RETURNING id`,
+		deviceID,
+	).Scan(&peripheralID); err != nil {
+		t.Fatalf("insert peripheral: %v", err)
+	}
+
+	// Insert a sensor peripheral (not an actuator).
+	var sensorID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO peripherals (device_id, name, kind, pin, category)
+		 VALUES ($1, 'temp', 'ds18b20', 4, 'sensor') RETURNING id`,
+		deviceID,
+	).Scan(&sensorID); err != nil {
+		t.Fatalf("insert sensor peripheral: %v", err)
+	}
+
+	condition := []byte(`{"op":"lt","left":{"op":"value","measurement":"ds18b20-4/temperature"},"right":{"op":"literal","value":19.0}}`)
+	action := []byte(`{"action":"set","value":1.0}`)
+
+	var triggerID string
+
+	t.Run("create trigger returns trigger and kind-pin", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		tr, kindPin, err := store.Create(ctx, tx, deviceID, userID, trigger.TriggerCreate{
+			Name:               "Heater on cold",
+			Condition:          condition,
+			TargetPeripheralID: peripheralID,
+			Action:             action,
+			CooldownSeconds:    60,
+		})
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("create trigger: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		if tr.ID == "" {
+			t.Error("expected non-empty trigger ID")
+		}
+		if tr.Name != "Heater on cold" {
+			t.Errorf("name: got %q, want %q", tr.Name, "Heater on cold")
+		}
+		if !tr.Enabled {
+			t.Error("expected enabled=true by default")
+		}
+		if tr.CooldownSeconds != 60 {
+			t.Errorf("cooldown_s: got %d, want 60", tr.CooldownSeconds)
+		}
+		if kindPin != "relay-14" {
+			t.Errorf("kind-pin: got %q, want %q", kindPin, "relay-14")
+		}
+		triggerID = tr.ID
+	})
+
+	t.Run("create with sensor peripheral returns ErrInvalidPeripheral", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer tx.Rollback()
+
+		_, _, err = store.Create(ctx, tx, deviceID, userID, trigger.TriggerCreate{
+			Name:               "bad",
+			Condition:          condition,
+			TargetPeripheralID: sensorID,
+			Action:             action,
+			CooldownSeconds:    60,
+		})
+		if !errors.Is(err, trigger.ErrInvalidPeripheral) {
+			t.Errorf("expected ErrInvalidPeripheral, got %v", err)
+		}
+	})
+
+	t.Run("create with unknown device returns ErrNotFound", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer tx.Rollback()
+
+		_, _, err = store.Create(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, trigger.TriggerCreate{
+			Name:               "bad",
+			Condition:          condition,
+			TargetPeripheralID: peripheralID,
+			Action:             action,
+		})
+		if !errors.Is(err, device.ErrNotFound) {
+			t.Errorf("expected device.ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("list returns created trigger", func(t *testing.T) {
+		triggers, err := store.List(ctx, deviceID, userID)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(triggers) == 0 {
+			t.Fatal("expected at least one trigger")
+		}
+		found := false
+		for _, tr := range triggers {
+			if tr.ID == triggerID {
+				found = true
+				if tr.Name != "Heater on cold" {
+					t.Errorf("name: got %q, want %q", tr.Name, "Heater on cold")
+				}
+			}
+		}
+		if !found {
+			t.Error("created trigger not found in list")
+		}
+	})
+
+	t.Run("list returns empty for wrong user", func(t *testing.T) {
+		var otherUserID string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO users (email, provider, provider_sub) VALUES ('other@test.com','test','sub-other') RETURNING id`,
+		).Scan(&otherUserID); err != nil {
+			t.Fatalf("insert other user: %v", err)
+		}
+		triggers, err := store.List(ctx, deviceID, otherUserID)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(triggers) != 0 {
+			t.Errorf("expected empty list for wrong user, got %d triggers", len(triggers))
+		}
+	})
+
+	t.Run("get returns trigger", func(t *testing.T) {
+		tr, err := store.Get(ctx, deviceID, userID, triggerID)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if tr.ID != triggerID {
+			t.Errorf("id: got %q, want %q", tr.ID, triggerID)
+		}
+	})
+
+	t.Run("get unknown trigger returns ErrNotFound", func(t *testing.T) {
+		_, err := store.Get(ctx, deviceID, userID, "00000000-0000-0000-0000-000000000000")
+		if !errors.Is(err, trigger.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("update trigger returns updated fields and kind-pin", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		updated, kindPin, err := store.Update(ctx, tx, deviceID, userID, triggerID, trigger.TriggerUpdate{
+			Name:            "Heater on cold updated",
+			Condition:       condition,
+			Action:          action,
+			CooldownSeconds: 120,
+			Enabled:         false,
+		})
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("update: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		if updated.Name != "Heater on cold updated" {
+			t.Errorf("name: got %q, want %q", updated.Name, "Heater on cold updated")
+		}
+		if updated.Enabled {
+			t.Error("expected enabled=false after update")
+		}
+		if updated.CooldownSeconds != 120 {
+			t.Errorf("cooldown_s: got %d, want 120", updated.CooldownSeconds)
+		}
+		if kindPin != "relay-14" {
+			t.Errorf("kind-pin: got %q, want %q", kindPin, "relay-14")
+		}
+	})
+
+	t.Run("update unknown trigger returns ErrNotFound", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer tx.Rollback()
+
+		_, _, err = store.Update(ctx, tx, deviceID, userID, "00000000-0000-0000-0000-000000000000", trigger.TriggerUpdate{
+			Name:      "x",
+			Condition: condition,
+			Action:    action,
+		})
+		if !errors.Is(err, trigger.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete soft-deletes the trigger", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		deleted, err := store.Delete(ctx, tx, deviceID, userID, triggerID)
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("delete: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		if deleted.ID != triggerID {
+			t.Errorf("deleted id: got %q, want %q", deleted.ID, triggerID)
+		}
+
+		// Should no longer appear in list.
+		triggers, err := store.List(ctx, deviceID, userID)
+		if err != nil {
+			t.Fatalf("list after delete: %v", err)
+		}
+		for _, tr := range triggers {
+			if tr.ID == triggerID {
+				t.Error("deleted trigger still appears in list")
+			}
+		}
+	})
+
+	t.Run("delete already-deleted trigger returns ErrNotFound", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer tx.Rollback()
+
+		_, err = store.Delete(ctx, tx, deviceID, userID, triggerID)
+		if !errors.Is(err, trigger.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 )
@@ -264,11 +265,13 @@ func main() {
 	// ── Stores & services ─────────────────────────────────────────────────────
 	deviceStore := device.NewStore(db)
 	peripheralStore := peripheral.NewStore(db)
+	triggerStore := trigger.NewStore(db)
 	provisioningStore := provisioning.NewStore(db)
 	outboxStore := outbox.NewPostgresStore(db)
 	readingsSvc := measurement.NewReadingsService(deviceFinderBridge{deviceStore}, influxClient, influxClient, logger)
 	deviceSvc := device.NewService(deviceStore, hivemqClient, mqttPublisher, logger)
 	peripheralSvc := peripheral.NewService(db, peripheralStore, outboxStore, influxClient, mqttPublisher, logger)
+	triggerSvc := trigger.NewService(db, triggerStore, outboxStore, logger)
 	provisioningSvc := provisioning.NewService(provisioningStore, logger)
 	activationSvc := provisioning.NewActivationService(db, provisioningStore, outboxStore, deviceSigner,
 		accountTimezoneReaderBridge{accountStore}, logger)
@@ -286,6 +289,7 @@ func main() {
 			provisioning.NewHiveMQProvisionProcessor(hivemqClient, logger),
 			peripheral.NewPeripheralPushProcessor(mqttPublisher, logger),
 			account.NewConfigPushProcessor(mqttPublisher, logger),
+			trigger.NewTriggerPushProcessor(mqttPublisher, logger),
 		},
 		10*time.Second,
 		5,
@@ -340,6 +344,11 @@ func main() {
 		r.Delete("/api/devices/{id}/peripherals/{peripheralId}", (&api.DeletePeripheralHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Patch("/api/devices/{id}/peripherals/{peripheralId}/control-mode", (&api.SetControlModeHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Post("/api/devices/{id}/peripherals/{peripheralId}/commands", (&api.CommandHandler{Service: peripheralSvc}).ServeHTTP)
+		r.Post("/api/devices/{id}/triggers", (&api.CreateTriggerHandler{Service: triggerSvc}).ServeHTTP)
+		r.Get("/api/devices/{id}/triggers", (&api.ListTriggersHandler{Service: triggerSvc}).ServeHTTP)
+		r.Get("/api/devices/{id}/triggers/{tid}", (&api.GetTriggerHandler{Service: triggerSvc}).ServeHTTP)
+		r.Patch("/api/devices/{id}/triggers/{tid}", (&api.PatchTriggerHandler{Service: triggerSvc}).ServeHTTP)
+		r.Delete("/api/devices/{id}/triggers/{tid}", (&api.DeleteTriggerHandler{Service: triggerSvc}).ServeHTTP)
 	})
 
 	fmt.Printf("listening on :%s\n", cfg.Port)


### PR DESCRIPTION
Add migration 019 creating the `triggers` table (FK to devices +
peripherals, JSONB condition/action, soft-delete). Introduce the
`internal/trigger` package with model, postgres store, service, and
`TriggerPushProcessor` outbox processor.

HTTP endpoints (session JWT auth):
  POST   /api/devices/{id}/triggers
  GET    /api/devices/{id}/triggers
  GET    /api/devices/{id}/triggers/{tid}
  PATCH  /api/devices/{id}/triggers/{tid}
  DELETE /api/devices/{id}/triggers/{tid}

On every mutating operation a `trigger.push` outbox event is inserted
in the same transaction. The processor publishes retained MQTT to
`fishhub/{device_id}/triggers/{trigger_id}`; on delete it first
publishes the delete payload then clears the retained message.

https://claude.ai/code/session_01PNN5mgEnhB5JfyqYQBoMPA

Closes #118 