### PR TITLE
trigger_events table, MQTT ingestion, and history endpoint

### DIFF
--- a/db/migrations/023_create_trigger_events.down.sql
+++ b/db/migrations/023_create_trigger_events.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS trigger_events_fired_at_idx;
+DROP INDEX IF EXISTS trigger_events_trigger_id_idx;
+DROP TABLE IF EXISTS trigger_events;

--- a/db/migrations/023_create_trigger_events.up.sql
+++ b/db/migrations/023_create_trigger_events.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE trigger_events (
+    id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    trigger_event_id  TEXT        NOT NULL UNIQUE,
+    trigger_id        UUID        NOT NULL REFERENCES triggers(id),
+    fired_at          TIMESTAMPTZ NOT NULL,
+    received_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    readings          JSONB       NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX trigger_events_trigger_id_idx ON trigger_events (trigger_id);
+CREATE INDEX trigger_events_fired_at_idx   ON trigger_events (fired_at DESC);

--- a/internal/api/trigger_events_handler.go
+++ b/internal/api/trigger_events_handler.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+const (
+	defaultEventLimit = 50
+	maxEventLimit     = 200
+)
+
+type ReadingResponse struct {
+	Peripheral string  `json:"peripheral"`
+	Value      float64 `json:"value"`
+}
+
+type TriggerEventResponse struct {
+	ID             string            `json:"id"`
+	TriggerEventID string            `json:"trigger_event_id"`
+	TriggerID      string            `json:"trigger_id"`
+	FiredAt        string            `json:"fired_at"`
+	ReceivedAt     string            `json:"received_at"`
+	Readings       []ReadingResponse `json:"readings"`
+}
+
+func triggerEventResponse(e trigger_events.TriggerEvent) TriggerEventResponse {
+	readings := make([]ReadingResponse, len(e.Readings))
+	for i, r := range e.Readings {
+		readings[i] = ReadingResponse{Peripheral: r.Peripheral, Value: r.Value}
+	}
+	return TriggerEventResponse{
+		ID:             e.ID,
+		TriggerEventID: e.TriggerEventID,
+		TriggerID:      e.TriggerID,
+		FiredAt:        e.FiredAt.UTC().Format(time.RFC3339),
+		ReceivedAt:     e.ReceivedAt.UTC().Format(time.RFC3339),
+		Readings:       readings,
+	}
+}
+
+// ListTriggerEventsHandler handles GET /api/devices/{id}/triggers/{tid}/events (session auth).
+type ListTriggerEventsHandler struct {
+	TriggerStore trigger.Store
+	EventStore   trigger_events.Store
+}
+
+func (h *ListTriggerEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+	triggerID := chi.URLParam(r, "tid")
+
+	limit := defaultEventLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "limit must be a positive integer")
+			return
+		}
+		if v > maxEventLimit {
+			v = maxEventLimit
+		}
+		limit = v
+	}
+
+	// Verify the trigger exists and belongs to this device + user.
+	if _, err := h.TriggerStore.Get(r.Context(), deviceID, claims.UserID, triggerID); err != nil {
+		if errors.Is(err, trigger.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "trigger_not_found", "trigger not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	events, err := h.EventStore.ListByTrigger(r.Context(), triggerID, limit)
+	if err != nil {
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	resp := make([]TriggerEventResponse, len(events))
+	for i, e := range events {
+		resp[i] = triggerEventResponse(e)
+	}
+	render.JSON(w, r, resp)
+}

--- a/internal/api/trigger_events_handler_test.go
+++ b/internal/api/trigger_events_handler_test.go
@@ -1,0 +1,169 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/api"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+)
+
+// ── stubTriggerEventStore ─────────────────────────────────────────────────────
+
+type stubTriggerEventStore struct {
+	events  []trigger_events.TriggerEvent
+	listErr error
+}
+
+func (s *stubTriggerEventStore) Ingest(_ context.Context, _ trigger_events.TriggerEvent) error {
+	return nil
+}
+func (s *stubTriggerEventStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+	return s.events, s.listErr
+}
+func (s *stubTriggerEventStore) TriggerBelongsToDevice(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newListTriggerEventsHandler(triggerStore trigger.Store, eventStore trigger_events.Store) *api.ListTriggerEventsHandler {
+	return &api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: eventStore}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestListTriggerEventsHandler(t *testing.T) {
+	firedAt := time.Date(2025, 5, 5, 14, 0, 0, 0, time.UTC)
+	receivedAt := firedAt.Add(time.Second)
+
+	sampleEvents := []trigger_events.TriggerEvent{
+		{
+			ID:             "evt-uuid-1",
+			TriggerEventID: "abc123",
+			TriggerID:      "trig-1",
+			FiredAt:        firedAt,
+			ReceivedAt:     receivedAt,
+			Readings: []trigger_events.Reading{
+				{Peripheral: "ds18b20-4/temperature", Value: 18.5},
+			},
+		},
+	}
+
+	t.Run("returns 200 with events list", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: sampleEvents}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp []map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(resp))
+		}
+		if resp[0]["trigger_event_id"] != "abc123" {
+			t.Errorf("trigger_event_id: got %v", resp[0]["trigger_event_id"])
+		}
+		readings, ok := resp[0]["readings"].([]any)
+		if !ok || len(readings) != 1 {
+			t.Errorf("expected 1 reading, got %v", resp[0]["readings"])
+		}
+	})
+
+	t.Run("trigger not found returns 404", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{getErr: trigger.ErrNotFound}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "ghost"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
+	})
+
+	t.Run("invalid limit returns 400", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=abc", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("zero limit returns 400", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=0", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("limit above max is clamped to 200", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=999", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("returns empty array when no events", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp []any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if len(resp) != 0 {
+			t.Errorf("expected empty list, got %v", resp)
+		}
+	})
+}

--- a/internal/trigger_events/model.go
+++ b/internal/trigger_events/model.go
@@ -1,0 +1,17 @@
+package trigger_events
+
+import "time"
+
+type Reading struct {
+	Peripheral string  `json:"peripheral"`
+	Value      float64 `json:"value"`
+}
+
+type TriggerEvent struct {
+	ID             string
+	TriggerEventID string
+	TriggerID      string
+	FiredAt        time.Time
+	ReceivedAt     time.Time
+	Readings       []Reading
+}

--- a/internal/trigger_events/mqtt_handler.go
+++ b/internal/trigger_events/mqtt_handler.go
@@ -1,0 +1,84 @@
+package trigger_events
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type MQTTHandler struct {
+	store  Store
+	logger *slog.Logger
+}
+
+func NewMQTTHandler(store Store, logger *slog.Logger) *MQTTHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MQTTHandler{store: store, logger: logger}
+}
+
+type mqttPayload struct {
+	TriggerEventID string    `json:"trigger_event_id"`
+	TriggerID      string    `json:"trigger_id"`
+	DeviceID       string    `json:"device_id"`
+	FiredAt        string    `json:"fired_at"`
+	Readings       []Reading `json:"readings"`
+}
+
+// Handle is the mqtt.MessageHandler callback. Topic shape: fishhub/{device_id}/trigger_events.
+func (h *MQTTHandler) Handle(ctx context.Context, topic string, payload []byte) {
+	deviceID, ok := deviceIDFromTopic(topic)
+	if !ok {
+		h.logger.Warn("mqtt trigger_events: unexpected topic shape", "topic", topic)
+		return
+	}
+
+	var p mqttPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		h.logger.Warn("mqtt trigger_events: invalid payload", "device_id", deviceID, "error", err)
+		return
+	}
+	if p.TriggerEventID == "" || p.TriggerID == "" || p.FiredAt == "" {
+		h.logger.Warn("mqtt trigger_events: missing required fields", "device_id", deviceID)
+		return
+	}
+
+	ok, err := h.store.TriggerBelongsToDevice(ctx, p.TriggerID, deviceID)
+	if err != nil {
+		h.logger.Error("mqtt trigger_events: ownership check", "device_id", deviceID, "trigger_id", p.TriggerID, "error", err)
+		return
+	}
+	if !ok {
+		h.logger.Warn("mqtt trigger_events: trigger does not belong to device", "device_id", deviceID, "trigger_id", p.TriggerID)
+		return
+	}
+
+	firedAt, err := time.Parse(time.RFC3339, p.FiredAt)
+	if err != nil {
+		h.logger.Warn("mqtt trigger_events: invalid fired_at", "device_id", deviceID, "fired_at", p.FiredAt, "error", err)
+		return
+	}
+
+	if err := h.store.Ingest(ctx, TriggerEvent{
+		TriggerEventID: p.TriggerEventID,
+		TriggerID:      p.TriggerID,
+		FiredAt:        firedAt,
+		Readings:       p.Readings,
+	}); err != nil {
+		h.logger.Error("mqtt trigger_events: ingest", "device_id", deviceID, "trigger_id", p.TriggerID, "error", err)
+	}
+}
+
+func deviceIDFromTopic(topic string) (string, bool) {
+	parts := strings.Split(topic, "/")
+	if len(parts) != 3 || parts[0] != "fishhub" || parts[2] != "trigger_events" {
+		return "", false
+	}
+	if parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
+}

--- a/internal/trigger_events/mqtt_handler_test.go
+++ b/internal/trigger_events/mqtt_handler_test.go
@@ -1,0 +1,133 @@
+package trigger_events_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+)
+
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+// ── stubStore ─────────────────────────────────────────────────────────────────
+
+type stubStore struct {
+	ingestCalled bool
+	ingestEvent  trigger_events.TriggerEvent
+	ingestErr    error
+
+	belongsResult bool
+	belongsErr    error
+}
+
+func (s *stubStore) Ingest(_ context.Context, e trigger_events.TriggerEvent) error {
+	s.ingestCalled = true
+	s.ingestEvent = e
+	return s.ingestErr
+}
+
+func (s *stubStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+	return nil, nil
+}
+
+func (s *stubStore) TriggerBelongsToDevice(_ context.Context, _, _ string) (bool, error) {
+	return s.belongsResult, s.belongsErr
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+const validPayload = `{
+	"trigger_event_id": "abc123",
+	"trigger_id":       "11111111-1111-1111-1111-111111111111",
+	"device_id":        "22222222-2222-2222-2222-222222222222",
+	"fired_at":         "2025-05-05T14:00:00Z",
+	"readings": [{"peripheral": "ds18b20-4/temperature", "value": 18.5}]
+}`
+
+func newHandler(store trigger_events.Store) *trigger_events.MQTTHandler {
+	return trigger_events.NewMQTTHandler(store, discardLogger)
+}
+
+func TestMQTTHandler_Handle(t *testing.T) {
+	t.Run("valid message ingests event", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/22222222-2222-2222-2222-222222222222/trigger_events", []byte(validPayload))
+
+		if !store.ingestCalled {
+			t.Fatal("expected Ingest to be called")
+		}
+		if store.ingestEvent.TriggerEventID != "abc123" {
+			t.Errorf("trigger_event_id: got %q", store.ingestEvent.TriggerEventID)
+		}
+		if len(store.ingestEvent.Readings) != 1 {
+			t.Errorf("readings: expected 1, got %d", len(store.ingestEvent.Readings))
+		}
+	})
+
+	t.Run("trigger not belonging to device drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: false}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/device-x/trigger_events", []byte(validPayload))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called")
+		}
+	})
+
+	t.Run("malformed topic drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		for _, topic := range []string{
+			"fishhub/trigger_events",
+			"fishhub/dev/trigger_events/extra",
+			"other/dev/trigger_events",
+			"fishhub//trigger_events",
+		} {
+			store.ingestCalled = false
+			h.Handle(context.Background(), topic, []byte(validPayload))
+			if store.ingestCalled {
+				t.Errorf("topic %q: expected Ingest not to be called", topic)
+			}
+		}
+	})
+
+	t.Run("malformed JSON drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/dev/trigger_events", []byte("not json"))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called on bad payload")
+		}
+	})
+
+	t.Run("missing required fields drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/dev/trigger_events", []byte(`{"trigger_id":"x"}`))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called on missing fields")
+		}
+	})
+
+	t.Run("invalid fired_at drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		payload := `{"trigger_event_id":"x","trigger_id":"t1","device_id":"d1","fired_at":"not-a-date","readings":[]}`
+		h.Handle(context.Background(), "fishhub/dev/trigger_events", []byte(payload))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called on invalid fired_at")
+		}
+	})
+}

--- a/internal/trigger_events/store.go
+++ b/internal/trigger_events/store.go
@@ -1,0 +1,87 @@
+package trigger_events
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type Store interface {
+	Ingest(ctx context.Context, e TriggerEvent) error
+	ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error)
+	TriggerBelongsToDevice(ctx context.Context, triggerID, deviceID string) (bool, error)
+}
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) Store {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) Ingest(ctx context.Context, e TriggerEvent) error {
+	readings, err := json.Marshal(e.Readings)
+	if err != nil {
+		return fmt.Errorf("ingest trigger event: marshal readings: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO trigger_events (trigger_event_id, trigger_id, fired_at, readings)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (trigger_event_id) DO NOTHING
+	`, e.TriggerEventID, e.TriggerID, e.FiredAt, readings)
+	if err != nil {
+		return fmt.Errorf("ingest trigger event: %w", err)
+	}
+	return nil
+}
+
+func (s *postgresStore) ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
+		FROM trigger_events
+		WHERE trigger_id = $1
+		ORDER BY fired_at DESC
+		LIMIT $2
+	`, triggerID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list trigger events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []TriggerEvent
+	for rows.Next() {
+		var e TriggerEvent
+		var rawReadings []byte
+		if err := rows.Scan(&e.ID, &e.TriggerEventID, &e.TriggerID, &e.FiredAt, &e.ReceivedAt, &rawReadings); err != nil {
+			return nil, fmt.Errorf("list trigger events: scan: %w", err)
+		}
+		if err := json.Unmarshal(rawReadings, &e.Readings); err != nil {
+			return nil, fmt.Errorf("list trigger events: unmarshal readings: %w", err)
+		}
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if events == nil {
+		return []TriggerEvent{}, nil
+	}
+	return events, nil
+}
+
+func (s *postgresStore) TriggerBelongsToDevice(ctx context.Context, triggerID, deviceID string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM triggers
+			WHERE id = $1 AND device_id = $2 AND deleted_at IS NULL
+		)
+	`, triggerID, deviceID).Scan(&exists)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("trigger belongs to device: %w", err)
+	}
+	return exists, nil
+}

--- a/internal/trigger_events/store_integration_test.go
+++ b/internal/trigger_events/store_integration_test.go
@@ -1,0 +1,144 @@
+package trigger_events_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/platform"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+)
+
+func TestTriggerEventsStore_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := trigger_events.NewStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	var deviceID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+	).Scan(&deviceID); err != nil {
+		t.Fatalf("insert device: %v", err)
+	}
+
+	var triggerID string
+	if err := db.QueryRowContext(ctx, `
+		INSERT INTO triggers (device_id, name, condition, cooldown_s)
+		VALUES ($1, 'test trigger', '{}', 60) RETURNING id`, deviceID,
+	).Scan(&triggerID); err != nil {
+		t.Fatalf("insert trigger: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	t.Run("ingest stores event", func(t *testing.T) {
+		err := store.Ingest(ctx, trigger_events.TriggerEvent{
+			TriggerEventID: "event-id-1",
+			TriggerID:      triggerID,
+			FiredAt:        now,
+			Readings: []trigger_events.Reading{
+				{Peripheral: "ds18b20-4/temperature", Value: 18.5},
+			},
+		})
+		if err != nil {
+			t.Fatalf("ingest: %v", err)
+		}
+
+		var count int
+		db.QueryRowContext(ctx, `SELECT COUNT(*) FROM trigger_events WHERE trigger_event_id = 'event-id-1'`).Scan(&count)
+		if count != 1 {
+			t.Errorf("expected 1 row, got %d", count)
+		}
+	})
+
+	t.Run("ingest is idempotent — duplicate trigger_event_id is a no-op", func(t *testing.T) {
+		err := store.Ingest(ctx, trigger_events.TriggerEvent{
+			TriggerEventID: "event-id-1",
+			TriggerID:      triggerID,
+			FiredAt:        now,
+			Readings:       []trigger_events.Reading{},
+		})
+		if err != nil {
+			t.Fatalf("second ingest: %v", err)
+		}
+
+		var count int
+		db.QueryRowContext(ctx, `SELECT COUNT(*) FROM trigger_events WHERE trigger_event_id = 'event-id-1'`).Scan(&count)
+		if count != 1 {
+			t.Errorf("expected exactly 1 row after duplicate ingest, got %d", count)
+		}
+	})
+
+	t.Run("ListByTrigger returns events in fired_at DESC order", func(t *testing.T) {
+		earlier := now.Add(-5 * time.Minute)
+		if err := store.Ingest(ctx, trigger_events.TriggerEvent{
+			TriggerEventID: "event-id-2",
+			TriggerID:      triggerID,
+			FiredAt:        earlier,
+			Readings:       []trigger_events.Reading{},
+		}); err != nil {
+			t.Fatalf("ingest second event: %v", err)
+		}
+
+		events, err := store.ListByTrigger(ctx, triggerID, 10)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(events) < 2 {
+			t.Fatalf("expected at least 2 events, got %d", len(events))
+		}
+		if !events[0].FiredAt.After(events[1].FiredAt) {
+			t.Errorf("expected events ordered fired_at DESC: first=%v second=%v",
+				events[0].FiredAt, events[1].FiredAt)
+		}
+	})
+
+	t.Run("ListByTrigger respects limit", func(t *testing.T) {
+		events, err := store.ListByTrigger(ctx, triggerID, 1)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(events) != 1 {
+			t.Errorf("expected 1 event with limit=1, got %d", len(events))
+		}
+	})
+
+	t.Run("ListByTrigger returns readings correctly", func(t *testing.T) {
+		events, err := store.ListByTrigger(ctx, triggerID, 10)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		// event-id-1 is the most recent (fired_at = now)
+		if len(events[0].Readings) != 1 {
+			t.Fatalf("expected 1 reading on most recent event, got %d", len(events[0].Readings))
+		}
+		if events[0].Readings[0].Peripheral != "ds18b20-4/temperature" {
+			t.Errorf("peripheral: got %q", events[0].Readings[0].Peripheral)
+		}
+		if events[0].Readings[0].Value != 18.5 {
+			t.Errorf("value: got %v", events[0].Readings[0].Value)
+		}
+	})
+
+	t.Run("TriggerBelongsToDevice returns true for correct device", func(t *testing.T) {
+		ok, err := store.TriggerBelongsToDevice(ctx, triggerID, deviceID)
+		if err != nil {
+			t.Fatalf("belongs: %v", err)
+		}
+		if !ok {
+			t.Error("expected true, got false")
+		}
+	})
+
+	t.Run("TriggerBelongsToDevice returns false for wrong device", func(t *testing.T) {
+		ok, err := store.TriggerBelongsToDevice(ctx, triggerID, "00000000-0000-0000-0000-000000000099")
+		if err != nil {
+			t.Fatalf("belongs: %v", err)
+		}
+		if ok {
+			t.Error("expected false, got true")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 )
@@ -282,6 +283,13 @@ func main() {
 		logger.Error("mqtt readings subscription failed", "error", err)
 	}
 
+	// ── MQTT trigger_events subscription ──────────────────────────────────────
+	triggerEventStore := trigger_events.NewStore(db)
+	triggerEventsMQTTHandler := trigger_events.NewMQTTHandler(triggerEventStore, logger)
+	if err := mqttSubscriber.Subscribe(ctx, "fishhub/+/trigger_events", triggerEventsMQTTHandler.Handle); err != nil {
+		logger.Error("mqtt trigger_events subscription failed", "error", err)
+	}
+
 	// ── Outbox runner ─────────────────────────────────────────────────────────
 	outboxRunner := outbox.NewRunner(
 		outboxStore,
@@ -349,6 +357,7 @@ func main() {
 		r.Get("/api/devices/{id}/triggers/{tid}", (&api.GetTriggerHandler{Service: triggerSvc}).ServeHTTP)
 		r.Patch("/api/devices/{id}/triggers/{tid}", (&api.PatchTriggerHandler{Service: triggerSvc}).ServeHTTP)
 		r.Delete("/api/devices/{id}/triggers/{tid}", (&api.DeleteTriggerHandler{Service: triggerSvc}).ServeHTTP)
+		r.Get("/api/devices/{id}/triggers/{tid}/events", (&api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: triggerEventStore}).ServeHTTP)
 	})
 
 	fmt.Printf("listening on :%s\n", cfg.Port)


### PR DESCRIPTION
## Summary

- Migration 023 creates `trigger_events` with a `trigger_event_id` UNIQUE dedup key, `trigger_id` FK → `triggers`, `fired_at`/`received_at` timestamps, and `readings` JSONB
- New `internal/trigger_events/` package: `Store` (Ingest idempotent via `ON CONFLICT DO NOTHING`, `ListByTrigger`, `TriggerBelongsToDevice`), `MQTTHandler` subscribing to `fishhub/+/trigger_events`
- MQTT handler verifies `trigger_id` belongs to the device in the topic before ingesting — unrecognised trigger IDs are logged and dropped
- `GET /api/devices/{id}/triggers/{tid}/events?limit=50` (default 50, max 200, clamped) under session auth; 404 if trigger not found or not owned by user

## Test plan

- [x] Integration: idempotent ingest (duplicate `trigger_event_id` → one row), `ListByTrigger` ordering and limit, `TriggerBelongsToDevice` true/false
- [x] Unit: MQTT handler rejects malformed topic, malformed JSON, missing fields, invalid `fired_at`, and unowned trigger
- [x] Handler: happy path 200, trigger not found 404, invalid and zero limit 400, limit > 200 clamped
- [x] `go test ./...` passes

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)