### PR TITLE
Update trigger API request/response shape to use actions array

### DIFF
--- a/internal/api/trigger_handler.go
+++ b/internal/api/trigger_handler.go
@@ -14,60 +14,48 @@ import (
 	"github.com/go-chi/render"
 )
 
+type ActionResponse struct {
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config"`
+}
+
 type TriggerResponse struct {
-	ID                 string          `json:"id"`
-	Name               string          `json:"name"`
-	Enabled            bool            `json:"enabled"`
-	Condition          json.RawMessage `json:"condition"`
-	TargetPeripheralID string          `json:"target_peripheral_id"`
-	Action             json.RawMessage `json:"action"`
-	CooldownSeconds    int             `json:"cooldown_s"`
-	CreatedAt          string          `json:"created_at"`
+	ID              string           `json:"id"`
+	Name            string           `json:"name"`
+	Enabled         bool             `json:"enabled"`
+	Condition       json.RawMessage  `json:"condition"`
+	Actions         []ActionResponse `json:"actions"`
+	CooldownSeconds int              `json:"cooldown_s"`
+	CreatedAt       string           `json:"created_at"`
 }
 
 func triggerResponse(t trigger.Trigger) TriggerResponse {
-	resp := TriggerResponse{
+	actions := make([]ActionResponse, len(t.Actions))
+	for i, a := range t.Actions {
+		actions[i] = ActionResponse{ID: a.ID, Type: a.Type, Config: a.Config}
+	}
+	return TriggerResponse{
 		ID:              t.ID,
 		Name:            t.Name,
 		Enabled:         t.Enabled,
 		Condition:       t.Condition,
+		Actions:         actions,
 		CooldownSeconds: t.CooldownSeconds,
 		CreatedAt:       t.CreatedAt.UTC().Format(time.RFC3339),
 	}
-	// Extract target_peripheral_id and action from the first peripheral_action.
-	for _, a := range t.Actions {
-		if a.Type != "peripheral_action" {
-			continue
-		}
-		var cfg struct {
-			PeripheralID string          `json:"peripheral_id"`
-			Command      string          `json:"command"`
-			Value        json.RawMessage `json:"value"`
-		}
-		if err := json.Unmarshal(a.Config, &cfg); err != nil {
-			break
-		}
-		resp.TargetPeripheralID = cfg.PeripheralID
-		resp.Action, _ = json.Marshal(map[string]json.RawMessage{
-			"action": mustMarshalString(cfg.Command),
-			"value":  cfg.Value,
-		})
-		break
-	}
-	return resp
 }
 
-func mustMarshalString(s string) json.RawMessage {
-	b, _ := json.Marshal(s)
-	return b
+type actionRequest struct {
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config"`
 }
 
 type createTriggerRequest struct {
-	Name               string          `json:"name"`
-	Condition          json.RawMessage `json:"condition"`
-	TargetPeripheralID string          `json:"target_peripheral_id"`
-	Action             json.RawMessage `json:"action"`
-	CooldownSeconds    int             `json:"cooldown_s"`
+	Name            string          `json:"name"`
+	Condition       json.RawMessage `json:"condition"`
+	Actions         []actionRequest `json:"actions"`
+	CooldownSeconds int             `json:"cooldown_s"`
 }
 
 // CreateTriggerHandler handles POST /api/devices/{id}/triggers (session auth).
@@ -92,15 +80,7 @@ func (h *CreateTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		apierr.Write(w, http.StatusBadRequest, "invalid_request", "condition is required")
 		return
 	}
-	if req.TargetPeripheralID == "" {
-		apierr.Write(w, http.StatusBadRequest, "invalid_request", "target_peripheral_id is required")
-		return
-	}
-	if len(req.Action) == 0 {
-		apierr.Write(w, http.StatusBadRequest, "invalid_request", "action is required")
-		return
-	}
-	if err := validateTriggerAction(req.Action); err != nil {
+	if err := validateActions(req.Actions); err != nil {
 		apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
@@ -109,19 +89,10 @@ func (h *CreateTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	actionConfig, err := buildPeripheralActionRequestConfig(req.TargetPeripheralID, req.Action)
-	if err != nil {
-		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid action")
-		return
-	}
-
 	t, err := h.Service.Create(r.Context(), deviceID, claims.UserID, trigger.TriggerCreate{
 		Name:      req.Name,
 		Condition: req.Condition,
-		Action: trigger.Action{
-			Type:   "peripheral_action",
-			Config: actionConfig,
-		},
+		Action:    trigger.Action{Type: req.Actions[0].Type, Config: req.Actions[0].Config},
 		CooldownSeconds: req.CooldownSeconds,
 	})
 	if err != nil {
@@ -187,12 +158,11 @@ func (h *GetTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type patchTriggerRequest struct {
-	Name               *string         `json:"name"`
-	Condition          json.RawMessage `json:"condition"`
-	TargetPeripheralID *string         `json:"target_peripheral_id"`
-	Action             json.RawMessage `json:"action"`
-	CooldownSeconds    *int            `json:"cooldown_s"`
-	Enabled            *bool           `json:"enabled"`
+	Name            *string         `json:"name"`
+	Condition       json.RawMessage `json:"condition"`
+	Actions         []actionRequest `json:"actions"`
+	CooldownSeconds *int            `json:"cooldown_s"`
+	Enabled         *bool           `json:"enabled"`
 }
 
 // PatchTriggerHandler handles PATCH /api/devices/{id}/triggers/{tid} (session auth).
@@ -214,12 +184,6 @@ func (h *PatchTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name must not be empty")
 		return
 	}
-	if len(req.Action) > 0 && string(req.Action) != "null" {
-		if err := validateTriggerAction(req.Action); err != nil {
-			apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
-			return
-		}
-	}
 	if req.CooldownSeconds != nil && *req.CooldownSeconds < 0 {
 		apierr.Write(w, http.StatusBadRequest, "invalid_request", "cooldown_s must be >= 0")
 		return
@@ -238,24 +202,12 @@ func (h *PatchTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Enabled:         req.Enabled,
 	}
 
-	// Only build the action patch if either the peripheral or action body is being changed.
-	actionJSON := req.Action
-	if string(actionJSON) == "null" {
-		actionJSON = nil
-	}
-	if req.TargetPeripheralID != nil || len(actionJSON) > 0 {
-		// Both fields must be present together to form a valid peripheral_action patch.
-		// If only one is present we cannot construct a valid config; return an error.
-		if req.TargetPeripheralID == nil || len(actionJSON) == 0 {
-			apierr.Write(w, http.StatusBadRequest, "invalid_request", "target_peripheral_id and action must be provided together")
+	if len(req.Actions) > 0 {
+		if err := validateActions(req.Actions); err != nil {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
-		config, err := buildPeripheralActionRequestConfig(*req.TargetPeripheralID, actionJSON)
-		if err != nil {
-			apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid action")
-			return
-		}
-		a := trigger.Action{Type: "peripheral_action", Config: config}
+		a := trigger.Action{Type: req.Actions[0].Type, Config: req.Actions[0].Config}
 		patch.Action = &a
 	}
 
@@ -298,33 +250,31 @@ func (h *DeleteTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// validateTriggerAction checks that action.action is "set" or "set_mode".
-func validateTriggerAction(raw json.RawMessage) error {
-	var a struct {
-		Action string `json:"action"`
+// validateActions enforces Phase 1 constraints: exactly one peripheral_action with
+// a non-empty peripheral_id and a valid command.
+func validateActions(actions []actionRequest) error {
+	if len(actions) == 0 {
+		return errors.New("actions must have exactly one entry")
 	}
-	if err := json.Unmarshal(raw, &a); err != nil {
-		return errors.New("action must be valid JSON")
+	if len(actions) > 1 {
+		return errors.New("actions must have exactly one entry")
 	}
-	if a.Action != "set" && a.Action != "set_mode" {
-		return errors.New(`action.action must be "set" or "set_mode"`)
+	a := actions[0]
+	if a.Type != "peripheral_action" {
+		return errors.New(`actions[0].type must be "peripheral_action"`)
+	}
+	var cfg struct {
+		PeripheralID string `json:"peripheral_id"`
+		Command      string `json:"command"`
+	}
+	if err := json.Unmarshal(a.Config, &cfg); err != nil {
+		return errors.New("actions[0].config must be valid JSON")
+	}
+	if cfg.PeripheralID == "" {
+		return errors.New("actions[0].config.peripheral_id is required")
+	}
+	if cfg.Command != "set" && cfg.Command != "set_mode" {
+		return errors.New(`actions[0].config.command must be "set" or "set_mode"`)
 	}
 	return nil
-}
-
-// buildPeripheralActionRequestConfig builds the peripheral_action config JSONB from
-// the flat API request fields (target_peripheral_id + action body).
-func buildPeripheralActionRequestConfig(peripheralID string, actionBody json.RawMessage) (json.RawMessage, error) {
-	var action struct {
-		Action string          `json:"action"`
-		Value  json.RawMessage `json:"value"`
-	}
-	if err := json.Unmarshal(actionBody, &action); err != nil {
-		return nil, err
-	}
-	return json.Marshal(map[string]any{
-		"peripheral_id": peripheralID,
-		"command":       action.Action,
-		"value":         action.Value,
-	})
 }

--- a/internal/api/trigger_handler_test.go
+++ b/internal/api/trigger_handler_test.go
@@ -16,7 +16,7 @@ import (
 
 func newTrigger() trigger.Trigger {
 	actionConfig, _ := json.Marshal(map[string]any{
-		"peripheral_id": "peri-1",
+		"peripheral_id": "00000000-0000-0000-0000-000000000001",
 		"peripheral":    "relay-14",
 		"command":       "set",
 		"value":         1.0,
@@ -40,14 +40,56 @@ func newTriggerService(t *testing.T, store *stubTriggerStore) *trigger.Service {
 	return trigger.NewService(testutil.NewTestDB(t), store, &stubOutboxStore{}, discardLogger)
 }
 
+// validActionBody is a well-formed actions array for use in request bodies.
+const validActionBody = `{"name":"Heater on cold","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set","value":1.0}}],"cooldown_s":60}`
+
+// ── validateActions ───────────────────────────────────────────────────────────
+
+func TestCreateTriggerHandler_validateActions(t *testing.T) {
+	newSvc := func() *trigger.Service {
+		return trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
+	}
+	newH := func() *api.CreateTriggerHandler {
+		return &api.CreateTriggerHandler{Service: newSvc()}
+	}
+	post := func(t *testing.T, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		newH().ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("zero actions returns 400", func(t *testing.T) {
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[]}`
+		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("more than one action returns 400", func(t *testing.T) {
+		cfg := `{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set"}`
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":` + cfg + `},{"type":"peripheral_action","config":` + cfg + `}]}`
+		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("unknown type returns 400", func(t *testing.T) {
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"unknown","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set"}}]}`
+		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("missing peripheral_id returns 400", func(t *testing.T) {
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":{"command":"set"}}]}`
+		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("invalid command returns 400", func(t *testing.T) {
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"explode"}}]}`
+		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
+	})
+}
+
 // ── CreateTriggerHandler ──────────────────────────────────────────────────────
 
 func TestCreateTriggerHandler(t *testing.T) {
-	// Use valid UUIDs so Postgres doesn't reject the query with a syntax error.
-	// The device/peripheral do not exist in the test DB, so the service returns
-	// device.ErrNotFound or ErrInvalidPeripheral as appropriate.
-	validBody := `{"name":"Heater on cold","condition":{"op":"lt"},"target_peripheral_id":"00000000-0000-0000-0000-000000000001","action":{"action":"set","value":1.0},"cooldown_s":60}`
-
 	t.Run("invalid body returns 400", func(t *testing.T) {
 		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}
@@ -62,7 +104,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}
 
-		body := `{"condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"set","value":1.0}}`
+		body := `{"condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set"}}]}`
 		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
@@ -73,40 +115,18 @@ func TestCreateTriggerHandler(t *testing.T) {
 		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}
 
-		body := `{"name":"Heater","target_peripheral_id":"peri-1","action":{"action":"set","value":1.0}}`
+		body := `{"name":"H","actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set"}}]}`
 		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
-	t.Run("missing target_peripheral_id returns 400", func(t *testing.T) {
+	t.Run("missing actions returns 400", func(t *testing.T) {
 		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}
 
-		body := `{"name":"Heater","condition":{"op":"lt"},"action":{"action":"set","value":1.0}}`
-		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("missing action returns 400", func(t *testing.T) {
-		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
-		h := &api.CreateTriggerHandler{Service: svc}
-
-		body := `{"name":"Heater","condition":{"op":"lt"},"target_peripheral_id":"peri-1"}`
-		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("invalid action.action returns 400", func(t *testing.T) {
-		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
-		h := &api.CreateTriggerHandler{Service: svc}
-
-		body := `{"name":"Heater","condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"invalid"}}`
+		body := `{"name":"H","condition":{"op":"lt"}}`
 		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
@@ -117,7 +137,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}
 
-		body := `{"name":"Heater","condition":{"op":"lt"},"target_peripheral_id":"peri-1","action":{"action":"set","value":1.0},"cooldown_s":-1}`
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set"}}],"cooldown_s":-1}`
 		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
@@ -125,13 +145,12 @@ func TestCreateTriggerHandler(t *testing.T) {
 	})
 
 	t.Run("device not found returns 404", func(t *testing.T) {
-		// Both device UUID and user UUID are valid but don't exist in the DB
-		// → validatePeripheralAction returns device.ErrNotFound.
+		// Both UUIDs valid but absent from DB → validatePeripheralAction returns device.ErrNotFound.
 		svc := newTriggerService(t, &stubTriggerStore{})
 		h := &api.CreateTriggerHandler{Service: svc}
 
 		req := withChiParam(
-			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(validBody)), "00000000-0000-0000-0000-000000000099"),
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(validActionBody)), "00000000-0000-0000-0000-000000000099"),
 			"id", "00000000-0000-0000-0000-000000000098",
 		)
 		rec := httptest.NewRecorder()
@@ -147,11 +166,11 @@ func TestCreateTriggerHandler(t *testing.T) {
 		var deviceID string
 		db.QueryRowContext(ctx, `INSERT INTO devices (user_id) VALUES ('00000000-0000-0000-0000-000000000001') RETURNING id`).Scan(&deviceID)
 
-		// peripheral_id in the request refers to a non-existent peripheral → ErrInvalidPeripheral.
 		svc := trigger.NewService(db, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}
 
-		body := `{"name":"H","condition":{"op":"lt"},"target_peripheral_id":"00000000-0000-0000-0000-000000000099","action":{"action":"set","value":1.0}}`
+		// peripheral_id doesn't exist → ErrInvalidPeripheral.
+		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000099","command":"set"}}]}`
 		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "00000000-0000-0000-0000-000000000001"), "id", deviceID)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
@@ -162,7 +181,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 // ── ListTriggersHandler ───────────────────────────────────────────────────────
 
 func TestListTriggersHandler(t *testing.T) {
-	t.Run("returns 200 with trigger list", func(t *testing.T) {
+	t.Run("returns 200 with trigger list including actions", func(t *testing.T) {
 		store := &stubTriggerStore{listed: []trigger.Trigger{newTrigger()}}
 		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
 		h := &api.ListTriggersHandler{Service: svc}
@@ -180,6 +199,17 @@ func TestListTriggersHandler(t *testing.T) {
 		}
 		if len(resp) != 1 || resp[0]["name"] != "Heater on cold" {
 			t.Errorf("unexpected response: %v", resp)
+		}
+		actions, ok := resp[0]["actions"].([]any)
+		if !ok || len(actions) != 1 {
+			t.Errorf("expected actions array with 1 entry, got %v", resp[0]["actions"])
+		}
+		// Old fields must be absent.
+		if _, found := resp[0]["target_peripheral_id"]; found {
+			t.Error("target_peripheral_id should not be in response")
+		}
+		if _, found := resp[0]["action"]; found {
+			t.Error("action should not be in response")
 		}
 	})
 
@@ -206,7 +236,7 @@ func TestListTriggersHandler(t *testing.T) {
 // ── GetTriggerHandler ─────────────────────────────────────────────────────────
 
 func TestGetTriggerHandler(t *testing.T) {
-	t.Run("returns 200 with trigger", func(t *testing.T) {
+	t.Run("returns 200 with actions array", func(t *testing.T) {
 		store := &stubTriggerStore{got: newTrigger()}
 		svc := trigger.NewService(nil, store, &stubOutboxStore{}, discardLogger)
 		h := &api.GetTriggerHandler{Service: svc}
@@ -225,6 +255,14 @@ func TestGetTriggerHandler(t *testing.T) {
 		}
 		if resp["name"] != "Heater on cold" {
 			t.Errorf("unexpected name: %v", resp["name"])
+		}
+		actions, ok := resp["actions"].([]any)
+		if !ok || len(actions) != 1 {
+			t.Errorf("expected actions array with 1 entry, got %v", resp["actions"])
+		}
+		// Old fields must be absent.
+		if _, found := resp["target_peripheral_id"]; found {
+			t.Error("target_peripheral_id should not be in response")
 		}
 	})
 
@@ -266,11 +304,11 @@ func TestPatchTriggerHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
-	t.Run("invalid action.action returns 400", func(t *testing.T) {
+	t.Run("invalid actions in patch returns 400", func(t *testing.T) {
 		svc := trigger.NewService(nil, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.PatchTriggerHandler{Service: svc}
 
-		body := `{"action":{"action":"invalid"}}`
+		body := `{"actions":[{"type":"peripheral_action","config":{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"explode"}}]}`
 		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body)), "user-1"),
 			map[string]string{"id": "dev-1", "tid": "trig-1"})
 		rec := httptest.NewRecorder()
@@ -301,6 +339,22 @@ func TestPatchTriggerHandler(t *testing.T) {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
+	})
+
+	t.Run("absent actions field leaves action unchanged", func(t *testing.T) {
+		store := &stubTriggerStore{got: newTrigger(), updated: newTrigger()}
+		svc := newTriggerService(t, store)
+		h := &api.PatchTriggerHandler{Service: svc}
+
+		body := `{"name":"renamed"}`
+		req := withChiParams(withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body)), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
 	})
 }
 


### PR DESCRIPTION
**Depends on:** #133

## Summary

- Replaces flat `target_peripheral_id` + `action` fields in trigger request and response with an `actions` array
- New `validateActions` enforces Phase 1 constraints: exactly one entry, type `peripheral_action`, non-empty `peripheral_id`, command `set` or `set_mode`
- `TriggerResponse` now has `Actions []ActionResponse`; old `TargetPeripheralID`/`Action` fields removed
- `createTriggerRequest` and `patchTriggerRequest` updated to `Actions []actionRequest`
- Removes the `validateTriggerAction` and `buildPeripheralActionRequestConfig` helpers

## Test plan

- [ ] `go test ./internal/api/...` — all tests pass
- [ ] `validateActions` error paths covered: zero actions, more than one, unknown type, missing `peripheral_id`, invalid `command`
- [ ] List/Get response assertions verify `actions` array is present and old fields are absent
- [ ] Patch with absent `actions` leaves the action unchanged

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)