### PR TITLE
Rename peripheral command field from action to command

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -443,17 +443,17 @@ Cookie: session=<session-jwt>
 **Request body**
 ```json
 {
-  "action": "set"
+  "command": "set"
 }
 ```
 
 | Field | Values | Description |
 |---|---|---|
-| `action` | `"set"` \| `"schedule"` | Command action to send to the peripheral |
+| `command` | `"set"` \| `"schedule"` | Command to send to the peripheral |
 
 **Response `204`** — command published
 
-**Response `400`** — invalid action (must be `"set"` or `"schedule"`)
+**Response `400`** — invalid command (must be `"set"` or `"schedule"`)
 
 **Response `401`** — not authenticated
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -504,7 +504,7 @@ func newCommandHandler(t *testing.T, pStore *stubPeripheralStore, pub *stubPubli
 }
 
 func TestCommandHandler(t *testing.T) {
-	const body = `{"action":"set","id":"cmd-1","value":1}`
+	const body = `{"command":"set","id":"cmd-1","value":1}`
 
 	relay := peripheral.Peripheral{ID: "p-1", DeviceID: "dev-1", Kind: "relay", Pin: 5, Category: "actuator"}
 
@@ -538,7 +538,7 @@ func TestCommandHandler(t *testing.T) {
 	t.Run("400 on invalid action", func(t *testing.T) {
 		h := newCommandHandler(t, &stubPeripheralStore{created: relay}, &stubPublisher{})
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, makeReq(`{"action":"invalid"}`, "user-1"))
+		h.ServeHTTP(rec, makeReq(`{"command":"invalid"}`, "user-1"))
 		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 

--- a/internal/device/service.go
+++ b/internal/device/service.go
@@ -77,10 +77,10 @@ func (s *Service) SendCommand(ctx context.Context, deviceID, userID, peripheralN
 	}
 
 	var req struct {
-		Action string `json:"action"`
+		Command string `json:"command"`
 	}
 	if err := json.NewDecoder(io.NopCloser(bytes.NewReader(body))).Decode(&req); err != nil ||
-		(req.Action != "set" && req.Action != "schedule") {
+		(req.Command != "set" && req.Command != "schedule") {
 		return ErrInvalidCommand
 	}
 

--- a/internal/mqtt/publisher_test.go
+++ b/internal/mqtt/publisher_test.go
@@ -11,7 +11,7 @@ func TestNoOpPublisher(t *testing.T) {
 	ctx := context.Background()
 	p := mqtt.NewNoOpPublisher()
 
-	if err := p.Publish(ctx, "fishhub/dev-1/commands/light", []byte(`{"action":"set","state":true}`)); err != nil {
+	if err := p.Publish(ctx, "fishhub/dev-1/commands/light", []byte(`{"command":"set","state":true}`)); err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}
 }

--- a/internal/peripheral/service.go
+++ b/internal/peripheral/service.go
@@ -144,7 +144,7 @@ func (s *Service) SetSchedule(ctx context.Context, deviceID, userID, peripheralI
 
 	msg, err := json.Marshal(map[string]any{
 		"id":      uuid.NewString(),
-		"action":  "schedule",
+		"command": "schedule",
 		"windows": schedule,
 	})
 	if err != nil {
@@ -178,9 +178,9 @@ func (s *Service) SetControlMode(ctx context.Context, deviceID, userID, peripher
 	}
 
 	msg, err := json.Marshal(map[string]any{
-		"id":     uuid.NewString(),
-		"action": "set_mode",
-		"mode":   mode,
+		"id":      uuid.NewString(),
+		"command": "set_mode",
+		"mode":    mode,
 	})
 	if err != nil {
 		return Peripheral{}, fmt.Errorf("set control mode: marshal mqtt payload: %w", err)
@@ -212,10 +212,10 @@ func (s *Service) SendCommand(ctx context.Context, deviceID, userID, peripheralI
 	}
 
 	var req struct {
-		Action string `json:"action"`
+		Command string `json:"command"`
 	}
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil ||
-		(req.Action != "set" && req.Action != "schedule") {
+		(req.Command != "set" && req.Command != "schedule") {
 		return ErrInvalidCommand
 	}
 


### PR DESCRIPTION
## Summary

- Renames `"action"` → `"command"` in MQTT payloads published by `peripheral/service.go` (schedule and set_mode commands) and validated in `device/service.go` and `peripheral/service.go`
- Updates all tests and API docs accordingly
- Clarifies the naming convention: `action` = a trigger action (e.g. `peripheral_action`); `command` = the verb sent to a peripheral (set, schedule, set_mode)

## Test plan

- [x] All server tests pass (`go test ./...`)
- [ ] Verify direct command endpoint still triggers relay correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)