### PR TITLE
Support multiple actions per trigger

### DIFF
--- a/internal/api/trigger_handler.go
+++ b/internal/api/trigger_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -89,10 +90,14 @@ func (h *CreateTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	actions := make([]trigger.Action, len(req.Actions))
+	for i, a := range req.Actions {
+		actions[i] = trigger.Action{Type: a.Type, Config: a.Config}
+	}
 	t, err := h.Service.Create(r.Context(), deviceID, claims.UserID, trigger.TriggerCreate{
-		Name:      req.Name,
-		Condition: req.Condition,
-		Action:    trigger.Action{Type: req.Actions[0].Type, Config: req.Actions[0].Config},
+		Name:            req.Name,
+		Condition:       req.Condition,
+		Actions:         actions,
 		CooldownSeconds: req.CooldownSeconds,
 	})
 	if err != nil {
@@ -207,8 +212,11 @@ func (h *PatchTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			apierr.Write(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
-		a := trigger.Action{Type: req.Actions[0].Type, Config: req.Actions[0].Config}
-		patch.Action = &a
+		actions := make([]trigger.Action, len(req.Actions))
+		for i, a := range req.Actions {
+			actions[i] = trigger.Action{Type: a.Type, Config: a.Config}
+		}
+		patch.Actions = actions
 	}
 
 	t, err := h.Service.Update(r.Context(), deviceID, claims.UserID, triggerID, patch)
@@ -250,31 +258,28 @@ func (h *DeleteTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// validateActions enforces Phase 1 constraints: exactly one peripheral_action with
-// a non-empty peripheral_id and a valid command.
+// validateActions requires at least one action and validates each peripheral_action entry.
 func validateActions(actions []actionRequest) error {
 	if len(actions) == 0 {
-		return errors.New("actions must have exactly one entry")
+		return errors.New("actions must have at least one entry")
 	}
-	if len(actions) > 1 {
-		return errors.New("actions must have exactly one entry")
-	}
-	a := actions[0]
-	if a.Type != "peripheral_action" {
-		return errors.New(`actions[0].type must be "peripheral_action"`)
-	}
-	var cfg struct {
-		PeripheralID string `json:"peripheral_id"`
-		Command      string `json:"command"`
-	}
-	if err := json.Unmarshal(a.Config, &cfg); err != nil {
-		return errors.New("actions[0].config must be valid JSON")
-	}
-	if cfg.PeripheralID == "" {
-		return errors.New("actions[0].config.peripheral_id is required")
-	}
-	if cfg.Command != "set" && cfg.Command != "set_mode" {
-		return errors.New(`actions[0].config.command must be "set" or "set_mode"`)
+	for i, a := range actions {
+		if a.Type != "peripheral_action" {
+			return fmt.Errorf("actions[%d].type must be \"peripheral_action\"", i)
+		}
+		var cfg struct {
+			PeripheralID string `json:"peripheral_id"`
+			Command      string `json:"command"`
+		}
+		if err := json.Unmarshal(a.Config, &cfg); err != nil {
+			return fmt.Errorf("actions[%d].config must be valid JSON", i)
+		}
+		if cfg.PeripheralID == "" {
+			return fmt.Errorf("actions[%d].config.peripheral_id is required", i)
+		}
+		if cfg.Command != "set" && cfg.Command != "set_mode" {
+			return fmt.Errorf("actions[%d].config.command must be \"set\" or \"set_mode\"", i)
+		}
 	}
 	return nil
 }

--- a/internal/api/trigger_handler_test.go
+++ b/internal/api/trigger_handler_test.go
@@ -65,10 +65,19 @@ func TestCreateTriggerHandler_validateActions(t *testing.T) {
 		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
 	})
 
-	t.Run("more than one action returns 400", func(t *testing.T) {
+	t.Run("two valid actions passes validation", func(t *testing.T) {
+		// Uses a real DB so the service can BeginTx; the peripheral won't exist so it
+		// returns 4xx/5xx, but NOT 400 for having two entries.
+		svc := newTriggerService(t, &stubTriggerStore{})
+		h := &api.CreateTriggerHandler{Service: svc}
 		cfg := `{"peripheral_id":"00000000-0000-0000-0000-000000000001","command":"set"}`
 		body := `{"name":"H","condition":{"op":"lt"},"actions":[{"type":"peripheral_action","config":` + cfg + `},{"type":"peripheral_action","config":` + cfg + `}]}`
-		assertErrorCode(t, post(t, body), http.StatusBadRequest, "invalid_request")
+		req := withChiParam(withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"), "id", "dev-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusBadRequest {
+			t.Errorf("expected non-400 for two valid actions, got %d: %s", rec.Code, rec.Body.String())
+		}
 	})
 
 	t.Run("unknown type returns 400", func(t *testing.T) {

--- a/internal/trigger/model.go
+++ b/internal/trigger/model.go
@@ -25,7 +25,7 @@ type Trigger struct {
 type TriggerCreate struct {
 	Name            string
 	Condition       json.RawMessage
-	Action          Action
+	Actions         []Action
 	CooldownSeconds int
 }
 
@@ -33,16 +33,17 @@ type TriggerCreate struct {
 type TriggerUpdate struct {
 	Name            string
 	Condition       json.RawMessage
-	Action          Action
+	Actions         []Action
 	CooldownSeconds int
 	Enabled         bool
 }
 
 // TriggerPatch holds the partial fields from a PATCH request (nil means no change).
+// Actions nil = no change; empty slice is disallowed.
 type TriggerPatch struct {
 	Name            *string
 	Condition       json.RawMessage
-	Action          *Action
+	Actions         []Action
 	CooldownSeconds *int
 	Enabled         *bool
 }

--- a/internal/trigger/service.go
+++ b/internal/trigger/service.go
@@ -63,16 +63,17 @@ func (s *Service) Create(ctx context.Context, deviceID, userID string, p Trigger
 	}
 	defer tx.Rollback()
 
-	kindPin, err := s.validatePeripheralAction(ctx, tx, deviceID, userID, p.Action)
-	if err != nil {
-		return Trigger{}, err
+	for i, a := range p.Actions {
+		kindPin, err := s.validatePeripheralAction(ctx, tx, deviceID, userID, a)
+		if err != nil {
+			return Trigger{}, err
+		}
+		cfg, err := buildPeripheralActionConfig(a.Config, kindPin)
+		if err != nil {
+			return Trigger{}, fmt.Errorf("create trigger: build action config: %w", err)
+		}
+		p.Actions[i].Config = cfg
 	}
-
-	actionConfig, err := buildPeripheralActionConfig(p.Action.Config, kindPin)
-	if err != nil {
-		return Trigger{}, fmt.Errorf("create trigger: build action config: %w", err)
-	}
-	p.Action.Config = actionConfig
 
 	t, err := s.store.Create(ctx, tx, deviceID, userID, p)
 	if err != nil {
@@ -170,15 +171,10 @@ func (s *Service) Update(ctx context.Context, deviceID, userID, triggerID string
 // If the action is being changed, validatePeripheralAction is called to resolve the kind-pin
 // and inject it into the config before storing.
 func (s *Service) applyPatch(ctx context.Context, tx *sql.Tx, deviceID, userID string, current Trigger, patch TriggerPatch) (TriggerUpdate, error) {
-	var currentAction Action
-	if len(current.Actions) > 0 {
-		currentAction = current.Actions[0]
-	}
-
 	u := TriggerUpdate{
 		Name:            current.Name,
 		Condition:       current.Condition,
-		Action:          currentAction,
+		Actions:         current.Actions,
 		CooldownSeconds: current.CooldownSeconds,
 		Enabled:         current.Enabled,
 	}
@@ -194,16 +190,20 @@ func (s *Service) applyPatch(ctx context.Context, tx *sql.Tx, deviceID, userID s
 	if patch.Enabled != nil {
 		u.Enabled = *patch.Enabled
 	}
-	if patch.Action != nil {
-		kindPin, err := s.validatePeripheralAction(ctx, tx, deviceID, userID, *patch.Action)
-		if err != nil {
-			return TriggerUpdate{}, err
+	if patch.Actions != nil {
+		resolved := make([]Action, len(patch.Actions))
+		for i, a := range patch.Actions {
+			kindPin, err := s.validatePeripheralAction(ctx, tx, deviceID, userID, a)
+			if err != nil {
+				return TriggerUpdate{}, err
+			}
+			cfg, err := buildPeripheralActionConfig(a.Config, kindPin)
+			if err != nil {
+				return TriggerUpdate{}, fmt.Errorf("apply patch: build action config: %w", err)
+			}
+			resolved[i] = Action{Type: a.Type, Config: cfg}
 		}
-		config, err := buildPeripheralActionConfig(patch.Action.Config, kindPin)
-		if err != nil {
-			return TriggerUpdate{}, fmt.Errorf("apply patch: build action config: %w", err)
-		}
-		u.Action = Action{Type: patch.Action.Type, Config: config}
+		u.Actions = resolved
 	}
 	return u, nil
 }

--- a/internal/trigger/service_test.go
+++ b/internal/trigger/service_test.go
@@ -58,8 +58,8 @@ func TestApplyPatch_noPatch_preservesAll(t *testing.T) {
 	if !bytes.Equal(u.Condition, cur.Condition) {
 		t.Error("condition changed")
 	}
-	if u.Action.ID != "a1" {
-		t.Error("action changed")
+	if len(u.Actions) != 1 || u.Actions[0].ID != "a1" {
+		t.Error("actions changed")
 	}
 }
 
@@ -122,14 +122,14 @@ func TestApplyPatch_nilCondition_unchanged(t *testing.T) {
 	}
 }
 
-func TestApplyPatch_nilAction_unchanged(t *testing.T) {
+func TestApplyPatch_nilActions_unchanged(t *testing.T) {
 	svc := NewService(nil, &stubStore{}, &stubOutbox{}, svcDiscardLogger)
-	u, err := svc.applyPatch(context.Background(), nil, "dev-1", "user-1", baseTrigger(), TriggerPatch{Action: nil})
+	u, err := svc.applyPatch(context.Background(), nil, "dev-1", "user-1", baseTrigger(), TriggerPatch{Actions: nil})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if u.Action.ID != "a1" {
-		t.Error("action was changed by nil patch")
+	if len(u.Actions) != 1 || u.Actions[0].ID != "a1" {
+		t.Error("actions were changed by nil patch")
 	}
 }
 
@@ -291,10 +291,10 @@ func TestService_Create_outboxFailure_rollsBack(t *testing.T) {
 	_, err := svc.Create(context.Background(), "dev-1", "user-1", TriggerCreate{
 		Name:      "test",
 		Condition: json.RawMessage(`{}`),
-		Action: Action{
+		Actions: []Action{{
 			Type:   "peripheral_action",
 			Config: json.RawMessage(`{"peripheral_id":"00000000-0000-0000-0000-000000000099"}`),
-		},
+		}},
 	})
 	// validatePeripheralAction will fail since peripheral doesn't exist — that's fine,
 	// the test just checks that errors propagate and no panic occurs.

--- a/internal/trigger/store.go
+++ b/internal/trigger/store.go
@@ -33,15 +33,6 @@ func NewStore(db *sql.DB) Store {
 }
 
 func (s *postgresStore) Create(ctx context.Context, tx *sql.Tx, deviceID, userID string, p TriggerCreate) (Trigger, error) {
-	var actionID string
-	if err := tx.QueryRowContext(ctx, `
-		INSERT INTO actions (type, config)
-		VALUES ($1, $2)
-		RETURNING id
-	`, p.Action.Type, p.Action.Config).Scan(&actionID); err != nil {
-		return Trigger{}, fmt.Errorf("create trigger: insert action: %w", err)
-	}
-
 	var t Trigger
 	if err := tx.QueryRowContext(ctx, `
 		INSERT INTO triggers (device_id, name, condition, cooldown_s)
@@ -54,13 +45,22 @@ func (s *postgresStore) Create(ctx context.Context, tx *sql.Tx, deviceID, userID
 		return Trigger{}, fmt.Errorf("create trigger: insert trigger: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO action_triggers (trigger_id, action_id) VALUES ($1, $2)
-	`, t.ID, actionID); err != nil {
-		return Trigger{}, fmt.Errorf("create trigger: insert action_triggers: %w", err)
+	for _, a := range p.Actions {
+		var actionID string
+		if err := tx.QueryRowContext(ctx, `
+			INSERT INTO actions (type, config)
+			VALUES ($1, $2)
+			RETURNING id
+		`, a.Type, a.Config).Scan(&actionID); err != nil {
+			return Trigger{}, fmt.Errorf("create trigger: insert action: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO action_triggers (trigger_id, action_id) VALUES ($1, $2)
+		`, t.ID, actionID); err != nil {
+			return Trigger{}, fmt.Errorf("create trigger: insert action_triggers: %w", err)
+		}
+		t.Actions = append(t.Actions, Action{ID: actionID, Type: a.Type, Config: a.Config})
 	}
-
-	t.Actions = []Action{{ID: actionID, Type: p.Action.Type, Config: p.Action.Config}}
 	return t, nil
 }
 
@@ -169,25 +169,31 @@ func (s *postgresStore) Update(ctx context.Context, tx *sql.Tx, deviceID, userID
 		return Trigger{}, fmt.Errorf("update trigger: %w", err)
 	}
 
-	var actionID string
-	if err := tx.QueryRowContext(ctx, `
-		SELECT at.action_id
-		FROM action_triggers at
-		JOIN actions a ON a.id = at.action_id
-		WHERE at.trigger_id = $1
-		  AND a.type = 'peripheral_action'
-		LIMIT 1
-	`, t.ID).Scan(&actionID); err != nil {
-		return Trigger{}, fmt.Errorf("update trigger: find action: %w", err)
-	}
-
+	// Replace the full action set: delete existing join rows and orphaned actions,
+	// then insert the new set.
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE actions SET config = $1 WHERE id = $2
-	`, u.Action.Config, actionID); err != nil {
-		return Trigger{}, fmt.Errorf("update trigger: update action: %w", err)
+		DELETE FROM actions a
+		USING action_triggers at
+		WHERE at.action_id = a.id AND at.trigger_id = $1
+	`, t.ID); err != nil {
+		return Trigger{}, fmt.Errorf("update trigger: delete old actions: %w", err)
 	}
 
-	t.Actions = []Action{{ID: actionID, Type: u.Action.Type, Config: u.Action.Config}}
+	t.Actions = t.Actions[:0]
+	for _, a := range u.Actions {
+		var actionID string
+		if err := tx.QueryRowContext(ctx, `
+			INSERT INTO actions (type, config) VALUES ($1, $2) RETURNING id
+		`, a.Type, a.Config).Scan(&actionID); err != nil {
+			return Trigger{}, fmt.Errorf("update trigger: insert action: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO action_triggers (trigger_id, action_id) VALUES ($1, $2)
+		`, t.ID, actionID); err != nil {
+			return Trigger{}, fmt.Errorf("update trigger: insert action_triggers: %w", err)
+		}
+		t.Actions = append(t.Actions, Action{ID: actionID, Type: a.Type, Config: a.Config})
+	}
 	return t, nil
 }
 

--- a/internal/trigger/store_integration_test.go
+++ b/internal/trigger/store_integration_test.go
@@ -64,9 +64,8 @@ func TestTriggerStore_integration(t *testing.T) {
 		tr, err := store.Create(ctx, tx, deviceID, userID, trigger.TriggerCreate{
 			Name:      "Heater on cold",
 			Condition: condition,
-			Action: trigger.Action{
-				Type:   "peripheral_action",
-				Config: actionConfig,
+			Actions: []trigger.Action{
+				{Type: "peripheral_action", Config: actionConfig},
 			},
 			CooldownSeconds: 60,
 		})
@@ -127,7 +126,7 @@ func TestTriggerStore_integration(t *testing.T) {
 		_, err = store.Create(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, trigger.TriggerCreate{
 			Name:      "bad",
 			Condition: condition,
-			Action:    trigger.Action{Type: "peripheral_action", Config: actionConfig},
+			Actions:   []trigger.Action{{Type: "peripheral_action", Config: actionConfig}},
 		})
 		// Store itself just inserts — it does not validate the peripheral. device.ErrNotFound
 		// comes from the service layer via validatePeripheralAction. The store will return a
@@ -203,17 +202,13 @@ func TestTriggerStore_integration(t *testing.T) {
 		}
 	})
 
-	t.Run("update trigger updates actions row, no new rows", func(t *testing.T) {
+	t.Run("update trigger replaces action set atomically", func(t *testing.T) {
 		newActionConfig, _ := json.Marshal(map[string]any{
 			"peripheral_id": peripheralID,
 			"peripheral":    "relay-14",
 			"command":       "set",
 			"value":         0.0,
 		})
-
-		// Capture the current action ID before updating.
-		currentTr, _ := store.Get(ctx, deviceID, userID, triggerID)
-		currentActionID := currentTr.Actions[0].ID
 
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
@@ -222,7 +217,7 @@ func TestTriggerStore_integration(t *testing.T) {
 		updated, err := store.Update(ctx, tx, deviceID, userID, triggerID, trigger.TriggerUpdate{
 			Name:            "Heater on cold updated",
 			Condition:       condition,
-			Action:          trigger.Action{Type: "peripheral_action", Config: newActionConfig},
+			Actions:         []trigger.Action{{Type: "peripheral_action", Config: newActionConfig}},
 			CooldownSeconds: 120,
 			Enabled:         false,
 		})
@@ -243,16 +238,10 @@ func TestTriggerStore_integration(t *testing.T) {
 		if updated.CooldownSeconds != 120 {
 			t.Errorf("cooldown_s: got %d, want 120", updated.CooldownSeconds)
 		}
-
-		// Same action ID — no new rows created.
 		if len(updated.Actions) != 1 {
 			t.Fatalf("expected 1 action, got %d", len(updated.Actions))
 		}
-		if updated.Actions[0].ID != currentActionID {
-			t.Errorf("expected same action ID %q, got %q", currentActionID, updated.Actions[0].ID)
-		}
 
-		// Verify action count is still 1 for this trigger.
 		var actionCount int
 		db.QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM action_triggers WHERE trigger_id = $1`,
@@ -260,6 +249,56 @@ func TestTriggerStore_integration(t *testing.T) {
 		).Scan(&actionCount)
 		if actionCount != 1 {
 			t.Errorf("expected 1 action_triggers row after update, got %d", actionCount)
+		}
+	})
+
+	t.Run("create trigger with two actions inserts both rows", func(t *testing.T) {
+		action2Config, _ := json.Marshal(map[string]any{
+			"peripheral_id": peripheralID,
+			"command":       "set",
+			"value":         0.0,
+		})
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		tr, err := store.Create(ctx, tx, deviceID, userID, trigger.TriggerCreate{
+			Name:      "Multi-action trigger",
+			Condition: condition,
+			Actions: []trigger.Action{
+				{Type: "peripheral_action", Config: actionConfig},
+				{Type: "peripheral_action", Config: action2Config},
+			},
+			CooldownSeconds: 30,
+		})
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("create multi-action: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+
+		if len(tr.Actions) != 2 {
+			t.Fatalf("expected 2 actions, got %d", len(tr.Actions))
+		}
+
+		var joinCount int
+		db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM action_triggers WHERE trigger_id = $1`, tr.ID,
+		).Scan(&joinCount)
+		if joinCount != 2 {
+			t.Errorf("expected 2 action_triggers rows, got %d", joinCount)
+		}
+
+		// Get hydrates both actions.
+		fetched, err := store.Get(ctx, deviceID, userID, tr.ID)
+		if err != nil {
+			t.Fatalf("get multi-action: %v", err)
+		}
+		if len(fetched.Actions) != 2 {
+			t.Errorf("get: expected 2 actions, got %d", len(fetched.Actions))
 		}
 	})
 
@@ -273,7 +312,7 @@ func TestTriggerStore_integration(t *testing.T) {
 		_, err = store.Update(ctx, tx, deviceID, userID, "00000000-0000-0000-0000-000000000000", trigger.TriggerUpdate{
 			Name:      "x",
 			Condition: condition,
-			Action:    trigger.Action{Type: "peripheral_action", Config: actionConfig},
+			Actions:   []trigger.Action{{Type: "peripheral_action", Config: actionConfig}},
 		})
 		if !errors.Is(err, trigger.ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got %v", err)
@@ -341,7 +380,7 @@ func TestTriggerStore_integration(t *testing.T) {
 		_, err = store.Create(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, trigger.TriggerCreate{
 			Name:      "orphan",
 			Condition: condition,
-			Action:    trigger.Action{Type: "peripheral_action", Config: actionConfig},
+			Actions:   []trigger.Action{{Type: "peripheral_action", Config: actionConfig}},
 		})
 		if err == nil {
 			t.Error("expected FK violation error, got nil")


### PR DESCRIPTION
## Summary

- `TriggerCreate`, `TriggerUpdate`, `TriggerPatch`: replace single `Action` field with `[]Action` slice
- `store.Create`: inserts N actions + N `action_triggers` rows in one transaction
- `store.Update`: delete-and-reinsert to atomically replace the full action set
- `service.Create` / `applyPatch`: validates and resolves `kind-pin` for each action in the slice
- `validateActions`: drops the "exactly one" constraint — now requires at least one, validates each entry individually with indexed error messages (e.g. `actions[1].config.peripheral_id is required`)
- All tests updated; integration test adds a two-action create scenario

Closes #136

## Test plan

- [x] `go test ./internal/trigger/... ./internal/api/...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)