### PR TITLE
Update trigger MQTT wire format to use actions array

### DIFF
--- a/internal/trigger/outbox_processor.go
+++ b/internal/trigger/outbox_processor.go
@@ -51,30 +51,20 @@ func (p *TriggerPushProcessor) Process(ctx context.Context, event outbox.Event) 
 		return nil
 	}
 
-	// Resolve the peripheral_action for the firmware wire format.
-	targetPeripheral, actionJSON, err := resolvePeripheralActionWireFormat(payload.Actions)
-	if err != nil {
-		p.logger.Error("trigger push: resolve peripheral action",
-			"device_id", payload.DeviceID, "trigger_id", payload.ID, "error", err)
-		return fmt.Errorf("resolve peripheral action: %w", err)
-	}
-
 	msg, err := json.Marshal(struct {
-		Op               string          `json:"op"`
-		ID               string          `json:"id"`
-		Enabled          bool            `json:"enabled"`
-		Condition        json.RawMessage `json:"condition"`
-		TargetPeripheral string          `json:"target_peripheral"`
-		Action           json.RawMessage `json:"action"`
-		CooldownS        int             `json:"cooldown_s"`
+		Op        string          `json:"op"`
+		ID        string          `json:"id"`
+		Enabled   bool            `json:"enabled"`
+		Condition json.RawMessage `json:"condition"`
+		Actions   []actionPayload `json:"actions"`
+		CooldownS int             `json:"cooldown_s"`
 	}{
-		Op:               "upsert",
-		ID:               payload.ID,
-		Enabled:          payload.Enabled,
-		Condition:        payload.Condition,
-		TargetPeripheral: targetPeripheral,
-		Action:           actionJSON,
-		CooldownS:        payload.CooldownS,
+		Op:        "upsert",
+		ID:        payload.ID,
+		Enabled:   payload.Enabled,
+		Condition: payload.Condition,
+		Actions:   payload.Actions,
+		CooldownS: payload.CooldownS,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal upsert message: %w", err)
@@ -86,37 +76,4 @@ func (p *TriggerPushProcessor) Process(ctx context.Context, event outbox.Event) 
 		return fmt.Errorf("mqtt publish upsert: %w", err)
 	}
 	return nil
-}
-
-// resolvePeripheralActionWireFormat extracts the target_peripheral kind-pin and
-// reconstructs the action JSONB from the first peripheral_action in actions.
-// This preserves the MQTT wire format the firmware expects.
-func resolvePeripheralActionWireFormat(actions []actionPayload) (targetPeripheral string, actionJSON json.RawMessage, err error) {
-	for _, a := range actions {
-		if a.Type != "peripheral_action" {
-			continue
-		}
-		var cfg struct {
-			Peripheral string          `json:"peripheral"`
-			Command    string          `json:"command"`
-			Value      json.RawMessage `json:"value"`
-		}
-		if err := json.Unmarshal(a.Config, &cfg); err != nil {
-			return "", nil, fmt.Errorf("unmarshal peripheral_action config: %w", err)
-		}
-		actionJSON, err = json.Marshal(map[string]json.RawMessage{
-			"action": mustMarshal(cfg.Command),
-			"value":  cfg.Value,
-		})
-		if err != nil {
-			return "", nil, fmt.Errorf("marshal action json: %w", err)
-		}
-		return cfg.Peripheral, actionJSON, nil
-	}
-	return "", nil, fmt.Errorf("no peripheral_action found in trigger payload")
-}
-
-func mustMarshal(s string) json.RawMessage {
-	b, _ := json.Marshal(s)
-	return b
 }

--- a/internal/trigger/outbox_processor_test.go
+++ b/internal/trigger/outbox_processor_test.go
@@ -48,13 +48,13 @@ func makeEvent(t *testing.T, payload any) outbox.Event {
 
 // internalPayload mirrors the internal triggerPushPayload struct for test construction.
 type internalPayload struct {
-	Op        string           `json:"op"`
-	ID        string           `json:"id"`
-	DeviceID  string           `json:"device_id"`
-	Enabled   bool             `json:"enabled,omitempty"`
-	Condition json.RawMessage  `json:"condition,omitempty"`
-	Actions   []actionPayload  `json:"actions,omitempty"`
-	CooldownS int              `json:"cooldown_s,omitempty"`
+	Op        string          `json:"op"`
+	ID        string          `json:"id"`
+	DeviceID  string          `json:"device_id"`
+	Enabled   bool            `json:"enabled,omitempty"`
+	Condition json.RawMessage `json:"condition,omitempty"`
+	Actions   []actionPayload `json:"actions,omitempty"`
+	CooldownS int             `json:"cooldown_s,omitempty"`
 }
 
 type actionPayload struct {
@@ -62,16 +62,15 @@ type actionPayload struct {
 	Config json.RawMessage `json:"config"`
 }
 
-// wirePayload mirrors the MQTT wire format the firmware expects (unchanged).
-type wirePayload struct {
-	Op               string          `json:"op"`
-	ID               string          `json:"id"`
-	DeviceID         string          `json:"device_id"`
-	Enabled          bool            `json:"enabled"`
-	Condition        json.RawMessage `json:"condition"`
-	TargetPeripheral string          `json:"target_peripheral"`
-	Action           json.RawMessage `json:"action"`
-	CooldownS        int             `json:"cooldown_s"`
+// mqttUpsertMessage mirrors the MQTT wire format published for upsert events.
+type mqttUpsertMessage struct {
+	Op        string          `json:"op"`
+	ID        string          `json:"id"`
+	DeviceID  string          `json:"device_id"`
+	Enabled   bool            `json:"enabled"`
+	Condition json.RawMessage `json:"condition"`
+	Actions   []actionPayload `json:"actions"`
+	CooldownS int             `json:"cooldown_s"`
 }
 
 func TestTriggerPushProcessor_EventType(t *testing.T) {
@@ -98,9 +97,7 @@ func TestTriggerPushProcessor_Upsert(t *testing.T) {
 		DeviceID:  "dev-1",
 		Enabled:   true,
 		Condition: json.RawMessage(`{"op":"lt","left":{"op":"value","measurement":"ds18b20-4/temperature"},"right":{"op":"literal","value":19.0}}`),
-		Actions: []actionPayload{
-			{Type: "peripheral_action", Config: actionConfig},
-		},
+		Actions:   []actionPayload{{Type: "peripheral_action", Config: actionConfig}},
 		CooldownS: 60,
 	}
 
@@ -120,37 +117,84 @@ func TestTriggerPushProcessor_Upsert(t *testing.T) {
 		t.Errorf("topic: got %q, want %q", call.topic, wantTopic)
 	}
 
-	var msg wirePayload
+	var msg mqttUpsertMessage
 	if err := json.Unmarshal(call.payload, &msg); err != nil {
 		t.Fatalf("unmarshal published payload: %v", err)
 	}
 	if msg.Op != "upsert" {
-		t.Errorf("op: got %q, want %q", msg.Op, "upsert")
+		t.Errorf("op: got %q, want upsert", msg.Op)
 	}
 	if msg.ID != "trig-1" {
-		t.Errorf("id: got %q, want %q", msg.ID, "trig-1")
-	}
-	if msg.TargetPeripheral != "relay-14" {
-		t.Errorf("target_peripheral: got %q, want %q", msg.TargetPeripheral, "relay-14")
+		t.Errorf("id: got %q, want trig-1", msg.ID)
 	}
 	if msg.CooldownS != 60 {
 		t.Errorf("cooldown_s: got %d, want 60", msg.CooldownS)
 	}
-	// device_id must NOT appear in the MQTT message
+	// device_id must NOT appear in the MQTT message.
 	if msg.DeviceID != "" {
 		t.Errorf("device_id should not be in MQTT payload, got %q", msg.DeviceID)
 	}
+	if len(msg.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(msg.Actions))
+	}
+	if msg.Actions[0].Type != "peripheral_action" {
+		t.Errorf("action type: got %q, want peripheral_action", msg.Actions[0].Type)
+	}
 
-	// Verify action shape in wire format: {"action":"set","value":1.0}
-	var action struct {
-		Action string          `json:"action"`
-		Value  json.RawMessage `json:"value"`
+	// Config must carry the peripheral kind-pin and command.
+	var cfg struct {
+		Peripheral string `json:"peripheral"`
+		Command    string `json:"command"`
 	}
-	if err := json.Unmarshal(msg.Action, &action); err != nil {
-		t.Fatalf("unmarshal action: %v", err)
+	if err := json.Unmarshal(msg.Actions[0].Config, &cfg); err != nil {
+		t.Fatalf("unmarshal action config: %v", err)
 	}
-	if action.Action != "set" {
-		t.Errorf("action.action: got %q, want set", action.Action)
+	if cfg.Peripheral != "relay-14" {
+		t.Errorf("peripheral: got %q, want relay-14", cfg.Peripheral)
+	}
+	if cfg.Command != "set" {
+		t.Errorf("command: got %q, want set", cfg.Command)
+	}
+
+	// Old flat fields must be absent.
+	var raw map[string]json.RawMessage
+	json.Unmarshal(call.payload, &raw)
+	if _, found := raw["target_peripheral"]; found {
+		t.Error("target_peripheral should not appear in MQTT message")
+	}
+	if _, found := raw["action"]; found {
+		t.Error("action should not appear in MQTT message")
+	}
+}
+
+func TestTriggerPushProcessor_Upsert_MultipleActions(t *testing.T) {
+	pub := &stubPublisher{}
+	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
+
+	cfg1, _ := json.Marshal(map[string]any{"peripheral": "relay-14", "command": "set", "value": 1.0})
+	cfg2, _ := json.Marshal(map[string]any{"peripheral": "relay-15", "command": "set", "value": 0.0})
+
+	payload := internalPayload{
+		Op:        "upsert",
+		ID:        "trig-2",
+		DeviceID:  "dev-1",
+		Enabled:   true,
+		Condition: json.RawMessage(`{}`),
+		Actions: []actionPayload{
+			{Type: "peripheral_action", Config: cfg1},
+			{Type: "peripheral_action", Config: cfg2},
+		},
+		CooldownS: 30,
+	}
+
+	if err := proc.Process(context.Background(), makeEvent(t, payload)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var msg mqttUpsertMessage
+	json.Unmarshal(pub.calls[0].payload, &msg)
+	if len(msg.Actions) != 2 {
+		t.Fatalf("expected 2 actions, got %d", len(msg.Actions))
 	}
 }
 
@@ -172,7 +216,6 @@ func TestTriggerPushProcessor_Delete(t *testing.T) {
 		t.Fatalf("expected 2 publish calls (delete + clear), got %d", len(pub.calls))
 	}
 
-	// First call: delete payload
 	deleteCall := pub.calls[0]
 	wantTopic := "fishhub/dev-1/triggers/trig-2"
 	if deleteCall.topic != wantTopic {
@@ -189,7 +232,6 @@ func TestTriggerPushProcessor_Delete(t *testing.T) {
 		t.Errorf("unexpected delete message: op=%q id=%q", msg.Op, msg.ID)
 	}
 
-	// Second call: empty payload to clear retained message
 	clearCall := pub.calls[1]
 	if clearCall.topic != wantTopic {
 		t.Errorf("clear topic: got %q, want %q", clearCall.topic, wantTopic)
@@ -203,12 +245,7 @@ func TestTriggerPushProcessor_PublishError(t *testing.T) {
 	pub := &stubPublisher{err: errors.New("broker down")}
 	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
 
-	actionConfig, _ := json.Marshal(map[string]any{
-		"peripheral":    "relay-14",
-		"peripheral_id": "p-uuid",
-		"command":       "set",
-		"value":         1.0,
-	})
+	actionConfig, _ := json.Marshal(map[string]any{"peripheral": "relay-14", "command": "set"})
 	payload := internalPayload{
 		Op:        "upsert",
 		ID:        "t1",
@@ -239,23 +276,5 @@ func TestTriggerPushProcessor_InvalidPayload(t *testing.T) {
 
 	if err := proc.Process(context.Background(), outbox.Event{Payload: []byte("not json")}); err == nil {
 		t.Fatal("expected error for invalid payload, got nil")
-	}
-}
-
-func TestTriggerPushProcessor_NoPeripheralAction_ReturnsError(t *testing.T) {
-	pub := &stubPublisher{}
-	proc := trigger.NewTriggerPushProcessor(pub, discardLogger)
-
-	// Upsert payload with no actions → processor should return an error.
-	payload := internalPayload{
-		Op:        "upsert",
-		ID:        "t1",
-		DeviceID:  "d1",
-		Condition: json.RawMessage(`{}`),
-		Actions:   []actionPayload{},
-	}
-
-	if err := proc.Process(context.Background(), makeEvent(t, payload)); err == nil {
-		t.Fatal("expected error for missing peripheral_action, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

- Replace flat `target_peripheral` + `action` fields in the upsert MQTT message with an `actions` array matching the data model introduced in #133
- Remove `resolvePeripheralActionWireFormat` and `mustMarshal` helpers from the outbox processor
- Add test coverage for multi-action payloads and verify old flat fields are absent from published messages

## New wire format

```json
{
  "op": "upsert",
  "id": "...",
  "enabled": true,
  "condition": { ... },
  "actions": [
    {
      "type": "peripheral_action",
      "config": { "peripheral": "relay-14", "command": "set", "value": 1.0 }
    }
  ],
  "cooldown_s": 60
}
```

Closes #126

## Test plan

- [x] `TestTriggerPushProcessor_Upsert` — retained publish, correct topic, actions array in payload, device_id absent, old flat fields absent
- [x] `TestTriggerPushProcessor_Upsert_MultipleActions` — two actions pass through correctly
- [x] `TestTriggerPushProcessor_Delete` — delete + clear retained messages unchanged
- [x] `TestTriggerPushProcessor_PublishError` / `TestTriggerPushProcessor_DeletePublishError` — errors propagated
- [x] `TestTriggerPushProcessor_InvalidPayload` — bad JSON returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)