### PR TITLE
Cursor pagination and readings in trigger events endpoint

### DIFF
--- a/db/migrations/023_create_trigger_events.down.sql
+++ b/db/migrations/023_create_trigger_events.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS trigger_events_fired_at_idx;
+DROP INDEX IF EXISTS trigger_events_trigger_id_idx;
+DROP TABLE IF EXISTS trigger_events;

--- a/db/migrations/023_create_trigger_events.up.sql
+++ b/db/migrations/023_create_trigger_events.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE trigger_events (
+    id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    trigger_event_id  TEXT        NOT NULL UNIQUE,
+    trigger_id        UUID        NOT NULL REFERENCES triggers(id),
+    fired_at          TIMESTAMPTZ NOT NULL,
+    received_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    readings          JSONB       NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX trigger_events_trigger_id_idx ON trigger_events (trigger_id);
+CREATE INDEX trigger_events_fired_at_idx   ON trigger_events (fired_at DESC);

--- a/internal/api/trigger_events_handler.go
+++ b/internal/api/trigger_events_handler.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+const (
+	defaultEventLimit = 50
+	maxEventLimit     = 200
+)
+
+type ReadingResponse struct {
+	Peripheral string  `json:"peripheral"`
+	Value      float64 `json:"value"`
+}
+
+type TriggerEventResponse struct {
+	ID             string            `json:"id"`
+	TriggerEventID string            `json:"trigger_event_id"`
+	TriggerID      string            `json:"trigger_id"`
+	FiredAt        string            `json:"fired_at"`
+	ReceivedAt     string            `json:"received_at"`
+	Readings       []ReadingResponse `json:"readings"`
+}
+
+func triggerEventResponse(e trigger_events.TriggerEvent) TriggerEventResponse {
+	readings := make([]ReadingResponse, len(e.Readings))
+	for i, r := range e.Readings {
+		readings[i] = ReadingResponse{Peripheral: r.Peripheral, Value: r.Value}
+	}
+	return TriggerEventResponse{
+		ID:             e.ID,
+		TriggerEventID: e.TriggerEventID,
+		TriggerID:      e.TriggerID,
+		FiredAt:        e.FiredAt.UTC().Format(time.RFC3339),
+		ReceivedAt:     e.ReceivedAt.UTC().Format(time.RFC3339),
+		Readings:       readings,
+	}
+}
+
+// ListTriggerEventsHandler handles GET /api/devices/{id}/triggers/{tid}/events (session auth).
+type ListTriggerEventsHandler struct {
+	TriggerStore trigger.Store
+	EventStore   trigger_events.Store
+}
+
+func (h *ListTriggerEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+	triggerID := chi.URLParam(r, "tid")
+
+	limit := defaultEventLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "limit must be a positive integer")
+			return
+		}
+		if v > maxEventLimit {
+			v = maxEventLimit
+		}
+		limit = v
+	}
+
+	// Verify the trigger exists and belongs to this device + user.
+	if _, err := h.TriggerStore.Get(r.Context(), deviceID, claims.UserID, triggerID); err != nil {
+		if errors.Is(err, trigger.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "trigger_not_found", "trigger not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	events, err := h.EventStore.ListByTrigger(r.Context(), triggerID, limit)
+	if err != nil {
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	resp := make([]TriggerEventResponse, len(events))
+	for i, e := range events {
+		resp[i] = triggerEventResponse(e)
+	}
+	render.JSON(w, r, resp)
+}

--- a/internal/api/trigger_events_handler.go
+++ b/internal/api/trigger_events_handler.go
@@ -1,9 +1,10 @@
 package api
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/apierr"
@@ -14,10 +15,7 @@ import (
 	"github.com/go-chi/render"
 )
 
-const (
-	defaultEventLimit = 50
-	maxEventLimit     = 200
-)
+const defaultEventPageSize = 20
 
 type ReadingResponse struct {
 	Peripheral string  `json:"peripheral"`
@@ -31,6 +29,34 @@ type TriggerEventResponse struct {
 	FiredAt        string            `json:"fired_at"`
 	ReceivedAt     string            `json:"received_at"`
 	Readings       []ReadingResponse `json:"readings"`
+}
+
+type TriggerEventsPageResponse struct {
+	Events     []TriggerEventResponse `json:"events"`
+	NextCursor *string                `json:"next_cursor,omitempty"`
+}
+
+// cursorToken is the JSON payload encoded inside the base64 cursor string.
+type cursorToken struct {
+	FiredAt time.Time `json:"fired_at"`
+	ID      string    `json:"id"`
+}
+
+func encodeCursor(firedAt time.Time, id string) string {
+	b, _ := json.Marshal(cursorToken{FiredAt: firedAt, ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeCursor(raw string) (time.Time, string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	var tok cursorToken
+	if err := json.Unmarshal(b, &tok); err != nil {
+		return time.Time{}, "", err
+	}
+	return tok.FiredAt, tok.ID, nil
 }
 
 func triggerEventResponse(e trigger_events.TriggerEvent) TriggerEventResponse {
@@ -59,17 +85,16 @@ func (h *ListTriggerEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	deviceID := chi.URLParam(r, "id")
 	triggerID := chi.URLParam(r, "tid")
 
-	limit := defaultEventLimit
-	if raw := r.URL.Query().Get("limit"); raw != "" {
-		v, err := strconv.Atoi(raw)
-		if err != nil || v <= 0 {
-			apierr.Write(w, http.StatusBadRequest, "invalid_request", "limit must be a positive integer")
+	// Parse optional cursor.
+	page := trigger_events.CursorPage{PageSize: defaultEventPageSize}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		firedAt, id, err := decodeCursor(raw)
+		if err != nil {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid cursor")
 			return
 		}
-		if v > maxEventLimit {
-			v = maxEventLimit
-		}
-		limit = v
+		page.AfterFiredAt = &firedAt
+		page.AfterID = &id
 	}
 
 	// Verify the trigger exists and belongs to this device + user.
@@ -82,15 +107,25 @@ func (h *ListTriggerEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	events, err := h.EventStore.ListByTrigger(r.Context(), triggerID, limit)
+	events, err := h.EventStore.ListByTriggerCursor(r.Context(), triggerID, page)
 	if err != nil {
 		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
-	resp := make([]TriggerEventResponse, len(events))
-	for i, e := range events {
-		resp[i] = triggerEventResponse(e)
+	resp := TriggerEventsPageResponse{
+		Events: make([]TriggerEventResponse, len(events)),
 	}
+	for i, e := range events {
+		resp.Events[i] = triggerEventResponse(e)
+	}
+
+	// Emit next_cursor only when a full page was returned (more may exist).
+	if len(events) == page.PageSize {
+		last := events[len(events)-1]
+		cursor := encodeCursor(last.FiredAt, last.ID)
+		resp.NextCursor = &cursor
+	}
+
 	render.JSON(w, r, resp)
 }

--- a/internal/api/trigger_events_handler_test.go
+++ b/internal/api/trigger_events_handler_test.go
@@ -1,0 +1,169 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/api"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+)
+
+// ── stubTriggerEventStore ─────────────────────────────────────────────────────
+
+type stubTriggerEventStore struct {
+	events  []trigger_events.TriggerEvent
+	listErr error
+}
+
+func (s *stubTriggerEventStore) Ingest(_ context.Context, _ trigger_events.TriggerEvent) error {
+	return nil
+}
+func (s *stubTriggerEventStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+	return s.events, s.listErr
+}
+func (s *stubTriggerEventStore) TriggerBelongsToDevice(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newListTriggerEventsHandler(triggerStore trigger.Store, eventStore trigger_events.Store) *api.ListTriggerEventsHandler {
+	return &api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: eventStore}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestListTriggerEventsHandler(t *testing.T) {
+	firedAt := time.Date(2025, 5, 5, 14, 0, 0, 0, time.UTC)
+	receivedAt := firedAt.Add(time.Second)
+
+	sampleEvents := []trigger_events.TriggerEvent{
+		{
+			ID:             "evt-uuid-1",
+			TriggerEventID: "abc123",
+			TriggerID:      "trig-1",
+			FiredAt:        firedAt,
+			ReceivedAt:     receivedAt,
+			Readings: []trigger_events.Reading{
+				{Peripheral: "ds18b20-4/temperature", Value: 18.5},
+			},
+		},
+	}
+
+	t.Run("returns 200 with events list", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: sampleEvents}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp []map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(resp))
+		}
+		if resp[0]["trigger_event_id"] != "abc123" {
+			t.Errorf("trigger_event_id: got %v", resp[0]["trigger_event_id"])
+		}
+		readings, ok := resp[0]["readings"].([]any)
+		if !ok || len(readings) != 1 {
+			t.Errorf("expected 1 reading, got %v", resp[0]["readings"])
+		}
+	})
+
+	t.Run("trigger not found returns 404", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{getErr: trigger.ErrNotFound}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "ghost"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
+	})
+
+	t.Run("invalid limit returns 400", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=abc", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("zero limit returns 400", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=0", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("limit above max is clamped to 200", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=999", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("returns empty array when no events", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp []any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if len(resp) != 0 {
+			t.Errorf("expected empty list, got %v", resp)
+		}
+	})
+}

--- a/internal/api/trigger_events_handler_test.go
+++ b/internal/api/trigger_events_handler_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,7 +24,7 @@ type stubTriggerEventStore struct {
 func (s *stubTriggerEventStore) Ingest(_ context.Context, _ trigger_events.TriggerEvent) error {
 	return nil
 }
-func (s *stubTriggerEventStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+func (s *stubTriggerEventStore) ListByTriggerCursor(_ context.Context, _ string, _ trigger_events.CursorPage) ([]trigger_events.TriggerEvent, error) {
 	return s.events, s.listErr
 }
 func (s *stubTriggerEventStore) TriggerBelongsToDevice(_ context.Context, _, _ string) (bool, error) {
@@ -34,6 +35,21 @@ func (s *stubTriggerEventStore) TriggerBelongsToDevice(_ context.Context, _, _ s
 
 func newListTriggerEventsHandler(triggerStore trigger.Store, eventStore trigger_events.Store) *api.ListTriggerEventsHandler {
 	return &api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: eventStore}
+}
+
+func makeFullPage() []trigger_events.TriggerEvent {
+	base := time.Date(2025, 5, 5, 14, 0, 0, 0, time.UTC)
+	events := make([]trigger_events.TriggerEvent, 20) // matches defaultEventPageSize
+	for i := range 20 {
+		events[i] = trigger_events.TriggerEvent{
+			ID:         fmt.Sprintf("id-%d", i),
+			TriggerID:  "trig-1",
+			FiredAt:    base.Add(-time.Duration(i) * time.Minute),
+			ReceivedAt: base.Add(-time.Duration(i)*time.Minute + time.Second),
+			Readings:   []trigger_events.Reading{},
+		}
+	}
+	return events
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -55,7 +71,7 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		},
 	}
 
-	t.Run("returns 200 with events list", func(t *testing.T) {
+	t.Run("returns 200 with events and readings", func(t *testing.T) {
 		triggerStore := &stubTriggerStore{got: newTrigger()}
 		eventStore := &stubTriggerEventStore{events: sampleEvents}
 		h := newListTriggerEventsHandler(triggerStore, eventStore)
@@ -70,20 +86,81 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 		}
-		var resp []map[string]any
+		var resp map[string]any
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if len(resp) != 1 {
-			t.Fatalf("expected 1 event, got %d", len(resp))
+		events, ok := resp["events"].([]any)
+		if !ok || len(events) != 1 {
+			t.Fatalf("expected 1 event, got %v", resp["events"])
 		}
-		if resp[0]["trigger_event_id"] != "abc123" {
-			t.Errorf("trigger_event_id: got %v", resp[0]["trigger_event_id"])
+		evt := events[0].(map[string]any)
+		if evt["trigger_event_id"] != "abc123" {
+			t.Errorf("trigger_event_id: got %v", evt["trigger_event_id"])
 		}
-		readings, ok := resp[0]["readings"].([]any)
+		readings, ok := evt["readings"].([]any)
 		if !ok || len(readings) != 1 {
-			t.Errorf("expected 1 reading, got %v", resp[0]["readings"])
+			t.Errorf("expected 1 reading, got %v", evt["readings"])
 		}
+		r := readings[0].(map[string]any)
+		if r["peripheral"] != "ds18b20-4/temperature" {
+			t.Errorf("peripheral: got %v", r["peripheral"])
+		}
+	})
+
+	t.Run("no next_cursor when fewer than page size events returned", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: sampleEvents} // 1 < 20
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if _, hasCursor := resp["next_cursor"]; hasCursor {
+			t.Error("expected no next_cursor when results < page size")
+		}
+	})
+
+	t.Run("next_cursor present when exactly page size events returned", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: makeFullPage()} // exactly 20
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if _, hasCursor := resp["next_cursor"]; !hasCursor {
+			t.Error("expected next_cursor when results == page size")
+		}
+	})
+
+	t.Run("invalid cursor returns 400", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?cursor=not-valid-base64!!!", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("trigger not found returns 404", func(t *testing.T) {
@@ -100,52 +177,7 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
 	})
 
-	t.Run("invalid limit returns 400", func(t *testing.T) {
-		triggerStore := &stubTriggerStore{got: newTrigger()}
-		eventStore := &stubTriggerEventStore{}
-		h := newListTriggerEventsHandler(triggerStore, eventStore)
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=abc", nil), "user-1"),
-			map[string]string{"id": "dev-1", "tid": "trig-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("zero limit returns 400", func(t *testing.T) {
-		triggerStore := &stubTriggerStore{got: newTrigger()}
-		eventStore := &stubTriggerEventStore{}
-		h := newListTriggerEventsHandler(triggerStore, eventStore)
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=0", nil), "user-1"),
-			map[string]string{"id": "dev-1", "tid": "trig-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("limit above max is clamped to 200", func(t *testing.T) {
-		triggerStore := &stubTriggerStore{got: newTrigger()}
-		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
-		h := newListTriggerEventsHandler(triggerStore, eventStore)
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=999", nil), "user-1"),
-			map[string]string{"id": "dev-1", "tid": "trig-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-		}
-	})
-
-	t.Run("returns empty array when no events", func(t *testing.T) {
+	t.Run("returns empty events array when no events", func(t *testing.T) {
 		triggerStore := &stubTriggerStore{got: newTrigger()}
 		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
 		h := newListTriggerEventsHandler(triggerStore, eventStore)
@@ -160,10 +192,14 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d", rec.Code)
 		}
-		var resp []any
+		var resp map[string]any
 		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
-		if len(resp) != 0 {
-			t.Errorf("expected empty list, got %v", resp)
+		events, ok := resp["events"].([]any)
+		if !ok {
+			t.Fatalf("expected events array, got %v", resp["events"])
+		}
+		if len(events) != 0 {
+			t.Errorf("expected empty events, got %v", events)
 		}
 	})
 }

--- a/internal/trigger_events/model.go
+++ b/internal/trigger_events/model.go
@@ -1,0 +1,17 @@
+package trigger_events
+
+import "time"
+
+type Reading struct {
+	Peripheral string  `json:"peripheral"`
+	Value      float64 `json:"value"`
+}
+
+type TriggerEvent struct {
+	ID             string
+	TriggerEventID string
+	TriggerID      string
+	FiredAt        time.Time
+	ReceivedAt     time.Time
+	Readings       []Reading
+}

--- a/internal/trigger_events/mqtt_handler.go
+++ b/internal/trigger_events/mqtt_handler.go
@@ -1,0 +1,84 @@
+package trigger_events
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type MQTTHandler struct {
+	store  Store
+	logger *slog.Logger
+}
+
+func NewMQTTHandler(store Store, logger *slog.Logger) *MQTTHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MQTTHandler{store: store, logger: logger}
+}
+
+type mqttPayload struct {
+	TriggerEventID string    `json:"trigger_event_id"`
+	TriggerID      string    `json:"trigger_id"`
+	DeviceID       string    `json:"device_id"`
+	FiredAt        string    `json:"fired_at"`
+	Readings       []Reading `json:"readings"`
+}
+
+// Handle is the mqtt.MessageHandler callback. Topic shape: fishhub/{device_id}/trigger_events.
+func (h *MQTTHandler) Handle(ctx context.Context, topic string, payload []byte) {
+	deviceID, ok := deviceIDFromTopic(topic)
+	if !ok {
+		h.logger.Warn("mqtt trigger_events: unexpected topic shape", "topic", topic)
+		return
+	}
+
+	var p mqttPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		h.logger.Warn("mqtt trigger_events: invalid payload", "device_id", deviceID, "error", err)
+		return
+	}
+	if p.TriggerEventID == "" || p.TriggerID == "" || p.FiredAt == "" {
+		h.logger.Warn("mqtt trigger_events: missing required fields", "device_id", deviceID)
+		return
+	}
+
+	ok, err := h.store.TriggerBelongsToDevice(ctx, p.TriggerID, deviceID)
+	if err != nil {
+		h.logger.Error("mqtt trigger_events: ownership check", "device_id", deviceID, "trigger_id", p.TriggerID, "error", err)
+		return
+	}
+	if !ok {
+		h.logger.Warn("mqtt trigger_events: trigger does not belong to device", "device_id", deviceID, "trigger_id", p.TriggerID)
+		return
+	}
+
+	firedAt, err := time.Parse(time.RFC3339, p.FiredAt)
+	if err != nil {
+		h.logger.Warn("mqtt trigger_events: invalid fired_at", "device_id", deviceID, "fired_at", p.FiredAt, "error", err)
+		return
+	}
+
+	if err := h.store.Ingest(ctx, TriggerEvent{
+		TriggerEventID: p.TriggerEventID,
+		TriggerID:      p.TriggerID,
+		FiredAt:        firedAt,
+		Readings:       p.Readings,
+	}); err != nil {
+		h.logger.Error("mqtt trigger_events: ingest", "device_id", deviceID, "trigger_id", p.TriggerID, "error", err)
+	}
+}
+
+func deviceIDFromTopic(topic string) (string, bool) {
+	parts := strings.Split(topic, "/")
+	if len(parts) != 3 || parts[0] != "fishhub" || parts[2] != "trigger_events" {
+		return "", false
+	}
+	if parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
+}

--- a/internal/trigger_events/mqtt_handler_test.go
+++ b/internal/trigger_events/mqtt_handler_test.go
@@ -28,7 +28,7 @@ func (s *stubStore) Ingest(_ context.Context, e trigger_events.TriggerEvent) err
 	return s.ingestErr
 }
 
-func (s *stubStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+func (s *stubStore) ListByTriggerCursor(_ context.Context, _ string, _ trigger_events.CursorPage) ([]trigger_events.TriggerEvent, error) {
 	return nil, nil
 }
 

--- a/internal/trigger_events/mqtt_handler_test.go
+++ b/internal/trigger_events/mqtt_handler_test.go
@@ -1,0 +1,133 @@
+package trigger_events_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+)
+
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+// ── stubStore ─────────────────────────────────────────────────────────────────
+
+type stubStore struct {
+	ingestCalled bool
+	ingestEvent  trigger_events.TriggerEvent
+	ingestErr    error
+
+	belongsResult bool
+	belongsErr    error
+}
+
+func (s *stubStore) Ingest(_ context.Context, e trigger_events.TriggerEvent) error {
+	s.ingestCalled = true
+	s.ingestEvent = e
+	return s.ingestErr
+}
+
+func (s *stubStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+	return nil, nil
+}
+
+func (s *stubStore) TriggerBelongsToDevice(_ context.Context, _, _ string) (bool, error) {
+	return s.belongsResult, s.belongsErr
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+const validPayload = `{
+	"trigger_event_id": "abc123",
+	"trigger_id":       "11111111-1111-1111-1111-111111111111",
+	"device_id":        "22222222-2222-2222-2222-222222222222",
+	"fired_at":         "2025-05-05T14:00:00Z",
+	"readings": [{"peripheral": "ds18b20-4/temperature", "value": 18.5}]
+}`
+
+func newHandler(store trigger_events.Store) *trigger_events.MQTTHandler {
+	return trigger_events.NewMQTTHandler(store, discardLogger)
+}
+
+func TestMQTTHandler_Handle(t *testing.T) {
+	t.Run("valid message ingests event", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/22222222-2222-2222-2222-222222222222/trigger_events", []byte(validPayload))
+
+		if !store.ingestCalled {
+			t.Fatal("expected Ingest to be called")
+		}
+		if store.ingestEvent.TriggerEventID != "abc123" {
+			t.Errorf("trigger_event_id: got %q", store.ingestEvent.TriggerEventID)
+		}
+		if len(store.ingestEvent.Readings) != 1 {
+			t.Errorf("readings: expected 1, got %d", len(store.ingestEvent.Readings))
+		}
+	})
+
+	t.Run("trigger not belonging to device drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: false}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/device-x/trigger_events", []byte(validPayload))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called")
+		}
+	})
+
+	t.Run("malformed topic drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		for _, topic := range []string{
+			"fishhub/trigger_events",
+			"fishhub/dev/trigger_events/extra",
+			"other/dev/trigger_events",
+			"fishhub//trigger_events",
+		} {
+			store.ingestCalled = false
+			h.Handle(context.Background(), topic, []byte(validPayload))
+			if store.ingestCalled {
+				t.Errorf("topic %q: expected Ingest not to be called", topic)
+			}
+		}
+	})
+
+	t.Run("malformed JSON drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/dev/trigger_events", []byte("not json"))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called on bad payload")
+		}
+	})
+
+	t.Run("missing required fields drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		h.Handle(context.Background(), "fishhub/dev/trigger_events", []byte(`{"trigger_id":"x"}`))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called on missing fields")
+		}
+	})
+
+	t.Run("invalid fired_at drops message", func(t *testing.T) {
+		store := &stubStore{belongsResult: true}
+		h := newHandler(store)
+
+		payload := `{"trigger_event_id":"x","trigger_id":"t1","device_id":"d1","fired_at":"not-a-date","readings":[]}`
+		h.Handle(context.Background(), "fishhub/dev/trigger_events", []byte(payload))
+
+		if store.ingestCalled {
+			t.Error("expected Ingest not to be called on invalid fired_at")
+		}
+	})
+}

--- a/internal/trigger_events/store.go
+++ b/internal/trigger_events/store.go
@@ -1,0 +1,87 @@
+package trigger_events
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type Store interface {
+	Ingest(ctx context.Context, e TriggerEvent) error
+	ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error)
+	TriggerBelongsToDevice(ctx context.Context, triggerID, deviceID string) (bool, error)
+}
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) Store {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) Ingest(ctx context.Context, e TriggerEvent) error {
+	readings, err := json.Marshal(e.Readings)
+	if err != nil {
+		return fmt.Errorf("ingest trigger event: marshal readings: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO trigger_events (trigger_event_id, trigger_id, fired_at, readings)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (trigger_event_id) DO NOTHING
+	`, e.TriggerEventID, e.TriggerID, e.FiredAt, readings)
+	if err != nil {
+		return fmt.Errorf("ingest trigger event: %w", err)
+	}
+	return nil
+}
+
+func (s *postgresStore) ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
+		FROM trigger_events
+		WHERE trigger_id = $1
+		ORDER BY fired_at DESC
+		LIMIT $2
+	`, triggerID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list trigger events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []TriggerEvent
+	for rows.Next() {
+		var e TriggerEvent
+		var rawReadings []byte
+		if err := rows.Scan(&e.ID, &e.TriggerEventID, &e.TriggerID, &e.FiredAt, &e.ReceivedAt, &rawReadings); err != nil {
+			return nil, fmt.Errorf("list trigger events: scan: %w", err)
+		}
+		if err := json.Unmarshal(rawReadings, &e.Readings); err != nil {
+			return nil, fmt.Errorf("list trigger events: unmarshal readings: %w", err)
+		}
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if events == nil {
+		return []TriggerEvent{}, nil
+	}
+	return events, nil
+}
+
+func (s *postgresStore) TriggerBelongsToDevice(ctx context.Context, triggerID, deviceID string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM triggers
+			WHERE id = $1 AND device_id = $2 AND deleted_at IS NULL
+		)
+	`, triggerID, deviceID).Scan(&exists)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("trigger belongs to device: %w", err)
+	}
+	return exists, nil
+}

--- a/internal/trigger_events/store.go
+++ b/internal/trigger_events/store.go
@@ -6,11 +6,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 )
+
+type CursorPage struct {
+	// AfterFiredAt and AfterID are nil on the first page.
+	AfterFiredAt *time.Time
+	AfterID      *string
+	PageSize     int
+}
 
 type Store interface {
 	Ingest(ctx context.Context, e TriggerEvent) error
-	ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error)
+	ListByTriggerCursor(ctx context.Context, triggerID string, page CursorPage) ([]TriggerEvent, error)
 	TriggerBelongsToDevice(ctx context.Context, triggerID, deviceID string) (bool, error)
 }
 
@@ -38,16 +46,32 @@ func (s *postgresStore) Ingest(ctx context.Context, e TriggerEvent) error {
 	return nil
 }
 
-func (s *postgresStore) ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
-		FROM trigger_events
-		WHERE trigger_id = $1
-		ORDER BY fired_at DESC
-		LIMIT $2
-	`, triggerID, limit)
+func (s *postgresStore) ListByTriggerCursor(ctx context.Context, triggerID string, page CursorPage) ([]TriggerEvent, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+
+	if page.AfterFiredAt == nil || page.AfterID == nil {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
+			FROM trigger_events
+			WHERE trigger_id = $1
+			ORDER BY fired_at DESC, id DESC
+			LIMIT $2
+		`, triggerID, page.PageSize)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
+			FROM trigger_events
+			WHERE trigger_id = $1
+			  AND (fired_at, id) < ($2, $3)
+			ORDER BY fired_at DESC, id DESC
+			LIMIT $4
+		`, triggerID, page.AfterFiredAt, page.AfterID, page.PageSize)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("list trigger events: %w", err)
+		return nil, fmt.Errorf("list trigger events cursor: %w", err)
 	}
 	defer rows.Close()
 
@@ -56,10 +80,10 @@ func (s *postgresStore) ListByTrigger(ctx context.Context, triggerID string, lim
 		var e TriggerEvent
 		var rawReadings []byte
 		if err := rows.Scan(&e.ID, &e.TriggerEventID, &e.TriggerID, &e.FiredAt, &e.ReceivedAt, &rawReadings); err != nil {
-			return nil, fmt.Errorf("list trigger events: scan: %w", err)
+			return nil, fmt.Errorf("list trigger events cursor: scan: %w", err)
 		}
 		if err := json.Unmarshal(rawReadings, &e.Readings); err != nil {
-			return nil, fmt.Errorf("list trigger events: unmarshal readings: %w", err)
+			return nil, fmt.Errorf("list trigger events cursor: unmarshal readings: %w", err)
 		}
 		events = append(events, e)
 	}

--- a/internal/trigger_events/store_integration_test.go
+++ b/internal/trigger_events/store_integration_test.go
@@ -71,7 +71,7 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 		}
 	})
 
-	t.Run("ListByTrigger returns events in fired_at DESC order", func(t *testing.T) {
+	t.Run("ListByTriggerCursor first page returns events in fired_at DESC order", func(t *testing.T) {
 		earlier := now.Add(-5 * time.Minute)
 		if err := store.Ingest(ctx, trigger_events.TriggerEvent{
 			TriggerEventID: "event-id-2",
@@ -82,7 +82,7 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 			t.Fatalf("ingest second event: %v", err)
 		}
 
-		events, err := store.ListByTrigger(ctx, triggerID, 10)
+		events, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 10})
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}
@@ -95,18 +95,50 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 		}
 	})
 
-	t.Run("ListByTrigger respects limit", func(t *testing.T) {
-		events, err := store.ListByTrigger(ctx, triggerID, 1)
+	t.Run("ListByTriggerCursor respects page size", func(t *testing.T) {
+		events, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 1})
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}
 		if len(events) != 1 {
-			t.Errorf("expected 1 event with limit=1, got %d", len(events))
+			t.Errorf("expected 1 event with page size 1, got %d", len(events))
 		}
 	})
 
-	t.Run("ListByTrigger returns readings correctly", func(t *testing.T) {
-		events, err := store.ListByTrigger(ctx, triggerID, 10)
+	t.Run("ListByTriggerCursor second page excludes first page events", func(t *testing.T) {
+		// First page: newest event (fired_at = now).
+		first, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 1})
+		if err != nil {
+			t.Fatalf("first page: %v", err)
+		}
+		if len(first) != 1 {
+			t.Fatalf("expected 1 event on first page, got %d", len(first))
+		}
+
+		// Second page using cursor from the first page's last item.
+		afterFiredAt := first[0].FiredAt
+		afterID := first[0].ID
+		second, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{
+			PageSize:     10,
+			AfterFiredAt: &afterFiredAt,
+			AfterID:      &afterID,
+		})
+		if err != nil {
+			t.Fatalf("second page: %v", err)
+		}
+		if len(second) == 0 {
+			t.Fatal("expected at least 1 event on second page")
+		}
+		// All second-page events must be strictly older than the cursor.
+		for _, e := range second {
+			if !e.FiredAt.Before(afterFiredAt) {
+				t.Errorf("second page event fired_at %v is not before cursor %v", e.FiredAt, afterFiredAt)
+			}
+		}
+	})
+
+	t.Run("ListByTriggerCursor returns readings correctly", func(t *testing.T) {
+		events, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 10})
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}

--- a/internal/trigger_events/store_integration_test.go
+++ b/internal/trigger_events/store_integration_test.go
@@ -1,0 +1,144 @@
+package trigger_events_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/platform"
+	"github.com/fishhub-oss/fishhub-server/internal/testutil"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
+)
+
+func TestTriggerEventsStore_integration(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	store := trigger_events.NewStore(db)
+	ctx := context.Background()
+	userID := platform.SeedUserID()
+
+	var deviceID string
+	if err := db.QueryRowContext(ctx,
+		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+	).Scan(&deviceID); err != nil {
+		t.Fatalf("insert device: %v", err)
+	}
+
+	var triggerID string
+	if err := db.QueryRowContext(ctx, `
+		INSERT INTO triggers (device_id, name, condition, cooldown_s)
+		VALUES ($1, 'test trigger', '{}', 60) RETURNING id`, deviceID,
+	).Scan(&triggerID); err != nil {
+		t.Fatalf("insert trigger: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	t.Run("ingest stores event", func(t *testing.T) {
+		err := store.Ingest(ctx, trigger_events.TriggerEvent{
+			TriggerEventID: "event-id-1",
+			TriggerID:      triggerID,
+			FiredAt:        now,
+			Readings: []trigger_events.Reading{
+				{Peripheral: "ds18b20-4/temperature", Value: 18.5},
+			},
+		})
+		if err != nil {
+			t.Fatalf("ingest: %v", err)
+		}
+
+		var count int
+		db.QueryRowContext(ctx, `SELECT COUNT(*) FROM trigger_events WHERE trigger_event_id = 'event-id-1'`).Scan(&count)
+		if count != 1 {
+			t.Errorf("expected 1 row, got %d", count)
+		}
+	})
+
+	t.Run("ingest is idempotent — duplicate trigger_event_id is a no-op", func(t *testing.T) {
+		err := store.Ingest(ctx, trigger_events.TriggerEvent{
+			TriggerEventID: "event-id-1",
+			TriggerID:      triggerID,
+			FiredAt:        now,
+			Readings:       []trigger_events.Reading{},
+		})
+		if err != nil {
+			t.Fatalf("second ingest: %v", err)
+		}
+
+		var count int
+		db.QueryRowContext(ctx, `SELECT COUNT(*) FROM trigger_events WHERE trigger_event_id = 'event-id-1'`).Scan(&count)
+		if count != 1 {
+			t.Errorf("expected exactly 1 row after duplicate ingest, got %d", count)
+		}
+	})
+
+	t.Run("ListByTrigger returns events in fired_at DESC order", func(t *testing.T) {
+		earlier := now.Add(-5 * time.Minute)
+		if err := store.Ingest(ctx, trigger_events.TriggerEvent{
+			TriggerEventID: "event-id-2",
+			TriggerID:      triggerID,
+			FiredAt:        earlier,
+			Readings:       []trigger_events.Reading{},
+		}); err != nil {
+			t.Fatalf("ingest second event: %v", err)
+		}
+
+		events, err := store.ListByTrigger(ctx, triggerID, 10)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(events) < 2 {
+			t.Fatalf("expected at least 2 events, got %d", len(events))
+		}
+		if !events[0].FiredAt.After(events[1].FiredAt) {
+			t.Errorf("expected events ordered fired_at DESC: first=%v second=%v",
+				events[0].FiredAt, events[1].FiredAt)
+		}
+	})
+
+	t.Run("ListByTrigger respects limit", func(t *testing.T) {
+		events, err := store.ListByTrigger(ctx, triggerID, 1)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(events) != 1 {
+			t.Errorf("expected 1 event with limit=1, got %d", len(events))
+		}
+	})
+
+	t.Run("ListByTrigger returns readings correctly", func(t *testing.T) {
+		events, err := store.ListByTrigger(ctx, triggerID, 10)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		// event-id-1 is the most recent (fired_at = now)
+		if len(events[0].Readings) != 1 {
+			t.Fatalf("expected 1 reading on most recent event, got %d", len(events[0].Readings))
+		}
+		if events[0].Readings[0].Peripheral != "ds18b20-4/temperature" {
+			t.Errorf("peripheral: got %q", events[0].Readings[0].Peripheral)
+		}
+		if events[0].Readings[0].Value != 18.5 {
+			t.Errorf("value: got %v", events[0].Readings[0].Value)
+		}
+	})
+
+	t.Run("TriggerBelongsToDevice returns true for correct device", func(t *testing.T) {
+		ok, err := store.TriggerBelongsToDevice(ctx, triggerID, deviceID)
+		if err != nil {
+			t.Fatalf("belongs: %v", err)
+		}
+		if !ok {
+			t.Error("expected true, got false")
+		}
+	})
+
+	t.Run("TriggerBelongsToDevice returns false for wrong device", func(t *testing.T) {
+		ok, err := store.TriggerBelongsToDevice(ctx, triggerID, "00000000-0000-0000-0000-000000000099")
+		if err != nil {
+			t.Fatalf("belongs: %v", err)
+		}
+		if ok {
+			t.Error("expected false, got true")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 	"github.com/fishhub-oss/fishhub-server/internal/trigger"
+	trigger_events "github.com/fishhub-oss/fishhub-server/internal/trigger_events"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 )
@@ -282,6 +283,13 @@ func main() {
 		logger.Error("mqtt readings subscription failed", "error", err)
 	}
 
+	// ── MQTT trigger_events subscription ──────────────────────────────────────
+	triggerEventStore := trigger_events.NewStore(db)
+	triggerEventsMQTTHandler := trigger_events.NewMQTTHandler(triggerEventStore, logger)
+	if err := mqttSubscriber.Subscribe(ctx, "fishhub/+/trigger_events", triggerEventsMQTTHandler.Handle); err != nil {
+		logger.Error("mqtt trigger_events subscription failed", "error", err)
+	}
+
 	// ── Outbox runner ─────────────────────────────────────────────────────────
 	outboxRunner := outbox.NewRunner(
 		outboxStore,
@@ -349,6 +357,7 @@ func main() {
 		r.Get("/api/devices/{id}/triggers/{tid}", (&api.GetTriggerHandler{Service: triggerSvc}).ServeHTTP)
 		r.Patch("/api/devices/{id}/triggers/{tid}", (&api.PatchTriggerHandler{Service: triggerSvc}).ServeHTTP)
 		r.Delete("/api/devices/{id}/triggers/{tid}", (&api.DeleteTriggerHandler{Service: triggerSvc}).ServeHTTP)
+		r.Get("/api/devices/{id}/triggers/{tid}/events", (&api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: triggerEventStore}).ServeHTTP)
 	})
 
 	fmt.Printf("listening on :%s\n", cfg.Port)


### PR DESCRIPTION
## Summary

- Replaces `ListByTrigger(limit int)` with `ListByTriggerCursor(page CursorPage)` on the `Store` interface — keyset pagination on `(fired_at DESC, id DESC)`
- `CursorPage` carries `AfterFiredAt *time.Time`, `AfterID *string`, and `PageSize int`; both pointer fields nil on the first page
- Handler decodes/encodes an opaque base64 cursor token; response shape changes from `[]TriggerEventResponse` to `{ events, next_cursor? }` — `next_cursor` is omitted when the page is the last one
- Default page size is 20; invalid cursor token returns 400
- All stubs updated; new handler tests cover cursor presence/absence and invalid cursor rejection; integration tests cover second-page exclusion and readings round-trip

No migration required — cursor is derived from existing `fired_at` + `id` columns (both already indexed).

Closes #128