### PR TITLE
Add GET /api/alerts with cursor pagination and unit lookup

### DIFF
--- a/internal/actions/alert/processor_test.go
+++ b/internal/actions/alert/processor_test.go
@@ -27,6 +27,10 @@ func (s *stubAlertStore) ListByUser(_ context.Context, _ string, _ int) ([]alert
 	return nil, nil
 }
 
+func (s *stubAlertStore) ListByUserCursor(_ context.Context, _ string, _ alerts.CursorPage) ([]alerts.Alert, error) {
+	return nil, nil
+}
+
 type stubTriggerStore struct {
 	trig   trigger.Trigger
 	action trigger.Action

--- a/internal/alerts/store.go
+++ b/internal/alerts/store.go
@@ -1,8 +1,18 @@
 package alerts
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+type CursorPage struct {
+	AfterCreatedAt *time.Time
+	AfterID        *string
+	PageSize       int
+}
 
 type Store interface {
 	Create(ctx context.Context, a Alert) (Alert, error)
 	ListByUser(ctx context.Context, userID string, limit int) ([]Alert, error)
+	ListByUserCursor(ctx context.Context, userID string, page CursorPage) ([]Alert, error)
 }

--- a/internal/alerts/store_postgres.go
+++ b/internal/alerts/store_postgres.go
@@ -35,6 +35,54 @@ func (s *postgresStore) Create(ctx context.Context, a Alert) (Alert, error) {
 	return out, nil
 }
 
+func (s *postgresStore) ListByUserCursor(ctx context.Context, userID string, page CursorPage) ([]Alert, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if page.AfterCreatedAt == nil || page.AfterID == nil {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, user_id, device_id, trigger_id, event_id, severity, message, context, created_at
+			FROM alerts
+			WHERE user_id = $1
+			ORDER BY created_at DESC, id DESC
+			LIMIT $2
+		`, userID, page.PageSize)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, user_id, device_id, trigger_id, event_id, severity, message, context, created_at
+			FROM alerts
+			WHERE user_id = $1
+			  AND (created_at, id) < ($2, $3)
+			ORDER BY created_at DESC, id DESC
+			LIMIT $4
+		`, userID, page.AfterCreatedAt, page.AfterID, page.PageSize)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list alerts cursor: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Alert
+	for rows.Next() {
+		var a Alert
+		if err := rows.Scan(
+			&a.ID, &a.UserID, &a.DeviceID, &a.TriggerID, &a.EventID,
+			&a.Severity, &a.Message, (*jsonMap)(&a.Context), &a.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("list alerts cursor: scan: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return []Alert{}, nil
+	}
+	return out, nil
+}
+
 func (s *postgresStore) ListByUser(ctx context.Context, userID string, limit int) ([]Alert, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, user_id, device_id, trigger_id, event_id, severity, message, context, created_at

--- a/internal/alerts/units.go
+++ b/internal/alerts/units.go
@@ -1,0 +1,33 @@
+package alerts
+
+import "strings"
+
+// unitLookup maps "<kind>/<measurement>" to the SenML unit string.
+// An empty string means the measurement is unitless — omit the field from responses.
+var unitLookup = map[string]string{
+	"ds18b20/temperature": "Cel",
+	"ph/ph":               "",
+}
+
+// UnitFor resolves the SenML unit for a peripheral string of the form
+// "<kind>-<pin>/<measurement>". Returns ("", false) when not found.
+func UnitFor(peripheral string) (string, bool) {
+	slash := strings.IndexByte(peripheral, '/')
+	if slash < 0 {
+		return "", false
+	}
+	measurement := peripheral[slash+1:]
+	kindPin := peripheral[:slash]
+
+	dash := strings.LastIndexByte(kindPin, '-')
+	var kind string
+	if dash < 0 {
+		kind = kindPin
+	} else {
+		kind = kindPin[:dash]
+	}
+
+	key := kind + "/" + measurement
+	unit, ok := unitLookup[key]
+	return unit, ok
+}

--- a/internal/api/alerts_handler.go
+++ b/internal/api/alerts_handler.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/alerts"
+	"github.com/fishhub-oss/fishhub-server/internal/apierr"
+	"github.com/fishhub-oss/fishhub-server/internal/auth"
+	"github.com/go-chi/render"
+)
+
+const defaultAlertPageSize = 20
+
+type AlertContextResponse struct {
+	Peripheral string  `json:"peripheral"`
+	Value      float64 `json:"value"`
+	Unit       string  `json:"unit,omitempty"`
+	FiredAt    string  `json:"fired_at"`
+}
+
+type AlertResponse struct {
+	ID        string               `json:"id"`
+	DeviceID  string               `json:"device_id"`
+	TriggerID string               `json:"trigger_id"`
+	EventID   string               `json:"event_id"`
+	Severity  string               `json:"severity"`
+	Message   string               `json:"message"`
+	Context   AlertContextResponse `json:"context"`
+	CreatedAt string               `json:"created_at"`
+}
+
+type AlertsPageResponse struct {
+	Alerts     []AlertResponse `json:"alerts"`
+	NextCursor *string         `json:"next_cursor,omitempty"`
+}
+
+// ListAlertsHandler handles GET /api/alerts (session auth).
+type ListAlertsHandler struct {
+	Store alerts.Store
+}
+
+func (h *ListAlertsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+
+	page := alerts.CursorPage{PageSize: defaultAlertPageSize}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		ts, id, err := decodeCursor(raw)
+		if err != nil {
+			apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid cursor")
+			return
+		}
+		page.AfterCreatedAt = &ts
+		page.AfterID = &id
+	}
+
+	rows, err := h.Store.ListByUserCursor(r.Context(), claims.UserID, page)
+	if err != nil {
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	resp := AlertsPageResponse{
+		Alerts: make([]AlertResponse, len(rows)),
+	}
+	for i, a := range rows {
+		resp.Alerts[i] = toAlertResponse(a)
+	}
+
+	if len(rows) == page.PageSize {
+		last := rows[len(rows)-1]
+		cursor := encodeCursor(last.CreatedAt, last.ID)
+		resp.NextCursor = &cursor
+	}
+
+	render.JSON(w, r, resp)
+}
+
+func toAlertResponse(a alerts.Alert) AlertResponse {
+	ctx := toAlertContextResponse(a.Context)
+	return AlertResponse{
+		ID:        a.ID,
+		DeviceID:  a.DeviceID,
+		TriggerID: a.TriggerID,
+		EventID:   a.EventID,
+		Severity:  a.Severity,
+		Message:   a.Message,
+		Context:   ctx,
+		CreatedAt: a.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func toAlertContextResponse(ctx map[string]any) AlertContextResponse {
+	var peripheral string
+	var value float64
+	var firedAt string
+
+	if v, ok := ctx["peripheral"].(string); ok {
+		peripheral = v
+	}
+	if v, ok := ctx["value"].(float64); ok {
+		value = v
+	}
+	if v, ok := ctx["fired_at"].(string); ok {
+		firedAt = v
+	} else if t, ok := ctx["fired_at"].(time.Time); ok {
+		firedAt = t.UTC().Format(time.RFC3339)
+	}
+
+	unit, _ := alerts.UnitFor(peripheral)
+
+	return AlertContextResponse{
+		Peripheral: peripheral,
+		Value:      value,
+		Unit:       unit,
+		FiredAt:    firedAt,
+	}
+}

--- a/internal/api/alerts_handler_test.go
+++ b/internal/api/alerts_handler_test.go
@@ -1,0 +1,180 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fishhub-oss/fishhub-server/internal/alerts"
+	"github.com/fishhub-oss/fishhub-server/internal/api"
+)
+
+// ── stubAlertStore ────────────────────────────────────────────────────────────
+
+type stubAlertStore struct {
+	created    alerts.Alert
+	createErr  error
+	listed     []alerts.Alert
+	listErr    error
+	cursorRows []alerts.Alert
+	cursorErr  error
+}
+
+func (s *stubAlertStore) Create(_ context.Context, a alerts.Alert) (alerts.Alert, error) {
+	return s.created, s.createErr
+}
+func (s *stubAlertStore) ListByUser(_ context.Context, _ string, _ int) ([]alerts.Alert, error) {
+	return s.listed, s.listErr
+}
+func (s *stubAlertStore) ListByUserCursor(_ context.Context, _ string, _ alerts.CursorPage) ([]alerts.Alert, error) {
+	return s.cursorRows, s.cursorErr
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newAlert(id string, createdAt time.Time) alerts.Alert {
+	return alerts.Alert{
+		ID:        id,
+		UserID:    "user-1",
+		DeviceID:  "dev-1",
+		TriggerID: "trig-1",
+		EventID:   "evt-1",
+		Severity:  "warning",
+		Message:   "Temperature dropped to 17.2°C",
+		Context: map[string]any{
+			"peripheral": "ds18b20-4/temperature",
+			"value":      17.2,
+			"fired_at":   "2025-05-05T14:00:00Z",
+		},
+		CreatedAt: createdAt,
+	}
+}
+
+func makeFullAlertPage() []alerts.Alert {
+	base := time.Date(2025, 5, 5, 14, 0, 0, 0, time.UTC)
+	rows := make([]alerts.Alert, 20)
+	for i := range 20 {
+		rows[i] = newAlert(fmt.Sprintf("alert-%d", i), base.Add(-time.Duration(i)*time.Minute))
+	}
+	return rows
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestListAlertsHandler(t *testing.T) {
+	createdAt := time.Date(2025, 5, 5, 14, 0, 0, 0, time.UTC)
+
+	t.Run("returns 200 with alerts including resolved unit", func(t *testing.T) {
+		store := &stubAlertStore{cursorRows: []alerts.Alert{newAlert("alert-1", createdAt)}}
+		h := &api.ListAlertsHandler{Store: store}
+
+		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/alerts", nil), "user-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		rows, ok := resp["alerts"].([]any)
+		if !ok || len(rows) != 1 {
+			t.Fatalf("expected 1 alert, got %v", resp["alerts"])
+		}
+		a := rows[0].(map[string]any)
+		if a["id"] != "alert-1" {
+			t.Errorf("id: got %v", a["id"])
+		}
+		ctx, ok := a["context"].(map[string]any)
+		if !ok {
+			t.Fatalf("context not an object: %v", a["context"])
+		}
+		if ctx["unit"] != "Cel" {
+			t.Errorf("unit: got %v, want Cel", ctx["unit"])
+		}
+		if ctx["peripheral"] != "ds18b20-4/temperature" {
+			t.Errorf("peripheral: got %v", ctx["peripheral"])
+		}
+	})
+
+	t.Run("no next_cursor when fewer than page size rows returned", func(t *testing.T) {
+		store := &stubAlertStore{cursorRows: []alerts.Alert{newAlert("a-1", createdAt)}}
+		h := &api.ListAlertsHandler{Store: store}
+
+		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/alerts", nil), "user-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if _, has := resp["next_cursor"]; has {
+			t.Error("expected no next_cursor for partial page")
+		}
+	})
+
+	t.Run("next_cursor present when exactly page size rows returned", func(t *testing.T) {
+		store := &stubAlertStore{cursorRows: makeFullAlertPage()}
+		h := &api.ListAlertsHandler{Store: store}
+
+		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/alerts", nil), "user-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		if _, has := resp["next_cursor"]; !has {
+			t.Error("expected next_cursor for full page")
+		}
+	})
+
+	t.Run("invalid cursor returns 400", func(t *testing.T) {
+		store := &stubAlertStore{}
+		h := &api.ListAlertsHandler{Store: store}
+
+		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/alerts?cursor=!!invalid!!", nil), "user-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusBadRequest, "invalid_request")
+	})
+
+	t.Run("store error returns 500", func(t *testing.T) {
+		store := &stubAlertStore{cursorErr: errSentinel}
+		h := &api.ListAlertsHandler{Store: store}
+
+		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/alerts", nil), "user-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		assertErrorCode(t, rec, http.StatusInternalServerError, "internal_error")
+	})
+
+	t.Run("returns empty alerts array when no rows", func(t *testing.T) {
+		store := &stubAlertStore{cursorRows: []alerts.Alert{}}
+		h := &api.ListAlertsHandler{Store: store}
+
+		req := withClaims(httptest.NewRequest(http.MethodGet, "/api/alerts", nil), "user-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		var resp map[string]any
+		json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+		rows, ok := resp["alerts"].([]any)
+		if !ok {
+			t.Fatalf("expected alerts array, got %v", resp["alerts"])
+		}
+		if len(rows) != 0 {
+			t.Errorf("expected empty alerts, got %d", len(rows))
+		}
+	})
+}

--- a/internal/api/cursor.go
+++ b/internal/api/cursor.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"time"
+)
+
+// cursorToken is the JSON payload encoded inside the opaque base64url cursor string.
+type cursorToken struct {
+	Timestamp time.Time `json:"ts"`
+	ID        string    `json:"id"`
+}
+
+func encodeCursor(ts time.Time, id string) string {
+	b, _ := json.Marshal(cursorToken{Timestamp: ts, ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeCursor(raw string) (time.Time, string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	var tok cursorToken
+	if err := json.Unmarshal(b, &tok); err != nil {
+		return time.Time{}, "", err
+	}
+	return tok.Timestamp, tok.ID, nil
+}

--- a/internal/api/trigger_events_handler.go
+++ b/internal/api/trigger_events_handler.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -34,29 +32,6 @@ type TriggerEventResponse struct {
 type TriggerEventsPageResponse struct {
 	Events     []TriggerEventResponse `json:"events"`
 	NextCursor *string                `json:"next_cursor,omitempty"`
-}
-
-// cursorToken is the JSON payload encoded inside the base64 cursor string.
-type cursorToken struct {
-	FiredAt time.Time `json:"fired_at"`
-	ID      string    `json:"id"`
-}
-
-func encodeCursor(firedAt time.Time, id string) string {
-	b, _ := json.Marshal(cursorToken{FiredAt: firedAt, ID: id})
-	return base64.RawURLEncoding.EncodeToString(b)
-}
-
-func decodeCursor(raw string) (time.Time, string, error) {
-	b, err := base64.RawURLEncoding.DecodeString(raw)
-	if err != nil {
-		return time.Time{}, "", err
-	}
-	var tok cursorToken
-	if err := json.Unmarshal(b, &tok); err != nil {
-		return time.Time{}, "", err
-	}
-	return tok.FiredAt, tok.ID, nil
 }
 
 func triggerEventResponse(e trigger_events.TriggerEvent) TriggerEventResponse {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/account"
+	"github.com/fishhub-oss/fishhub-server/internal/alerts"
 	"github.com/fishhub-oss/fishhub-server/internal/api"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/device"
@@ -312,6 +313,9 @@ func main() {
 		logger.Warn("redis not configured — jobs will not be enqueued")
 	}
 
+	// ── Alerts store ──────────────────────────────────────────────────────────
+	alertStore := alerts.NewPostgresStore(db)
+
 	// ── MQTT trigger_events subscription ──────────────────────────────────────
 	triggerEventStore := trigger_events.NewStore(db)
 	triggerEventsMQTTHandler := trigger_events.NewMQTTHandler(
@@ -392,6 +396,7 @@ func main() {
 		r.Patch("/api/devices/{id}/triggers/{tid}", (&api.PatchTriggerHandler{Service: triggerSvc}).ServeHTTP)
 		r.Delete("/api/devices/{id}/triggers/{tid}", (&api.DeleteTriggerHandler{Service: triggerSvc}).ServeHTTP)
 		r.Get("/api/devices/{id}/triggers/{tid}/events", (&api.ListTriggerEventsHandler{TriggerStore: triggerStore, EventStore: triggerEventStore}).ServeHTTP)
+		r.Get("/api/alerts", (&api.ListAlertsHandler{Store: alertStore}).ServeHTTP)
 	})
 
 	srv := &http.Server{Addr: ":" + cfg.Port, Handler: r}


### PR DESCRIPTION
## Summary

- Adds `GET /api/alerts` (session auth) returning alerts for the signed-in user, newest first, with keyset cursor pagination matching the trigger-events pattern (opaque base64url token, page size 20, `next_cursor` omitted on last page).
- Server resolves the SenML unit for each alert's `context.peripheral` from an in-memory kind/measurement lookup and injects it as a `unit` field — no DB change required.
- Extracts shared `encodeCursor`/`decodeCursor` helpers into `internal/api/cursor.go`, removing the duplicate from `trigger_events_handler.go`.

## Test plan

- [x] `go test ./...` passes
- [x] Handler tests: happy path with unit resolution, cursor present/absent, invalid cursor → 400, store error → 500, empty page

Closes #130