### PR TITLE
Fix alert action type rejected by trigger validation

### DIFF
--- a/internal/api/trigger_handler.go
+++ b/internal/api/trigger_handler.go
@@ -258,27 +258,43 @@ func (h *DeleteTriggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// validateActions requires at least one action and validates each peripheral_action entry.
+// validateActions requires at least one action and validates each action by type.
 func validateActions(actions []actionRequest) error {
 	if len(actions) == 0 {
 		return errors.New("actions must have at least one entry")
 	}
 	for i, a := range actions {
-		if a.Type != "peripheral_action" {
-			return fmt.Errorf("actions[%d].type must be \"peripheral_action\"", i)
-		}
-		var cfg struct {
-			PeripheralID string `json:"peripheral_id"`
-			Command      string `json:"command"`
-		}
-		if err := json.Unmarshal(a.Config, &cfg); err != nil {
-			return fmt.Errorf("actions[%d].config must be valid JSON", i)
-		}
-		if cfg.PeripheralID == "" {
-			return fmt.Errorf("actions[%d].config.peripheral_id is required", i)
-		}
-		if cfg.Command != "set" && cfg.Command != "set_mode" {
-			return fmt.Errorf("actions[%d].config.command must be \"set\" or \"set_mode\"", i)
+		switch a.Type {
+		case "peripheral_action":
+			var cfg struct {
+				PeripheralID string `json:"peripheral_id"`
+				Command      string `json:"command"`
+			}
+			if err := json.Unmarshal(a.Config, &cfg); err != nil {
+				return fmt.Errorf("actions[%d].config must be valid JSON", i)
+			}
+			if cfg.PeripheralID == "" {
+				return fmt.Errorf("actions[%d].config.peripheral_id is required", i)
+			}
+			if cfg.Command != "set" && cfg.Command != "set_mode" {
+				return fmt.Errorf("actions[%d].config.command must be \"set\" or \"set_mode\"", i)
+			}
+		case "alert":
+			var cfg struct {
+				Severity        string `json:"severity"`
+				MessageTemplate string `json:"message_template"`
+			}
+			if err := json.Unmarshal(a.Config, &cfg); err != nil {
+				return fmt.Errorf("actions[%d].config must be valid JSON", i)
+			}
+			if cfg.Severity != "info" && cfg.Severity != "warning" && cfg.Severity != "critical" {
+				return fmt.Errorf("actions[%d].config.severity must be \"info\", \"warning\", or \"critical\"", i)
+			}
+			if cfg.MessageTemplate == "" {
+				return fmt.Errorf("actions[%d].config.message_template is required", i)
+			}
+		default:
+			return fmt.Errorf("actions[%d].type %q is not supported", i, a.Type)
 		}
 	}
 	return nil

--- a/internal/trigger/service.go
+++ b/internal/trigger/service.go
@@ -64,6 +64,9 @@ func (s *Service) Create(ctx context.Context, deviceID, userID string, p Trigger
 	defer tx.Rollback()
 
 	for i, a := range p.Actions {
+		if a.Type != "peripheral_action" {
+			continue
+		}
 		kindPin, err := s.validatePeripheralAction(ctx, tx, deviceID, userID, a)
 		if err != nil {
 			return Trigger{}, err
@@ -193,6 +196,10 @@ func (s *Service) applyPatch(ctx context.Context, tx *sql.Tx, deviceID, userID s
 	if patch.Actions != nil {
 		resolved := make([]Action, len(patch.Actions))
 		for i, a := range patch.Actions {
+			if a.Type != "peripheral_action" {
+				resolved[i] = a
+				continue
+			}
 			kindPin, err := s.validatePeripheralAction(ctx, tx, deviceID, userID, a)
 			if err != nil {
 				return TriggerUpdate{}, err


### PR DESCRIPTION
## Problem

Two bugs prevented `alert` actions from being accepted by the API:

1. `validateActions` in `trigger_handler.go` hard-coded `peripheral_action` as the only valid type, returning `actions[0].type must be "peripheral_action"` for any other value.
2. `Create` and `applyPatch` in `service.go` called `validatePeripheralAction` on every action unconditionally — so even if the handler check were bypassed, `alert` actions would fail peripheral resolution.

## Fix

- `validateActions` now dispatches per type: `peripheral_action` validates `peripheral_id` and `command` as before; `alert` validates `severity` (must be `info`, `warning`, or `critical`) and `message_template` (required); any unknown type returns an unsupported error.
- In `Create` and `applyPatch`, peripheral validation and config rewriting are skipped for non-`peripheral_action` entries.