### PR TITLE
Fix timezone validation failing on Railway

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/fishhub-oss/fishhub-server/internal/account"
 	"github.com/fishhub-oss/fishhub-server/internal/alerts"


### PR DESCRIPTION
## Problem

`time.LoadLocation` looks up timezones from the host OS (`/usr/share/zoneinfo` or equivalent). The minimal Docker image used on Railway doesn't ship that database, so any call to `LoadLocation` with a non-UTC zone returns an error — causing timezone validation in the account service to always fail in staging.

## Fix

Add `_ "time/tzdata"` to `main.go`. This embeds the full IANA timezone database directly into the binary at compile time, making it available on any host regardless of what's installed on the OS.

One-line change, no behaviour difference locally (where the OS tzdata is present), fixes the failure on Railway.