### PR TITLE
Update docs for TE&A Phase 1 actions array shape

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -482,8 +482,16 @@ Cookie: session=<session-jwt>
     "left":  { "op": "value",   "measurement": "ds18b20-4/temperature" },
     "right": { "op": "literal", "value": 19.0 }
   },
-  "target_peripheral_id": "<peripheral-uuid>",
-  "action": { "action": "set", "value": 1.0 },
+  "actions": [
+    {
+      "type": "peripheral_action",
+      "config": {
+        "peripheral_id": "<peripheral-uuid>",
+        "command": "set",
+        "value": 1.0
+      }
+    }
+  ],
   "cooldown_s": 60
 }
 ```
@@ -492,29 +500,43 @@ Cookie: session=<session-jwt>
 |---|---|---|
 | `name` | yes | Human-readable label |
 | `condition` | yes | JSON expression tree (see firmware `docs/peripherals.md` for the full operator reference) |
-| `target_peripheral_id` | yes | UUID of the peripheral to actuate — must be an `actuator` peripheral owned by the same device |
-| `action` | yes | `{"action":"set","value":<number>}` or `{"action":"set_mode","mode":"automatic"\|"manual"}` |
+| `actions` | yes | Array of action objects (Phase 1: exactly one entry, type `peripheral_action`) |
+| `actions[].type` | yes | Must be `"peripheral_action"` |
+| `actions[].config.peripheral_id` | yes | UUID of the peripheral to actuate — must be an `actuator` peripheral owned by the same device |
+| `actions[].config.command` | yes | `"set"` or `"set_mode"` |
+| `actions[].config.value` | yes | Value to pass to the peripheral (number for `set`; `"automatic"` or `"manual"` for `set_mode`) |
 | `cooldown_s` | no | Minimum seconds between firings (default: `60`, must be `>= 0`) |
 
 **Validation:**
-- `action.action` must be `"set"` or `"set_mode"`.
-- `target_peripheral_id` must refer to a peripheral with `category = "actuator"` belonging to the same device.
+- `actions` must contain exactly one entry.
+- `actions[0].type` must be `"peripheral_action"`.
+- `actions[0].config.peripheral_id` must be non-empty and refer to a peripheral with `category = "actuator"` belonging to the same device.
+- `actions[0].config.command` must be `"set"` or `"set_mode"`.
 
 **Response `201`**
 ```json
 {
-  "id":                   "<uuid>",
-  "name":                 "Heater on cold",
-  "enabled":              true,
-  "condition":            { ... },
-  "target_peripheral_id": "<peripheral-uuid>",
-  "action":               { "action": "set", "value": 1.0 },
-  "cooldown_s":           60,
-  "created_at":           "2024-04-13T12:00:00Z"
+  "id":        "<uuid>",
+  "name":      "Heater on cold",
+  "enabled":   true,
+  "condition": { ... },
+  "actions": [
+    {
+      "id":     "<action-uuid>",
+      "type":   "peripheral_action",
+      "config": {
+        "peripheral_id": "<peripheral-uuid>",
+        "command": "set",
+        "value": 1.0
+      }
+    }
+  ],
+  "cooldown_s":  60,
+  "created_at":  "2024-04-13T12:00:00Z"
 }
 ```
 
-**Response `400`** — missing required field, invalid `action.action`, `cooldown_s < 0`, or invalid `target_peripheral_id` (not an actuator or not owned by the device)
+**Response `400`** — missing required field, invalid `actions` (wrong count, unknown type, missing `peripheral_id`, invalid `command`), `cooldown_s < 0`, or `peripheral_id` not an actuator owned by the device
 
 **Response `401`** — not authenticated
 
@@ -538,14 +560,23 @@ Cookie: session=<session-jwt>
 ```json
 [
   {
-    "id":                   "<uuid>",
-    "name":                 "Heater on cold",
-    "enabled":              true,
-    "condition":            { ... },
-    "target_peripheral_id": "<peripheral-uuid>",
-    "action":               { "action": "set", "value": 1.0 },
-    "cooldown_s":           60,
-    "created_at":           "2024-04-13T12:00:00Z"
+    "id":        "<uuid>",
+    "name":      "Heater on cold",
+    "enabled":   true,
+    "condition": { ... },
+    "actions": [
+      {
+        "id":     "<action-uuid>",
+        "type":   "peripheral_action",
+        "config": {
+          "peripheral_id": "<peripheral-uuid>",
+          "command": "set",
+          "value": 1.0
+        }
+      }
+    ],
+    "cooldown_s":  60,
+    "created_at":  "2024-04-13T12:00:00Z"
   }
 ]
 ```
@@ -594,14 +625,23 @@ Cookie: session=<session-jwt>
   "name":       "Heater on cold (updated)",
   "enabled":    false,
   "condition":  { ... },
-  "action":     { "action": "set", "value": 1.0 },
+  "actions": [
+    {
+      "type": "peripheral_action",
+      "config": {
+        "peripheral_id": "<peripheral-uuid>",
+        "command": "set",
+        "value": 1.0
+      }
+    }
+  ],
   "cooldown_s": 120
 }
 ```
 
 **Validation (same as create, applied only to provided fields):**
 - `name` must not be an empty string if provided.
-- `action.action` must be `"set"` or `"set_mode"` if `action` is provided.
+- `actions`, if provided, must pass the same validation as create (exactly one entry, valid type, non-empty `peripheral_id`, valid `command`).
 - `cooldown_s` must be `>= 0` if provided.
 
 On success, publishes an updated `upsert` MQTT message to `fishhub/{device_id}/triggers/{trigger_id}` via the outbox.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,31 +9,49 @@ fishhub-server/
 ├── db/
 │   └── migrations/          # SQL migration files (golang-migrate format)
 └── internal/
-    ├── sensors/             # domain: device provisioning, readings ingestion + query, commands
-    │   ├── handler.go               ReadingsHandler, ReadingsQueryHandler,
-    │   │                            DevicesHandler, DeleteDeviceHandler, PatchDeviceHandler,
+    ├── api/                 # HTTP handlers (all session-auth endpoints live here)
+    │   ├── handler.go               DevicesHandler, ReadingsQueryHandler,
+    │   │                            DeleteDeviceHandler, PatchDeviceHandler,
     │   │                            ProvisionHandler, ActivateHandler, ActivationStatusHandler,
-    │   │                            CommandHandler
-    │   ├── service.go               DeviceService, ReadingsService, ProvisioningService,
-    │   │                            ActivationService, HiveMQProvisionProcessor
-    │   ├── store.go                 DeviceStore, ProvisioningStore interfaces
-    │   │                            + error sentinels (ErrCodeNotFound, ErrCodeAlreadyUsed,
-    │   │                            ErrDeviceNotFound, ErrInvalidCommand, ErrInfluxWrite)
-    │   ├── store_postgres.go        DeviceStore Postgres impl
-    │   ├── store_provisioning_postgres.go  ProvisioningStore Postgres impl
-    │   ├── influx.go                InfluxClient (ReadingWriter + ReadingQuerier), influxDBClient
-    │   ├── senml.go                 SenML RFC 8428 parser
-    │   └── model.go                 DeviceInfo, context helpers
+    │   │                            CreatePeripheralHandler, ListPeripheralsHandler,
+    │   │                            SetPeripheralScheduleHandler, CommandHandler, ...
+    │   └── trigger_handler.go       CreateTriggerHandler, ListTriggersHandler,
+    │                                GetTriggerHandler, PatchTriggerHandler, DeleteTriggerHandler
+    ├── device/              # domain: device lifecycle
+    │   ├── model.go                 Device struct, ErrNotFound
+    │   ├── service.go               DeviceService (List, FindByIDAndUserID, Delete, Patch)
+    │   └── store.go                 DeviceStore interface + Postgres impl
+    ├── provisioning/        # domain: device pairing codes + activation
+    │   ├── service.go               ProvisioningService, ActivationService
+    │   ├── store.go                 ProvisioningStore interface + Postgres impl
+    │   └── outbox_processor.go      HiveMQProvisionProcessor (EventProcessor for hivemq.provision)
+    ├── peripheral/          # domain: peripherals, schedules, commands
+    │   ├── model.go                 Peripheral struct, ErrNotFound
+    │   ├── service.go               PeripheralService (Create, List, SetSchedule, SendCommand)
+    │   └── store.go                 PeripheralStore interface + Postgres impl
+    ├── measurement/         # domain: sensor readings (InfluxDB)
+    │   ├── model.go                 Reading, Measurement structs
+    │   ├── service.go               MeasurementService (QueryReadings)
+    │   ├── store_influx.go          InfluxDB reader/writer
+    │   └── mqtt_handler.go          MQTT readings ingestion handler
+    ├── trigger/             # domain: trigger CRUD + MQTT push
+    │   ├── model.go                 Trigger, Action, TriggerCreate, TriggerPatch, TriggerUpdate
+    │   ├── service.go               Service (Create, List, Get, Update, Delete)
+    │   │                            validatePeripheralAction — checks peripheral_id is an actuator
+    │   ├── store.go                 Store interface + Postgres impl
+    │   │                            hydrateActions — batch-loads actions via action_triggers join
+    │   ├── outbox_processor.go      TriggerPushProcessor — publishes upsert/delete to MQTT
+    │   └── errors.go                ErrNotFound, ErrInvalidPeripheral
+    ├── senml/               # SenML RFC 8428 parser
+    ├── apierr/              # apierr.Write — writes consistent JSON error responses
     ├── auth/                # domain: OIDC verification, JWT sessions, refresh token rotation
     │   ├── handler.go               VerifyHandler, RefreshHandler, LogoutHandler
     │   ├── service.go               AuthService interface, oidcService implementation
-    │   ├── store.go                 UserStore + RefreshTokenStore interfaces
-    │   ├── store_postgres.go        Postgres implementations
-    │   └── model.go                 User, RefreshToken, error sentinels
+    │   ├── store.go                 UserStore + RefreshTokenStore interfaces + Postgres impls
+    │   └── model.go                 User, RefreshToken, Claims, error sentinels
     ├── account/             # domain: account profile (created on first login via event)
-    │   ├── handler.go               MeHandler
-    │   ├── store.go                 AccountStore interface
-    │   ├── store_postgres.go        Postgres implementation
+    │   ├── handler.go               MeHandler, UpdateMeHandler
+    │   ├── store.go                 AccountStore interface + Postgres impl
     │   ├── model.go                 Account struct
     │   └── events.go                AccountEventHandler (implements auth.UserEventHandler)
     ├── devicejwt/           # device JWT issuance — wraps jwtutil with device-specific claims
@@ -46,8 +64,8 @@ fishhub-server/
     │   │                            NewNoOp() for unconfigured environments
     │   └── jwks.go                  JWKSHandler — serves GET /.well-known/jwks.json
     │                                aggregates public keys from one or more Signers
-    ├── mqtt/                # MQTT command publishing
-    │   └── publisher.go             Publisher interface (Publish)
+    ├── mqtt/                # MQTT publishing
+    │   └── publisher.go             Publisher interface (Publish, PublishRetained)
     │                                pahoPublisher — TLS connection to HiveMQ broker (QoS 1)
     │                                NewNoOpPublisher() when HIVEMQ_HOST not set
     ├── hivemq/              # HiveMQ Cloud REST API client
@@ -67,18 +85,25 @@ fishhub-server/
 
 ```
 main.go
- ├── platform     — DB connection, migrations, seed, middleware
- ├── jwtutil      — low-level JWT signing + JWKS handler
- ├── devicejwt    — device JWT issuance (wraps jwtutil)
- ├── sensors      — device provisioning, readings ingestion + query, commands
- │    └── uses outbox.Store (for activation), hivemq.Client (for delete), mqtt.Publisher (for commands)
- ├── auth         — OIDC verification, JWT + refresh token issuance
- ├── account      — account profiles, MeHandler
+ ├── platform       — DB connection, migrations, seed, middleware
+ ├── jwtutil        — low-level JWT signing + JWKS handler
+ ├── devicejwt      — device JWT issuance (wraps jwtutil)
+ ├── api            — all HTTP handlers; imports device, peripheral, measurement, trigger, provisioning
+ ├── device         — device lifecycle
+ ├── provisioning   — device pairing + activation
+ │    └── outbox_processor: HiveMQProvisionProcessor (EventProcessor)
+ ├── peripheral     — peripheral CRUD + commands
+ ├── measurement    — InfluxDB readings ingestion + query
+ ├── trigger        — trigger CRUD + MQTT push
+ │    └── outbox_processor: TriggerPushProcessor (EventProcessor)
+ ├── senml          — SenML parser (used by measurement MQTT handler)
+ ├── auth           — OIDC verification, JWT + refresh token issuance
+ ├── account        — account profiles
  │    └── implements auth.UserEventHandler (called after OIDC verify)
- ├── hivemq       — HiveMQ Cloud REST API client
- ├── mqtt         — MQTT broker publisher
- └── outbox       — outbox runner + Postgres store
-      └── runs sensors.HiveMQProvisionProcessor as EventProcessor
+ ├── hivemq         — HiveMQ Cloud REST API client
+ ├── mqtt           — MQTT broker publisher
+ └── outbox         — outbox runner + Postgres store
+      └── runs HiveMQProvisionProcessor and TriggerPushProcessor as EventProcessors
 ```
 
 ## Design principles
@@ -97,20 +122,12 @@ main.go
 
 ## Request lifecycle
 
-### POST /readings (device JWT auth)
+### MQTT readings ingestion (device publishes to broker)
 ```
-DeviceAuthenticator middleware
-  ├── parse "Bearer <token>" from Authorization header
-  ├── validate RS256 JWT signature with devicejwt.Signer.PublicKey()
-  ├── extract sub (device_id) and user_id claims
-  ├── 401 if missing/invalid
-  └── store DeviceInfo{DeviceID, UserID} in context
-
-ReadingsHandler.Create
-  ├── DeviceFromContext(ctx)
-  ├── ParseSenML(body) → Reading{Measurements, BaseTime}
-  ├── 400 on malformed payload
-  └── InfluxClient.WriteReading(ctx, Reading) → InfluxDB 3 Core
+measurement.MQTTHandler
+  ├── receives SenML payload on fishhub/<device_id>/readings
+  ├── senml.Parse(payload) → Reading{Measurements, BaseTime}
+  └── MeasurementService.WriteReading(ctx, Reading) → InfluxDB 3 Core
 ```
 
 ### POST /api/devices/provision → device pairing (session JWT)
@@ -224,6 +241,54 @@ PatchDeviceHandler
         ├── UPDATE devices SET name=? WHERE id=? AND user_id=?
         └── 404 (ErrDeviceNotFound) if no row matched
   └── 200 {"id":"...","name":"...","created_at":"..."}
+```
+
+### POST /api/devices/{id}/triggers → create trigger (session JWT)
+```
+SessionAuthenticator middleware
+  └── store Claims{UserID} in context
+
+api.CreateTriggerHandler
+  ├── decode body {name, condition, actions, cooldown_s}
+  ├── validateActions — exactly one entry, type peripheral_action,
+  │   non-empty peripheral_id, command "set"|"set_mode"
+  └── trigger.Service.Create(ctx, deviceID, userID, TriggerCreate)
+        ├── validatePeripheralAction — peripheral must be category=actuator, owned by device
+        │   builds peripheral kind-pin string for the MQTT config payload
+        ├── (in tx) Store.Create — inserts actions row, triggers row, action_triggers row
+        └── outbox.Store.Insert(tx, "trigger.push", payload{op:upsert, ...})
+  └── 201 {id, name, enabled, condition, actions:[{id, type, config}], cooldown_s, created_at}
+```
+
+### PATCH /api/devices/{id}/triggers/{tid} → update trigger (session JWT)
+```
+api.PatchTriggerHandler
+  ├── decode partial body; validate provided fields
+  └── trigger.Service.Update(ctx, deviceID, userID, triggerID, TriggerPatch)
+        ├── merge patch onto current trigger values
+        ├── if actions provided: validatePeripheralAction
+        ├── (in tx) Store.Update — updates triggers row + existing actions row config
+        └── outbox.Store.Insert(tx, "trigger.push", payload{op:upsert, ...})
+  └── 200 trigger object
+```
+
+### DELETE /api/devices/{id}/triggers/{tid} → delete trigger (session JWT)
+```
+api.DeleteTriggerHandler
+  └── trigger.Service.Delete(ctx, deviceID, userID, triggerID)
+        ├── (in tx) Store.Delete — sets deleted_at on triggers row
+        └── outbox.Store.Insert(tx, "trigger.push", payload{op:delete, id:...})
+  └── 204
+```
+
+### Trigger MQTT push (outbox runner)
+```
+outbox.Runner (background goroutine)
+  └── for each "trigger.push" event:
+        trigger.TriggerPushProcessor.Process(ctx, event)
+          ├── op=upsert → PublishRetained(fishhub/<device_id>/triggers/<trigger_id>,
+          │               {op,id,enabled,condition,actions:[{type,config}],cooldown_s})
+          └── op=delete → PublishRetained({op,id}) then PublishRetained("") to clear retained
 ```
 
 ### POST /auth/verify → session issuance

--- a/docs/database.md
+++ b/docs/database.md
@@ -95,21 +95,49 @@ Stores pending side-effects that must be processed asynchronously. Currently use
 ### `triggers`
 ```
 triggers
-├── id                   UUID  PK  default gen_random_uuid()
-├── device_id            UUID  FK → devices.id  NOT NULL
-├── name                 TEXT  NOT NULL
-├── enabled              BOOL  NOT NULL  default true
-├── condition            JSONB NOT NULL
-├── target_peripheral_id UUID  FK → peripherals.id  NOT NULL
-├── action               JSONB NOT NULL
-├── cooldown_s           INT   NOT NULL  default 60
-├── deleted_at           TIMESTAMPTZ  (nullable)
-└── created_at           TIMESTAMPTZ  NOT NULL  default now()
+├── id         UUID  PK  default gen_random_uuid()
+├── device_id  UUID  FK → devices.id  NOT NULL
+├── name       TEXT  NOT NULL
+├── enabled    BOOL  NOT NULL  default true
+├── condition  JSONB NOT NULL
+├── cooldown_s INT   NOT NULL  default 60
+├── deleted_at TIMESTAMPTZ  (nullable)
+└── created_at TIMESTAMPTZ  NOT NULL  default now()
 
 INDEX triggers_device_id_idx ON (device_id) WHERE deleted_at IS NULL
 ```
 
-Each trigger belongs to one device and targets one peripheral. `condition` is an opaque JSONB expression tree — the server stores and forwards it without interpreting it; evaluation happens on the firmware. `action` is a JSONB object with shape `{"action":"set","value":<number>}` or `{"action":"set_mode","mode":"automatic"|"manual"}`. Soft-deleted triggers (`deleted_at IS NOT NULL`) are excluded from all list/get queries.
+Each trigger belongs to one device. `condition` is an opaque JSONB expression tree — the server stores and forwards it without interpreting it; evaluation happens on the firmware. Soft-deleted triggers (`deleted_at IS NOT NULL`) are excluded from all list/get queries.
+
+### `actions`
+```
+actions
+├── id         UUID  PK  default gen_random_uuid()
+├── type       TEXT  NOT NULL
+├── config     JSONB NOT NULL
+└── created_at TIMESTAMPTZ  NOT NULL  default now()
+```
+
+Stores the what-to-do for a trigger. `type` is always `"peripheral_action"` in Phase 1. `config` is a JSONB object with shape:
+```json
+{
+  "peripheral_id": "<peripheral-uuid>",
+  "command": "set" | "set_mode",
+  "value": <number> | "automatic" | "manual"
+}
+```
+
+### `action_triggers`
+```
+action_triggers
+├── trigger_id  UUID  FK → triggers.id  ON DELETE CASCADE  NOT NULL
+└── action_id   UUID  FK → actions.id   ON DELETE CASCADE  NOT NULL
+
+PRIMARY KEY (trigger_id, action_id)
+INDEX action_triggers_trigger_id_idx ON (trigger_id)
+```
+
+Join table linking triggers to their actions. Phase 1 always has exactly one action per trigger, but the schema is open for future multi-action support.
 
 ## Relationships
 
@@ -120,7 +148,7 @@ users ──< devices
       └──  accounts  (1:1 via user_id UNIQUE)
 devices ──< peripherals
         └──< triggers
-triggers ──> peripherals  (target_peripheral_id)
+triggers ──< action_triggers ──> actions
 outbox_events  (standalone — no FK; device/trigger referenced via payload)
 ```
 
@@ -156,6 +184,9 @@ They run automatically on server startup via `platform.Migrate()`. Current migra
 | 017 | Add `category` and `control_mode` columns to `peripherals` |
 | 018 | Add `timezone` column to `accounts` |
 | 019 | Create `triggers` table |
+| 020 | Create `actions` table |
+| 021 | Create `action_triggers` join table |
+| 022 | Migrate existing trigger rows to `actions` + `action_triggers`; drop `target_peripheral_id` and `action` columns from `triggers` |
 
 To add a migration, create the next numbered `.up.sql` / `.down.sql` pair in `db/migrations/`. Migrations run on the next server startup.
 


### PR DESCRIPTION
## Summary

Documentation-only update to reflect the TE&A Phase 1 changes landed in #133, #137, and #139.

- **api.md**: rewrite all trigger endpoint request/response shapes — `actions` array replaces the old `target_peripheral_id` + `action` flat fields; document `validateActions` constraints (exactly one entry, type `peripheral_action`, non-empty `peripheral_id`, command `set`/`set_mode`)
- **database.md**: update `triggers` table schema (no more `target_peripheral_id`/`action` columns); add `actions` and `action_triggers` table documentation; update the relationships diagram; add migrations 020–022 to the table
- **architecture.md**: rewrite the package layout tree (the `sensors/` monolith was split into `api/`, `device/`, `provisioning/`, `peripheral/`, `measurement/`, `trigger/`, `senml/`); update the dependency graph; add trigger create/patch/delete and MQTT push request lifecycle sections; fix the readings ingestion lifecycle (MQTT, not HTTP)

Closes #138