### PR TITLE
Update error messages to say command instead of action

### DIFF
--- a/internal/device/errors.go
+++ b/internal/device/errors.go
@@ -4,5 +4,5 @@ import "errors"
 
 var (
 	ErrNotFound       = errors.New("device not found")
-	ErrInvalidCommand = errors.New("action must be 'set' or 'schedule'")
+	ErrInvalidCommand = errors.New("command must be 'set' or 'schedule'")
 )

--- a/internal/peripheral/errors.go
+++ b/internal/peripheral/errors.go
@@ -7,5 +7,5 @@ var (
 	ErrNotFound       = errors.New("peripheral not found")
 	ErrAlreadyExists  = errors.New("peripheral already exists")
 	ErrPinInUse       = errors.New("peripheral pin already in use")
-	ErrInvalidCommand = errors.New("action must be 'set' or 'schedule'")
+	ErrInvalidCommand = errors.New("command must be 'set' or 'schedule'")
 )


### PR DESCRIPTION
## Summary

- Fixes leftover `"action must be 'set' or 'schedule'"` error strings in `device/errors.go` and `peripheral/errors.go` → `"command must be 'set' or 'schedule'"`

Follow-up to #141.

## Test plan

- [x] All server tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)