### PR TITLE
Add EMQX broker support alongside HiveMQ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,30 @@ CORS_ALLOWED_ORIGINS=http://localhost:3001
 GOOGLE_CLIENT_ID=
 JWT_SECRET=change-me-to-a-random-32-plus-byte-secret
 JWT_TTL_HOURS=24
+
+
+
+######## MQTT broker selector
+# Set to "hivemq" (default) or "emqx"
+MQTT_BROKER=hivemq
+
+######## HiveMQ Cloud (used when MQTT_BROKER=hivemq)
+# HIVEMQ_API_BASE_URL=
+# HIVEMQ_API_TOKEN=
+# HIVEMQ_DEVICE_ROLE_ID=
+# HIVEMQ_HOST=
+# HIVEMQ_PORT=8883
+# HIVEMQ_SERVER_USERNAME=
+# HIVEMQ_SERVER_PASSWORD=
+
+######## EMQX self-hosted on Railway (used when MQTT_BROKER=emqx)
+# EMQX_API_BASE_URL=http://emqx.railway.internal:18083
+# EMQX_API_KEY=admin
+# EMQX_API_SECRET=
+# EMQX_AUTH_ID=password_based:built_in_database
+# EMQX_HOST=emqx.railway.internal        # server connects via private network
+# EMQX_PORT=1883
+# EMQX_DEVICE_HOST=                      # returned to firmware (public TLS domain)
+# EMQX_DEVICE_PORT=8883
+# EMQX_SERVER_USERNAME=server
+# EMQX_SERVER_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /app/fishhub-server .
+RUN go build -o /app/fishhub-server . && \
+    go build -o /app/fishhub-worker ./cmd/worker
 
 FROM alpine:3.21
 
 WORKDIR /app
 COPY --from=builder /app/fishhub-server .
+COPY --from=builder /app/fishhub-worker .
 COPY --from=builder /src/db/migrations ./db/migrations
 
 CMD ["/app/fishhub-server"]

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -52,8 +52,14 @@ func main() {
 	triggerStore := trigger.NewStore(db)
 	processor := alert.NewProcessor(alertStore, triggerStore)
 
+	redisOpt, err := asynq.ParseRedisURI(redisURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid REDIS_URL: %v\n", err)
+		os.Exit(1)
+	}
+
 	srv := asynq.NewServer(
-		asynq.RedisClientOpt{Addr: redisURL},
+		redisOpt,
 		asynq.Config{
 			Queues: map[string]int{"trigger-actions": 1},
 			Logger: &asynqLogger{logger},

--- a/db/migrations/025_rename_hivemq_outbox_event.down.sql
+++ b/db/migrations/025_rename_hivemq_outbox_event.down.sql
@@ -1,0 +1,4 @@
+UPDATE outbox_events
+SET event_type = 'hivemq.provision_device'
+WHERE event_type = 'mqtt.provision_device'
+  AND status != 'completed';

--- a/db/migrations/025_rename_hivemq_outbox_event.up.sql
+++ b/db/migrations/025_rename_hivemq_outbox_event.up.sql
@@ -1,0 +1,4 @@
+UPDATE outbox_events
+SET event_type = 'mqtt.provision_device'
+WHERE event_type = 'hivemq.provision_device'
+  AND status != 'completed';

--- a/internal/device/service.go
+++ b/internal/device/service.go
@@ -9,23 +9,23 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
+	"github.com/fishhub-oss/fishhub-server/internal/mqttbroker"
 )
 
 // Service orchestrates multi-step device operations.
 type Service struct {
-	store     Store
-	hiveMQ    hivemq.Client
-	publisher mqtt.Publisher
-	logger    *slog.Logger
+	store       Store
+	provisioner mqttbroker.Provisioner
+	publisher   mqtt.Publisher
+	logger      *slog.Logger
 }
 
-func NewService(store Store, hiveMQ hivemq.Client, publisher mqtt.Publisher, logger *slog.Logger) *Service {
+func NewService(store Store, provisioner mqttbroker.Provisioner, publisher mqtt.Publisher, logger *slog.Logger) *Service {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Service{store: store, hiveMQ: hiveMQ, publisher: publisher, logger: logger}
+	return &Service{store: store, provisioner: provisioner, publisher: publisher, logger: logger}
 }
 
 // Delete soft-deletes the device and revokes its MQTT credentials.
@@ -39,8 +39,8 @@ func (s *Service) Delete(ctx context.Context, deviceID, userID string) error {
 		return err
 	}
 	if mqttUsername != "" {
-		if err := s.hiveMQ.DeleteDevice(ctx, mqttUsername); err != nil {
-			s.logger.Warn("hivemq delete device", "device_id", deviceID, "error", err)
+		if err := s.provisioner.DeleteDevice(ctx, mqttUsername); err != nil {
+			s.logger.Warn("mqtt broker delete device", "device_id", deviceID, "error", err)
 		}
 	}
 	return nil

--- a/internal/emqx/client.go
+++ b/internal/emqx/client.go
@@ -1,0 +1,88 @@
+package emqx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fishhub-oss/fishhub-server/internal/mqttbroker"
+)
+
+var _ mqttbroker.Provisioner = (*apiClient)(nil)
+var _ mqttbroker.Provisioner = (*noopClient)(nil)
+
+type apiClient struct {
+	baseURL string
+	authID  string
+	http    *http.Client
+	key     string
+	secret  string
+}
+
+// NewAPIClient returns a Provisioner that manages credentials via the EMQX v5 REST API.
+// key and secret are the EMQX admin credentials (HTTP Basic auth).
+// authID is the authentication resource ID (e.g. "password_based:built_in_database").
+func NewAPIClient(baseURL, key, secret, authID string) mqttbroker.Provisioner {
+	return &apiClient{
+		baseURL: baseURL,
+		authID:  authID,
+		key:     key,
+		secret:  secret,
+		http:    &http.Client{},
+	}
+}
+
+func (c *apiClient) ProvisionDevice(ctx context.Context, username, password string) error {
+	body, _ := json.Marshal(map[string]string{
+		"user_id":  username,
+		"password": password,
+	})
+	path := fmt.Sprintf("/api/v5/authentication/%s/users", c.authID)
+	if err := c.do(ctx, http.MethodPost, path, body); err != nil {
+		return fmt.Errorf("emqx: create credential: %w", err)
+	}
+	return nil
+}
+
+func (c *apiClient) DeleteDevice(ctx context.Context, username string) error {
+	path := fmt.Sprintf("/api/v5/authentication/%s/users/%s", c.authID, username)
+	if err := c.do(ctx, http.MethodDelete, path, nil); err != nil {
+		return fmt.Errorf("emqx: delete credential: %w", err)
+	}
+	return nil
+}
+
+func (c *apiClient) do(ctx context.Context, method, path string, body []byte) error {
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(body))
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	}
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(c.key, c.secret)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// noopClient is returned when EMQX is not configured.
+type noopClient struct{}
+
+func NewNoOp() mqttbroker.Provisioner                                          { return &noopClient{} }
+func (n *noopClient) ProvisionDevice(_ context.Context, _, _ string) error    { return nil }
+func (n *noopClient) DeleteDevice(_ context.Context, _ string) error          { return nil }

--- a/internal/hivemq/client.go
+++ b/internal/hivemq/client.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/fishhub-oss/fishhub-server/internal/mqttbroker"
 )
 
-// Client provisions and removes per-device MQTT credentials in HiveMQ Cloud.
-type Client interface {
-	ProvisionDevice(ctx context.Context, username, password string) error
-	DeleteDevice(ctx context.Context, username string) error
-}
+// Ensure apiClient and noopClient implement mqttbroker.Provisioner.
+var _ mqttbroker.Provisioner = (*apiClient)(nil)
+var _ mqttbroker.Provisioner = (*noopClient)(nil)
 
 type apiClient struct {
 	baseURL      string
@@ -21,8 +21,8 @@ type apiClient struct {
 	http         *http.Client
 }
 
-// NewAPIClient returns a Client that calls the HiveMQ Cloud REST API.
-func NewAPIClient(baseURL, apiToken, deviceRoleID string) Client {
+// NewAPIClient returns a Provisioner that calls the HiveMQ Cloud REST API.
+func NewAPIClient(baseURL, apiToken, deviceRoleID string) mqttbroker.Provisioner {
 	return &apiClient{
 		baseURL:      baseURL,
 		apiToken:     apiToken,
@@ -92,6 +92,6 @@ func (c *apiClient) do(ctx context.Context, method, path string, body []byte) er
 // noopClient is returned when HIVEMQ_API_BASE_URL is not configured.
 type noopClient struct{}
 
-func NewNoOp() Client                                                          { return &noopClient{} }
+func NewNoOp() mqttbroker.Provisioner                                          { return &noopClient{} }
 func (n *noopClient) ProvisionDevice(_ context.Context, _, _ string) error    { return nil }
 func (n *noopClient) DeleteDevice(_ context.Context, _ string) error          { return nil }

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -21,13 +21,19 @@ type pahoPublisher struct {
 	client paho.Client
 }
 
-// NewPublisher connects to the HiveMQ broker with the given server credentials and returns a Publisher.
-func NewPublisher(host string, port int, username, password string, logger *slog.Logger) (Publisher, error) {
+// NewPublisher connects to the MQTT broker with the given server credentials and returns a Publisher.
+// Set useTLS=true for brokers that require TLS (e.g. HiveMQ Cloud on 8883);
+// set useTLS=false for plain TCP connections (e.g. EMQX on the private Railway network).
+func NewPublisher(host string, port int, username, password string, useTLS bool, logger *slog.Logger) (Publisher, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	scheme := "tcp"
+	if useTLS {
+		scheme = "tls"
+	}
 	opts := paho.NewClientOptions().
-		AddBroker(fmt.Sprintf("tls://%s:%d", host, port)).
+		AddBroker(fmt.Sprintf("%s://%s:%d", scheme, host, port)).
 		SetClientID("fishhub-server").
 		SetUsername(username).
 		SetPassword(password).

--- a/internal/mqtt/subscriber.go
+++ b/internal/mqtt/subscriber.go
@@ -22,15 +22,21 @@ type pahoSubscriber struct {
 	client paho.Client
 }
 
-// NewSubscriber connects to the HiveMQ broker and returns a Subscriber.
+// NewSubscriber connects to the MQTT broker and returns a Subscriber.
 // Uses a separate client ID from the publisher so both can coexist.
 // CleanSession(false) ensures the subscription survives reconnects.
-func NewSubscriber(host string, port int, username, password string, logger *slog.Logger) (Subscriber, error) {
+// Set useTLS=true for brokers that require TLS (e.g. HiveMQ Cloud on 8883);
+// set useTLS=false for plain TCP connections (e.g. EMQX on the private Railway network).
+func NewSubscriber(host string, port int, username, password string, useTLS bool, logger *slog.Logger) (Subscriber, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	scheme := "tcp"
+	if useTLS {
+		scheme = "tls"
+	}
 	opts := paho.NewClientOptions().
-		AddBroker(fmt.Sprintf("tls://%s:%d", host, port)).
+		AddBroker(fmt.Sprintf("%s://%s:%d", scheme, host, port)).
 		SetClientID("fishhub-server-sub").
 		SetUsername(username).
 		SetPassword(password).

--- a/internal/mqttbroker/provisioner.go
+++ b/internal/mqttbroker/provisioner.go
@@ -1,0 +1,9 @@
+package mqttbroker
+
+import "context"
+
+// Provisioner manages per-device MQTT credentials on a broker.
+type Provisioner interface {
+	ProvisionDevice(ctx context.Context, username, password string) error
+	DeleteDevice(ctx context.Context, username string) error
+}

--- a/internal/provisioning/activation.go
+++ b/internal/provisioning/activation.go
@@ -99,13 +99,13 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 		return ActivationResult{}, fmt.Errorf("activate device: %w", err)
 	}
 
-	if err := s.outboxStore.Insert(ctx, tx, EventTypeHiveMQProvision, HiveMQProvisionPayload{
+	if err := s.outboxStore.Insert(ctx, tx, EventTypeMQTTProvision, MQTTProvisionPayload{
 		DeviceID: deviceID,
 		Username: mqttUsername,
 		Password: mqttPassword,
-	}, hiveMQProvisionClaimTimeoutSeconds); err != nil {
-		s.logger.Error("activate: enqueue hivemq provision", "device_id", deviceID, "error", err)
-		return ActivationResult{}, fmt.Errorf("enqueue hivemq provision: %w", err)
+	}, mqttProvisionClaimTimeoutSeconds); err != nil {
+		s.logger.Error("activate: enqueue mqtt provision", "device_id", deviceID, "error", err)
+		return ActivationResult{}, fmt.Errorf("enqueue mqtt provision: %w", err)
 	}
 
 	if err := s.outboxStore.Insert(ctx, tx, eventTypeDeviceConfigPush, deviceConfigPushPayload{

--- a/internal/provisioning/outbox_processor.go
+++ b/internal/provisioning/outbox_processor.go
@@ -7,12 +7,12 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
+	"github.com/fishhub-oss/fishhub-server/internal/mqttbroker"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 )
 
-const EventTypeHiveMQProvision = "hivemq.provision_device"
-const hiveMQProvisionClaimTimeoutSeconds = 30
+const EventTypeMQTTProvision = "mqtt.provision_device"
+const mqttProvisionClaimTimeoutSeconds = 30
 
 // eventTypeDeviceConfigPush and its payload are defined here for use by
 // ActivationService. The account package defines its own copy of these for
@@ -25,39 +25,39 @@ type deviceConfigPushPayload struct {
 	Timezone string `json:"timezone"`
 }
 
-type HiveMQProvisionPayload struct {
+type MQTTProvisionPayload struct {
 	DeviceID string `json:"device_id"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
 
-type HiveMQProvisionProcessor struct {
-	hiveMQ hivemq.Client
-	logger *slog.Logger
+type MQTTProvisionProcessor struct {
+	provisioner mqttbroker.Provisioner
+	logger      *slog.Logger
 }
 
-func NewHiveMQProvisionProcessor(hiveMQ hivemq.Client, logger *slog.Logger) *HiveMQProvisionProcessor {
-	return &HiveMQProvisionProcessor{hiveMQ: hiveMQ, logger: logger}
+func NewMQTTProvisionProcessor(provisioner mqttbroker.Provisioner, logger *slog.Logger) *MQTTProvisionProcessor {
+	return &MQTTProvisionProcessor{provisioner: provisioner, logger: logger}
 }
 
-func (p *HiveMQProvisionProcessor) EventType() string { return EventTypeHiveMQProvision }
+func (p *MQTTProvisionProcessor) EventType() string { return EventTypeMQTTProvision }
 
-func (p *HiveMQProvisionProcessor) Process(ctx context.Context, event outbox.Event) error {
-	var payload HiveMQProvisionPayload
+func (p *MQTTProvisionProcessor) Process(ctx context.Context, event outbox.Event) error {
+	var payload MQTTProvisionPayload
 	if err := json.Unmarshal(event.Payload, &payload); err != nil {
 		return fmt.Errorf("unmarshal payload: %w", err)
 	}
 
-	err := p.hiveMQ.ProvisionDevice(ctx, payload.Username, payload.Password)
+	err := p.provisioner.ProvisionDevice(ctx, payload.Username, payload.Password)
 	if err != nil && isAlreadyExists(err) {
-		p.logger.Info("hivemq provision: credential already exists, treating as success",
+		p.logger.Info("mqtt provision: credential already exists, treating as success",
 			"device_id", payload.DeviceID)
 		return nil
 	}
 	return err
 }
 
-// isAlreadyExists reports whether the HiveMQ API error indicates the credential
+// isAlreadyExists reports whether the broker API error indicates the credential
 // already exists (HTTP 409 Conflict).
 func isAlreadyExists(err error) bool {
 	if err == nil {

--- a/internal/provisioning/outbox_processor_test.go
+++ b/internal/provisioning/outbox_processor_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
 )
 
-type stubHiveMQClient struct{ err error }
+type stubProvisioner struct{ err error }
 
-func (s *stubHiveMQClient) ProvisionDevice(_ context.Context, _, _ string) error { return s.err }
-func (s *stubHiveMQClient) DeleteDevice(_ context.Context, _ string) error        { return s.err }
+func (s *stubProvisioner) ProvisionDevice(_ context.Context, _, _ string) error { return s.err }
+func (s *stubProvisioner) DeleteDevice(_ context.Context, _ string) error        { return s.err }
 
 var errSentinel = errNew("store error")
 
@@ -24,11 +24,10 @@ type sentinelError struct{ msg string }
 
 func (e *sentinelError) Error() string { return e.msg }
 
-func TestHiveMQProvisionProcessor_HappyPath(t *testing.T) {
-	client := &stubHiveMQClient{}
-	proc := provisioning.NewHiveMQProvisionProcessor(client, discardLogger)
+func TestMQTTProvisionProcessor_HappyPath(t *testing.T) {
+	proc := provisioning.NewMQTTProvisionProcessor(&stubProvisioner{}, discardLogger)
 
-	payload, _ := json.Marshal(provisioning.HiveMQProvisionPayload{
+	payload, _ := json.Marshal(provisioning.MQTTProvisionPayload{
 		DeviceID: "dev-1",
 		Username: "dev-1",
 		Password: "secret",
@@ -39,11 +38,10 @@ func TestHiveMQProvisionProcessor_HappyPath(t *testing.T) {
 	}
 }
 
-func TestHiveMQProvisionProcessor_AlreadyExists(t *testing.T) {
-	client := &stubHiveMQClient{err: &sentinelError{msg: "409 conflict"}}
-	proc := provisioning.NewHiveMQProvisionProcessor(client, discardLogger)
+func TestMQTTProvisionProcessor_AlreadyExists(t *testing.T) {
+	proc := provisioning.NewMQTTProvisionProcessor(&stubProvisioner{err: &sentinelError{msg: "409 conflict"}}, discardLogger)
 
-	payload, _ := json.Marshal(provisioning.HiveMQProvisionPayload{
+	payload, _ := json.Marshal(provisioning.MQTTProvisionPayload{
 		DeviceID: "dev-1",
 		Username: "dev-1",
 		Password: "secret",
@@ -54,9 +52,9 @@ func TestHiveMQProvisionProcessor_AlreadyExists(t *testing.T) {
 	}
 }
 
-func TestHiveMQProvisionProcessor_EventType(t *testing.T) {
-	proc := provisioning.NewHiveMQProvisionProcessor(&stubHiveMQClient{}, discardLogger)
-	if proc.EventType() != provisioning.EventTypeHiveMQProvision {
+func TestMQTTProvisionProcessor_EventType(t *testing.T) {
+	proc := provisioning.NewMQTTProvisionProcessor(&stubProvisioner{}, discardLogger)
+	if proc.EventType() != provisioning.EventTypeMQTTProvision {
 		t.Errorf("unexpected event type: %q", proc.EventType())
 	}
 }

--- a/internal/queue/asynq/queue.go
+++ b/internal/queue/asynq/queue.go
@@ -13,8 +13,12 @@ type Queue struct {
 }
 
 func NewQueue(redisURL string) *Queue {
+	opt, err := asynq.ParseRedisURI(redisURL)
+	if err != nil {
+		panic(fmt.Sprintf("asynq: invalid redis URL: %v", err))
+	}
 	return &Queue{
-		client: asynq.NewClient(asynq.RedisClientOpt{Addr: redisURL}),
+		client: asynq.NewClient(opt),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -299,6 +299,7 @@ func main() {
 	var mqttHost string
 	var mqttPort int
 	var mqttUser, mqttPass string
+	var mqttUseTLS bool
 	var deviceMQTTHost string
 	var deviceMQTTPort int
 
@@ -313,6 +314,7 @@ func main() {
 		}
 		mqttHost, mqttPort = cfg.EMQXHost, cfg.EMQXPort
 		mqttUser, mqttPass = cfg.EMQXServerUser, cfg.EMQXServerPass
+		mqttUseTLS = false // plain TCP over private Railway network
 		deviceMQTTHost, deviceMQTTPort = cfg.EMQXDeviceHost, cfg.EMQXDevicePort
 	default: // "hivemq"
 		if cfg.HiveMQBaseURL != "" {
@@ -324,21 +326,22 @@ func main() {
 		}
 		mqttHost, mqttPort = cfg.HiveMQHost, cfg.HiveMQPort
 		mqttUser, mqttPass = cfg.HiveMQServerUser, cfg.HiveMQServerPass
+		mqttUseTLS = true // HiveMQ Cloud requires TLS
 		deviceMQTTHost, deviceMQTTPort = cfg.HiveMQHost, cfg.HiveMQPort
 	}
 
 	var mqttPublisher mqtt.Publisher = mqtt.NewNoOpPublisher()
 	var mqttSubscriber mqtt.Subscriber = mqtt.NewNoOpSubscriber()
 	if mqttHost != "" {
-		p, err := mqtt.NewPublisher(mqttHost, mqttPort, mqttUser, mqttPass, logger)
+		p, err := mqtt.NewPublisher(mqttHost, mqttPort, mqttUser, mqttPass, mqttUseTLS, logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mqtt init: %v\n", err)
 			os.Exit(1)
 		}
 		mqttPublisher = p
-		logger.Info("mqtt publisher configured", "host", mqttHost, "broker", cfg.MQTTBroker)
+		logger.Info("mqtt publisher configured", "host", mqttHost, "broker", cfg.MQTTBroker, "tls", mqttUseTLS)
 
-		sub, err := mqtt.NewSubscriber(mqttHost, mqttPort, mqttUser, mqttPass, logger)
+		sub, err := mqtt.NewSubscriber(mqttHost, mqttPort, mqttUser, mqttPass, mqttUseTLS, logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mqtt subscriber init: %v\n", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -19,10 +19,12 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/device"
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
+	"github.com/fishhub-oss/fishhub-server/internal/emqx"
 	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
+	"github.com/fishhub-oss/fishhub-server/internal/mqttbroker"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
@@ -102,6 +104,7 @@ type config struct {
 	DeviceJWTPEMKey    string
 	DeviceJWTKID       string
 	IDPHost            string
+	// HiveMQ
 	HiveMQBaseURL      string
 	HiveMQAPIToken     string
 	HiveMQRoleID       string
@@ -109,8 +112,21 @@ type config struct {
 	HiveMQPort         int
 	HiveMQServerUser   string
 	HiveMQServerPass   string
-	CORSOrigins        []string
-	RedisURL           string
+	// EMQX
+	EMQXAPIBaseURL   string
+	EMQXAPIKey       string
+	EMQXAPISecret    string
+	EMQXAuthID       string
+	EMQXHost         string
+	EMQXPort         int
+	EMQXDeviceHost   string
+	EMQXDevicePort   int
+	EMQXServerUser   string
+	EMQXServerPass   string
+	// Broker selector
+	MQTTBroker       string // "hivemq" (default) or "emqx"
+	CORSOrigins      []string
+	RedisURL         string
 }
 
 func loadConfig() config {
@@ -126,6 +142,20 @@ func loadConfig() config {
 		hivemqPort = 8883
 	}
 
+	emqxPort, _ := strconv.Atoi(os.Getenv("EMQX_PORT"))
+	if emqxPort == 0 {
+		emqxPort = 1883
+	}
+	emqxDevicePort, _ := strconv.Atoi(os.Getenv("EMQX_DEVICE_PORT"))
+	if emqxDevicePort == 0 {
+		emqxDevicePort = 8883
+	}
+
+	mqttBroker := os.Getenv("MQTT_BROKER")
+	if mqttBroker == "" {
+		mqttBroker = "hivemq"
+	}
+
 	corsOrigins := []string{"http://localhost:3001"}
 	if v := os.Getenv("CORS_ALLOWED_ORIGINS"); v != "" {
 		corsOrigins = strings.Split(v, ",")
@@ -139,20 +169,31 @@ func loadConfig() config {
 		JWTTTLHours:        jwtTTLHours,
 		GoogleClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		InfluxHost:         os.Getenv("INFLUXDB3_HOST"),
-		InfluxToken:      os.Getenv("INFLUXDB3_TOKEN"),
-		InfluxDatabase:   os.Getenv("INFLUXDB3_DATABASE"),
-		DeviceJWTPEMKey:  strings.ReplaceAll(os.Getenv("DEVICE_JWT_PRIVATE_KEY"), `\n`, "\n"),
-		DeviceJWTKID:     os.Getenv("DEVICE_JWT_KID"),
-		IDPHost:          os.Getenv("IDP_HOST"),
-		HiveMQBaseURL:    os.Getenv("HIVEMQ_API_BASE_URL"),
-		HiveMQAPIToken:   os.Getenv("HIVEMQ_API_TOKEN"),
-		HiveMQRoleID:     os.Getenv("HIVEMQ_DEVICE_ROLE_ID"),
-		HiveMQHost:       os.Getenv("HIVEMQ_HOST"),
-		HiveMQPort:       hivemqPort,
-		HiveMQServerUser: os.Getenv("HIVEMQ_SERVER_USERNAME"),
-		HiveMQServerPass: os.Getenv("HIVEMQ_SERVER_PASSWORD"),
-		CORSOrigins:      corsOrigins,
-		RedisURL:         os.Getenv("REDIS_URL"),
+		InfluxToken:        os.Getenv("INFLUXDB3_TOKEN"),
+		InfluxDatabase:     os.Getenv("INFLUXDB3_DATABASE"),
+		DeviceJWTPEMKey:    strings.ReplaceAll(os.Getenv("DEVICE_JWT_PRIVATE_KEY"), `\n`, "\n"),
+		DeviceJWTKID:       os.Getenv("DEVICE_JWT_KID"),
+		IDPHost:            os.Getenv("IDP_HOST"),
+		HiveMQBaseURL:      os.Getenv("HIVEMQ_API_BASE_URL"),
+		HiveMQAPIToken:     os.Getenv("HIVEMQ_API_TOKEN"),
+		HiveMQRoleID:       os.Getenv("HIVEMQ_DEVICE_ROLE_ID"),
+		HiveMQHost:         os.Getenv("HIVEMQ_HOST"),
+		HiveMQPort:         hivemqPort,
+		HiveMQServerUser:   os.Getenv("HIVEMQ_SERVER_USERNAME"),
+		HiveMQServerPass:   os.Getenv("HIVEMQ_SERVER_PASSWORD"),
+		EMQXAPIBaseURL:     os.Getenv("EMQX_API_BASE_URL"),
+		EMQXAPIKey:         os.Getenv("EMQX_API_KEY"),
+		EMQXAPISecret:      os.Getenv("EMQX_API_SECRET"),
+		EMQXAuthID:         os.Getenv("EMQX_AUTH_ID"),
+		EMQXHost:           os.Getenv("EMQX_HOST"),
+		EMQXPort:           emqxPort,
+		EMQXDeviceHost:     os.Getenv("EMQX_DEVICE_HOST"),
+		EMQXDevicePort:     emqxDevicePort,
+		EMQXServerUser:     os.Getenv("EMQX_SERVER_USERNAME"),
+		EMQXServerPass:     os.Getenv("EMQX_SERVER_PASSWORD"),
+		MQTTBroker:         mqttBroker,
+		CORSOrigins:        corsOrigins,
+		RedisURL:           os.Getenv("REDIS_URL"),
 	}
 }
 
@@ -253,35 +294,58 @@ func main() {
 		logger.Warn("device jwt not configured — tokens will not be issued at activation")
 	}
 
-	// ── HiveMQ ────────────────────────────────────────────────────────────────
-	hivemqClient := hivemq.Client(hivemq.NewNoOp())
-	if cfg.HiveMQBaseURL != "" {
-		hivemqClient = hivemq.NewAPIClient(cfg.HiveMQBaseURL, cfg.HiveMQAPIToken, cfg.HiveMQRoleID)
-		logger.Info("hivemq api configured", "base_url", cfg.HiveMQBaseURL)
-	} else {
-		logger.Warn("hivemq api not configured — mqtt credentials will not be provisioned at activation")
+	// ── MQTT broker provisioner + connection ──────────────────────────────────
+	var brokerProvisioner mqttbroker.Provisioner
+	var mqttHost string
+	var mqttPort int
+	var mqttUser, mqttPass string
+	var deviceMQTTHost string
+	var deviceMQTTPort int
+
+	switch cfg.MQTTBroker {
+	case "emqx":
+		if cfg.EMQXAPIBaseURL != "" {
+			brokerProvisioner = emqx.NewAPIClient(cfg.EMQXAPIBaseURL, cfg.EMQXAPIKey, cfg.EMQXAPISecret, cfg.EMQXAuthID)
+			logger.Info("emqx api configured", "base_url", cfg.EMQXAPIBaseURL)
+		} else {
+			brokerProvisioner = emqx.NewNoOp()
+			logger.Warn("emqx api not configured — mqtt credentials will not be provisioned at activation")
+		}
+		mqttHost, mqttPort = cfg.EMQXHost, cfg.EMQXPort
+		mqttUser, mqttPass = cfg.EMQXServerUser, cfg.EMQXServerPass
+		deviceMQTTHost, deviceMQTTPort = cfg.EMQXDeviceHost, cfg.EMQXDevicePort
+	default: // "hivemq"
+		if cfg.HiveMQBaseURL != "" {
+			brokerProvisioner = hivemq.NewAPIClient(cfg.HiveMQBaseURL, cfg.HiveMQAPIToken, cfg.HiveMQRoleID)
+			logger.Info("hivemq api configured", "base_url", cfg.HiveMQBaseURL)
+		} else {
+			brokerProvisioner = hivemq.NewNoOp()
+			logger.Warn("hivemq api not configured — mqtt credentials will not be provisioned at activation")
+		}
+		mqttHost, mqttPort = cfg.HiveMQHost, cfg.HiveMQPort
+		mqttUser, mqttPass = cfg.HiveMQServerUser, cfg.HiveMQServerPass
+		deviceMQTTHost, deviceMQTTPort = cfg.HiveMQHost, cfg.HiveMQPort
 	}
 
-	// ── MQTT publisher + subscriber ───────────────────────────────────────────
 	var mqttPublisher mqtt.Publisher = mqtt.NewNoOpPublisher()
 	var mqttSubscriber mqtt.Subscriber = mqtt.NewNoOpSubscriber()
-	if cfg.HiveMQHost != "" {
-		p, err := mqtt.NewPublisher(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass, logger)
+	if mqttHost != "" {
+		p, err := mqtt.NewPublisher(mqttHost, mqttPort, mqttUser, mqttPass, logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mqtt init: %v\n", err)
 			os.Exit(1)
 		}
 		mqttPublisher = p
-		logger.Info("mqtt publisher configured", "host", cfg.HiveMQHost)
+		logger.Info("mqtt publisher configured", "host", mqttHost, "broker", cfg.MQTTBroker)
 
-		sub, err := mqtt.NewSubscriber(cfg.HiveMQHost, cfg.HiveMQPort, cfg.HiveMQServerUser, cfg.HiveMQServerPass, logger)
+		sub, err := mqtt.NewSubscriber(mqttHost, mqttPort, mqttUser, mqttPass, logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mqtt subscriber init: %v\n", err)
 			os.Exit(1)
 		}
 		mqttSubscriber = sub
 	} else {
-		logger.Warn("mqtt publishing disabled — HIVEMQ_HOST not set")
+		logger.Warn("mqtt publishing disabled — broker host not set", "broker", cfg.MQTTBroker)
 	}
 
 	// ── Stores & services ─────────────────────────────────────────────────────
@@ -291,7 +355,7 @@ func main() {
 	provisioningStore := provisioning.NewStore(db)
 	outboxStore := outbox.NewPostgresStore(db)
 	readingsSvc := measurement.NewReadingsService(deviceFinderBridge{deviceStore}, influxClient, influxClient, logger)
-	deviceSvc := device.NewService(deviceStore, hivemqClient, mqttPublisher, logger)
+	deviceSvc := device.NewService(deviceStore, brokerProvisioner, mqttPublisher, logger)
 	peripheralSvc := peripheral.NewService(db, peripheralStore, outboxStore, influxClient, mqttPublisher, logger)
 	triggerSvc := trigger.NewService(db, triggerStore, outboxStore, logger)
 	provisioningSvc := provisioning.NewService(provisioningStore, logger)
@@ -333,7 +397,7 @@ func main() {
 	outboxRunner := outbox.NewRunner(
 		outboxStore,
 		[]outbox.EventProcessor{
-			provisioning.NewHiveMQProvisionProcessor(hivemqClient, logger),
+			provisioning.NewMQTTProvisionProcessor(brokerProvisioner, logger),
 			peripheral.NewPeripheralPushProcessor(mqttPublisher, logger),
 			account.NewConfigPushProcessor(mqttPublisher, logger),
 			trigger.NewTriggerPushProcessor(mqttPublisher, logger),
@@ -365,8 +429,8 @@ func main() {
 		r.Use(platform.DeviceAuthenticator(deviceSigner))
 		r.Get("/devices/{id}/status", (&api.ActivationStatusHandler{
 			Store:    deviceStore,
-			MQTTHost: cfg.HiveMQHost,
-			MQTTPort: cfg.HiveMQPort,
+			MQTTHost: deviceMQTTHost,
+			MQTTPort: deviceMQTTPort,
 		}).ServeHTTP)
 	})
 


### PR DESCRIPTION
## Summary

- Introduces a broker-neutral `mqttbroker.Provisioner` interface extracted from `hivemq.Client`, implemented by both `internal/hivemq` and the new `internal/emqx` package
- `MQTT_BROKER=emqx` switches to self-hosted EMQX (Railway); defaults to `hivemq` — no breaking change for existing deployments
- Renames outbox event type `hivemq.provision_device` → `mqtt.provision_device` with a migration for in-flight rows
- Separate `EMQX_DEVICE_HOST`/`EMQX_DEVICE_PORT` vars for what the firmware receives, since the server connects internally (`emqx.railway.internal:1883`) while devices connect over TLS via the public Railway domain

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] Deploy with `MQTT_BROKER=emqx` and provision a new device — confirm MQTT credentials created in EMQX
- [ ] Delete a device — confirm credentials removed from EMQX
- [ ] Deploy with `MQTT_BROKER=hivemq` (or unset) — confirm HiveMQ behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)