### PR TITLE
Cursor pagination and readings in trigger events endpoint

### DIFF
--- a/internal/api/trigger_events_handler.go
+++ b/internal/api/trigger_events_handler.go
@@ -1,9 +1,10 @@
 package api
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/apierr"
@@ -14,10 +15,7 @@ import (
 	"github.com/go-chi/render"
 )
 
-const (
-	defaultEventLimit = 50
-	maxEventLimit     = 200
-)
+const defaultEventPageSize = 20
 
 type ReadingResponse struct {
 	Peripheral string  `json:"peripheral"`
@@ -31,6 +29,34 @@ type TriggerEventResponse struct {
 	FiredAt        string            `json:"fired_at"`
 	ReceivedAt     string            `json:"received_at"`
 	Readings       []ReadingResponse `json:"readings"`
+}
+
+type TriggerEventsPageResponse struct {
+	Events     []TriggerEventResponse `json:"events"`
+	NextCursor *string                `json:"next_cursor,omitempty"`
+}
+
+// cursorToken is the JSON payload encoded inside the base64 cursor string.
+type cursorToken struct {
+	FiredAt time.Time `json:"fired_at"`
+	ID      string    `json:"id"`
+}
+
+func encodeCursor(firedAt time.Time, id string) string {
+	b, _ := json.Marshal(cursorToken{FiredAt: firedAt, ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeCursor(raw string) (time.Time, string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	var tok cursorToken
+	if err := json.Unmarshal(b, &tok); err != nil {
+		return time.Time{}, "", err
+	}
+	return tok.FiredAt, tok.ID, nil
 }
 
 func triggerEventResponse(e trigger_events.TriggerEvent) TriggerEventResponse {
@@ -59,17 +85,16 @@ func (h *ListTriggerEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	deviceID := chi.URLParam(r, "id")
 	triggerID := chi.URLParam(r, "tid")
 
-	limit := defaultEventLimit
-	if raw := r.URL.Query().Get("limit"); raw != "" {
-		v, err := strconv.Atoi(raw)
-		if err != nil || v <= 0 {
-			apierr.Write(w, http.StatusBadRequest, "invalid_request", "limit must be a positive integer")
+	// Parse optional cursor.
+	page := trigger_events.CursorPage{PageSize: defaultEventPageSize}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		firedAt, id, err := decodeCursor(raw)
+		if err != nil {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid cursor")
 			return
 		}
-		if v > maxEventLimit {
-			v = maxEventLimit
-		}
-		limit = v
+		page.AfterFiredAt = &firedAt
+		page.AfterID = &id
 	}
 
 	// Verify the trigger exists and belongs to this device + user.
@@ -82,15 +107,25 @@ func (h *ListTriggerEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	events, err := h.EventStore.ListByTrigger(r.Context(), triggerID, limit)
+	events, err := h.EventStore.ListByTriggerCursor(r.Context(), triggerID, page)
 	if err != nil {
 		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 
-	resp := make([]TriggerEventResponse, len(events))
-	for i, e := range events {
-		resp[i] = triggerEventResponse(e)
+	resp := TriggerEventsPageResponse{
+		Events: make([]TriggerEventResponse, len(events)),
 	}
+	for i, e := range events {
+		resp.Events[i] = triggerEventResponse(e)
+	}
+
+	// Emit next_cursor only when a full page was returned (more may exist).
+	if len(events) == page.PageSize {
+		last := events[len(events)-1]
+		cursor := encodeCursor(last.FiredAt, last.ID)
+		resp.NextCursor = &cursor
+	}
+
 	render.JSON(w, r, resp)
 }

--- a/internal/api/trigger_events_handler_test.go
+++ b/internal/api/trigger_events_handler_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,7 +24,7 @@ type stubTriggerEventStore struct {
 func (s *stubTriggerEventStore) Ingest(_ context.Context, _ trigger_events.TriggerEvent) error {
 	return nil
 }
-func (s *stubTriggerEventStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+func (s *stubTriggerEventStore) ListByTriggerCursor(_ context.Context, _ string, _ trigger_events.CursorPage) ([]trigger_events.TriggerEvent, error) {
 	return s.events, s.listErr
 }
 func (s *stubTriggerEventStore) TriggerBelongsToDevice(_ context.Context, _, _ string) (bool, error) {
@@ -34,6 +35,21 @@ func (s *stubTriggerEventStore) TriggerBelongsToDevice(_ context.Context, _, _ s
 
 func newListTriggerEventsHandler(triggerStore trigger.Store, eventStore trigger_events.Store) *api.ListTriggerEventsHandler {
 	return &api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: eventStore}
+}
+
+func makeFullPage() []trigger_events.TriggerEvent {
+	base := time.Date(2025, 5, 5, 14, 0, 0, 0, time.UTC)
+	events := make([]trigger_events.TriggerEvent, 20) // matches defaultEventPageSize
+	for i := range 20 {
+		events[i] = trigger_events.TriggerEvent{
+			ID:         fmt.Sprintf("id-%d", i),
+			TriggerID:  "trig-1",
+			FiredAt:    base.Add(-time.Duration(i) * time.Minute),
+			ReceivedAt: base.Add(-time.Duration(i)*time.Minute + time.Second),
+			Readings:   []trigger_events.Reading{},
+		}
+	}
+	return events
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -55,7 +71,7 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		},
 	}
 
-	t.Run("returns 200 with events list", func(t *testing.T) {
+	t.Run("returns 200 with events and readings", func(t *testing.T) {
 		triggerStore := &stubTriggerStore{got: newTrigger()}
 		eventStore := &stubTriggerEventStore{events: sampleEvents}
 		h := newListTriggerEventsHandler(triggerStore, eventStore)
@@ -70,20 +86,81 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 		}
-		var resp []map[string]any
+		var resp map[string]any
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if len(resp) != 1 {
-			t.Fatalf("expected 1 event, got %d", len(resp))
+		events, ok := resp["events"].([]any)
+		if !ok || len(events) != 1 {
+			t.Fatalf("expected 1 event, got %v", resp["events"])
 		}
-		if resp[0]["trigger_event_id"] != "abc123" {
-			t.Errorf("trigger_event_id: got %v", resp[0]["trigger_event_id"])
+		evt := events[0].(map[string]any)
+		if evt["trigger_event_id"] != "abc123" {
+			t.Errorf("trigger_event_id: got %v", evt["trigger_event_id"])
 		}
-		readings, ok := resp[0]["readings"].([]any)
+		readings, ok := evt["readings"].([]any)
 		if !ok || len(readings) != 1 {
-			t.Errorf("expected 1 reading, got %v", resp[0]["readings"])
+			t.Errorf("expected 1 reading, got %v", evt["readings"])
 		}
+		r := readings[0].(map[string]any)
+		if r["peripheral"] != "ds18b20-4/temperature" {
+			t.Errorf("peripheral: got %v", r["peripheral"])
+		}
+	})
+
+	t.Run("no next_cursor when fewer than page size events returned", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: sampleEvents} // 1 < 20
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if _, hasCursor := resp["next_cursor"]; hasCursor {
+			t.Error("expected no next_cursor when results < page size")
+		}
+	})
+
+	t.Run("next_cursor present when exactly page size events returned", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{events: makeFullPage()} // exactly 20
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if _, hasCursor := resp["next_cursor"]; !hasCursor {
+			t.Error("expected next_cursor when results == page size")
+		}
+	})
+
+	t.Run("invalid cursor returns 400", func(t *testing.T) {
+		triggerStore := &stubTriggerStore{got: newTrigger()}
+		eventStore := &stubTriggerEventStore{}
+		h := newListTriggerEventsHandler(triggerStore, eventStore)
+
+		req := withChiParams(
+			withClaims(httptest.NewRequest(http.MethodGet, "/?cursor=not-valid-base64!!!", nil), "user-1"),
+			map[string]string{"id": "dev-1", "tid": "trig-1"},
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
 	})
 
 	t.Run("trigger not found returns 404", func(t *testing.T) {
@@ -100,52 +177,7 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusNotFound, "trigger_not_found")
 	})
 
-	t.Run("invalid limit returns 400", func(t *testing.T) {
-		triggerStore := &stubTriggerStore{got: newTrigger()}
-		eventStore := &stubTriggerEventStore{}
-		h := newListTriggerEventsHandler(triggerStore, eventStore)
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=abc", nil), "user-1"),
-			map[string]string{"id": "dev-1", "tid": "trig-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("zero limit returns 400", func(t *testing.T) {
-		triggerStore := &stubTriggerStore{got: newTrigger()}
-		eventStore := &stubTriggerEventStore{}
-		h := newListTriggerEventsHandler(triggerStore, eventStore)
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=0", nil), "user-1"),
-			map[string]string{"id": "dev-1", "tid": "trig-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
-	})
-
-	t.Run("limit above max is clamped to 200", func(t *testing.T) {
-		triggerStore := &stubTriggerStore{got: newTrigger()}
-		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
-		h := newListTriggerEventsHandler(triggerStore, eventStore)
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodGet, "/?limit=999", nil), "user-1"),
-			map[string]string{"id": "dev-1", "tid": "trig-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-		}
-	})
-
-	t.Run("returns empty array when no events", func(t *testing.T) {
+	t.Run("returns empty events array when no events", func(t *testing.T) {
 		triggerStore := &stubTriggerStore{got: newTrigger()}
 		eventStore := &stubTriggerEventStore{events: []trigger_events.TriggerEvent{}}
 		h := newListTriggerEventsHandler(triggerStore, eventStore)
@@ -160,10 +192,14 @@ func TestListTriggerEventsHandler(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d", rec.Code)
 		}
-		var resp []any
+		var resp map[string]any
 		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
-		if len(resp) != 0 {
-			t.Errorf("expected empty list, got %v", resp)
+		events, ok := resp["events"].([]any)
+		if !ok {
+			t.Fatalf("expected events array, got %v", resp["events"])
+		}
+		if len(events) != 0 {
+			t.Errorf("expected empty events, got %v", events)
 		}
 	})
 }

--- a/internal/trigger_events/mqtt_handler_test.go
+++ b/internal/trigger_events/mqtt_handler_test.go
@@ -28,7 +28,7 @@ func (s *stubStore) Ingest(_ context.Context, e trigger_events.TriggerEvent) err
 	return s.ingestErr
 }
 
-func (s *stubStore) ListByTrigger(_ context.Context, _ string, _ int) ([]trigger_events.TriggerEvent, error) {
+func (s *stubStore) ListByTriggerCursor(_ context.Context, _ string, _ trigger_events.CursorPage) ([]trigger_events.TriggerEvent, error) {
 	return nil, nil
 }
 

--- a/internal/trigger_events/store.go
+++ b/internal/trigger_events/store.go
@@ -6,11 +6,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 )
+
+type CursorPage struct {
+	// AfterFiredAt and AfterID are nil on the first page.
+	AfterFiredAt *time.Time
+	AfterID      *string
+	PageSize     int
+}
 
 type Store interface {
 	Ingest(ctx context.Context, e TriggerEvent) error
-	ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error)
+	ListByTriggerCursor(ctx context.Context, triggerID string, page CursorPage) ([]TriggerEvent, error)
 	TriggerBelongsToDevice(ctx context.Context, triggerID, deviceID string) (bool, error)
 }
 
@@ -38,16 +46,32 @@ func (s *postgresStore) Ingest(ctx context.Context, e TriggerEvent) error {
 	return nil
 }
 
-func (s *postgresStore) ListByTrigger(ctx context.Context, triggerID string, limit int) ([]TriggerEvent, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
-		FROM trigger_events
-		WHERE trigger_id = $1
-		ORDER BY fired_at DESC
-		LIMIT $2
-	`, triggerID, limit)
+func (s *postgresStore) ListByTriggerCursor(ctx context.Context, triggerID string, page CursorPage) ([]TriggerEvent, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+
+	if page.AfterFiredAt == nil || page.AfterID == nil {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
+			FROM trigger_events
+			WHERE trigger_id = $1
+			ORDER BY fired_at DESC, id DESC
+			LIMIT $2
+		`, triggerID, page.PageSize)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, trigger_event_id, trigger_id, fired_at, received_at, readings
+			FROM trigger_events
+			WHERE trigger_id = $1
+			  AND (fired_at, id) < ($2, $3)
+			ORDER BY fired_at DESC, id DESC
+			LIMIT $4
+		`, triggerID, page.AfterFiredAt, page.AfterID, page.PageSize)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("list trigger events: %w", err)
+		return nil, fmt.Errorf("list trigger events cursor: %w", err)
 	}
 	defer rows.Close()
 
@@ -56,10 +80,10 @@ func (s *postgresStore) ListByTrigger(ctx context.Context, triggerID string, lim
 		var e TriggerEvent
 		var rawReadings []byte
 		if err := rows.Scan(&e.ID, &e.TriggerEventID, &e.TriggerID, &e.FiredAt, &e.ReceivedAt, &rawReadings); err != nil {
-			return nil, fmt.Errorf("list trigger events: scan: %w", err)
+			return nil, fmt.Errorf("list trigger events cursor: scan: %w", err)
 		}
 		if err := json.Unmarshal(rawReadings, &e.Readings); err != nil {
-			return nil, fmt.Errorf("list trigger events: unmarshal readings: %w", err)
+			return nil, fmt.Errorf("list trigger events cursor: unmarshal readings: %w", err)
 		}
 		events = append(events, e)
 	}

--- a/internal/trigger_events/store_integration_test.go
+++ b/internal/trigger_events/store_integration_test.go
@@ -71,7 +71,7 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 		}
 	})
 
-	t.Run("ListByTrigger returns events in fired_at DESC order", func(t *testing.T) {
+	t.Run("ListByTriggerCursor first page returns events in fired_at DESC order", func(t *testing.T) {
 		earlier := now.Add(-5 * time.Minute)
 		if err := store.Ingest(ctx, trigger_events.TriggerEvent{
 			TriggerEventID: "event-id-2",
@@ -82,7 +82,7 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 			t.Fatalf("ingest second event: %v", err)
 		}
 
-		events, err := store.ListByTrigger(ctx, triggerID, 10)
+		events, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 10})
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}
@@ -95,18 +95,50 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 		}
 	})
 
-	t.Run("ListByTrigger respects limit", func(t *testing.T) {
-		events, err := store.ListByTrigger(ctx, triggerID, 1)
+	t.Run("ListByTriggerCursor respects page size", func(t *testing.T) {
+		events, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 1})
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}
 		if len(events) != 1 {
-			t.Errorf("expected 1 event with limit=1, got %d", len(events))
+			t.Errorf("expected 1 event with page size 1, got %d", len(events))
 		}
 	})
 
-	t.Run("ListByTrigger returns readings correctly", func(t *testing.T) {
-		events, err := store.ListByTrigger(ctx, triggerID, 10)
+	t.Run("ListByTriggerCursor second page excludes first page events", func(t *testing.T) {
+		// First page: newest event (fired_at = now).
+		first, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 1})
+		if err != nil {
+			t.Fatalf("first page: %v", err)
+		}
+		if len(first) != 1 {
+			t.Fatalf("expected 1 event on first page, got %d", len(first))
+		}
+
+		// Second page using cursor from the first page's last item.
+		afterFiredAt := first[0].FiredAt
+		afterID := first[0].ID
+		second, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{
+			PageSize:     10,
+			AfterFiredAt: &afterFiredAt,
+			AfterID:      &afterID,
+		})
+		if err != nil {
+			t.Fatalf("second page: %v", err)
+		}
+		if len(second) == 0 {
+			t.Fatal("expected at least 1 event on second page")
+		}
+		// All second-page events must be strictly older than the cursor.
+		for _, e := range second {
+			if !e.FiredAt.Before(afterFiredAt) {
+				t.Errorf("second page event fired_at %v is not before cursor %v", e.FiredAt, afterFiredAt)
+			}
+		}
+	})
+
+	t.Run("ListByTriggerCursor returns readings correctly", func(t *testing.T) {
+		events, err := store.ListByTriggerCursor(ctx, triggerID, trigger_events.CursorPage{PageSize: 10})
 		if err != nil {
 			t.Fatalf("list: %v", err)
 		}


### PR DESCRIPTION
## Summary

- Replaces `ListByTrigger(limit int)` with `ListByTriggerCursor(page CursorPage)` on the `Store` interface — keyset pagination on `(fired_at DESC, id DESC)`
- `CursorPage` carries `AfterFiredAt *time.Time`, `AfterID *string`, and `PageSize int`; both pointer fields nil on the first page
- Handler decodes/encodes an opaque base64 cursor token; response shape changes from `[]TriggerEventResponse` to `{ events, next_cursor? }` — `next_cursor` is omitted when the page is the last one
- Default page size is 20; invalid cursor token returns 400
- All stubs updated; new handler tests cover cursor presence/absence and invalid cursor rejection; integration tests cover second-page exclusion and readings round-trip

No migration required — cursor is derived from existing `fired_at` + `id` columns (both already indexed).

Closes #128