### PR TITLE
Add device model and port-based peripheral registration

### DIFF
--- a/db/migrations/026_create_device_models.down.sql
+++ b/db/migrations/026_create_device_models.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS device_model_ports;
+DROP TABLE IF EXISTS device_models;

--- a/db/migrations/026_create_device_models.up.sql
+++ b/db/migrations/026_create_device_models.up.sql
@@ -1,0 +1,40 @@
+CREATE TABLE device_models (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug       VARCHAR(64)  NOT NULL UNIQUE,
+    name       VARCHAR(128) NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE TABLE device_model_ports (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    model_id   UUID        NOT NULL REFERENCES device_models(id),
+    kind       VARCHAR(32) NOT NULL,
+    label      VARCHAR(32) NOT NULL,
+    pin        INT         NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (model_id, pin),
+    UNIQUE (model_id, kind, label)
+);
+
+-- Seed fishhub-v1
+INSERT INTO device_models (slug, name)
+VALUES ('fishhub-v1', 'FishHub v1')
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO device_model_ports (model_id, kind, label, pin)
+SELECT m.id, v.kind, v.label, v.pin
+FROM device_models m,
+     (VALUES
+         ('ds18b20', 'TEMP',     4),
+         ('relay',   'RELAY 1', 16),
+         ('relay',   'RELAY 2', 17),
+         ('relay',   'RELAY 3', 26),
+         ('relay',   'RELAY 4', 27),
+         ('analog',  'ANALOG 1', 32),
+         ('analog',  'ANALOG 2', 33),
+         ('analog',  'ANALOG 3', 34),
+         ('analog',  'ANALOG 4', 35)
+     ) AS v(kind, label, pin)
+WHERE m.slug = 'fishhub-v1'
+ON CONFLICT DO NOTHING;

--- a/db/migrations/027_devices_add_model_id.down.sql
+++ b/db/migrations/027_devices_add_model_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN IF EXISTS model_id;

--- a/db/migrations/027_devices_add_model_id.up.sql
+++ b/db/migrations/027_devices_add_model_id.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE devices
+    ADD COLUMN model_id UUID REFERENCES device_models(id);
+
+UPDATE devices
+SET model_id = (SELECT id FROM device_models WHERE slug = 'fishhub-v1')
+WHERE model_id IS NULL;
+
+ALTER TABLE devices
+    ALTER COLUMN model_id SET NOT NULL;

--- a/db/migrations/028_peripherals_add_port_id.down.sql
+++ b/db/migrations/028_peripherals_add_port_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS peripherals_port_id_active_idx;
+ALTER TABLE peripherals DROP COLUMN IF EXISTS port_id;

--- a/db/migrations/028_peripherals_add_port_id.up.sql
+++ b/db/migrations/028_peripherals_add_port_id.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE peripherals
+    ADD COLUMN port_id UUID REFERENCES device_model_ports(id);
+
+CREATE UNIQUE INDEX peripherals_port_id_active_idx
+    ON peripherals (port_id)
+    WHERE deleted_at IS NULL AND port_id IS NOT NULL;

--- a/docs/database.md
+++ b/docs/database.md
@@ -18,11 +18,51 @@ UNIQUE (provider, provider_sub)
 
 Stores one row per identity. The `provider`/`provider_sub` pair identifies the OAuth account (e.g. `provider='google'`, `provider_sub='<google-sub-claim>'`). The seed user has `provider='local'`.
 
+### `device_models`
+```
+device_models
+├── id         UUID        PK  default gen_random_uuid()
+├── slug       VARCHAR(64) UNIQUE NOT NULL
+├── name       VARCHAR(128) NOT NULL
+└── created_at TIMESTAMPTZ NOT NULL  default now()
+```
+
+Hardware model catalogue. Currently only `fishhub-v1` is seeded. Each model defines a fixed set of ports (see `device_model_ports`).
+
+### `device_model_ports`
+```
+device_model_ports
+├── id         UUID        PK  default gen_random_uuid()
+├── model_id   UUID        FK → device_models.id  NOT NULL
+├── kind       VARCHAR(32) NOT NULL  -- e.g. 'relay', 'ds18b20', 'analog'
+├── label      VARCHAR(32) NOT NULL  -- e.g. 'RELAY 1', 'TEMP', 'ANALOG 2'
+├── pin        INT         NOT NULL  -- GPIO pin number
+└── created_at TIMESTAMPTZ NOT NULL  default now()
+
+UNIQUE (model_id, pin)
+UNIQUE (model_id, kind, label)
+```
+
+One row per physical port on a hardware model. The `fishhub-v1` seed data:
+
+| Label | Kind | Pin |
+|-------|------|-----|
+| TEMP | ds18b20 | 4 |
+| RELAY 1 | relay | 16 |
+| RELAY 2 | relay | 17 |
+| RELAY 3 | relay | 26 |
+| RELAY 4 | relay | 27 |
+| ANALOG 1 | analog | 32 |
+| ANALOG 2 | analog | 33 |
+| ANALOG 3 | analog | 34 |
+| ANALOG 4 | analog | 35 |
+
 ### `devices`
 ```
 devices
 ├── id             UUID  PK  default gen_random_uuid()
 ├── user_id        UUID  FK → users.id  NOT NULL
+├── model_id       UUID  FK → device_models.id  NOT NULL
 ├── name           TEXT  (nullable)
 ├── mqtt_username  TEXT  (nullable)
 ├── mqtt_password  TEXT  (nullable)
@@ -30,7 +70,7 @@ devices
 └── created_at     TIMESTAMPTZ  default now()
 ```
 
-A device row is created when the ESP32 claims a pairing code via `POST /devices/activate`. `mqtt_username` and `mqtt_password` are populated asynchronously by the outbox runner after HiveMQ provisioning completes. `deleted_at` is set on soft-delete; soft-deleted devices are excluded from all queries.
+A device row is created when the ESP32 claims a pairing code via `POST /devices/activate`. `model_id` is set to `fishhub-v1` at claim time. `mqtt_username` and `mqtt_password` are populated asynchronously by the outbox runner after HiveMQ provisioning completes. `deleted_at` is set on soft-delete; soft-deleted devices are excluded from all queries.
 
 ### `provisioning_codes`
 ```
@@ -139,14 +179,39 @@ INDEX action_triggers_trigger_id_idx ON (trigger_id)
 
 Join table linking triggers to their actions. Phase 1 always has exactly one action per trigger, but the schema is open for future multi-action support.
 
+### `peripherals`
+```
+peripherals
+├── id           UUID  PK  default gen_random_uuid()
+├── device_id    UUID  FK → devices.id  NOT NULL
+├── name         TEXT  NOT NULL
+├── kind         TEXT  NOT NULL  -- e.g. 'relay', 'ds18b20', 'analog'
+├── pin          INT   NOT NULL  -- GPIO pin number (copied from port at creation)
+├── port_id      UUID  FK → device_model_ports.id  (nullable for legacy rows)
+├── category     TEXT  NOT NULL  -- 'sensor' | 'actuator'
+├── control_mode TEXT  (nullable)  -- 'automatic' | 'manual'; non-null for actuators only
+├── schedule     JSONB NOT NULL  default '[]'
+├── deleted_at   TIMESTAMPTZ  (nullable)
+├── created_at   TIMESTAMPTZ  NOT NULL  default now()
+└── updated_at   TIMESTAMPTZ  NOT NULL  default now()
+
+UNIQUE INDEX peripherals_device_name_active_idx ON (device_id, name) WHERE deleted_at IS NULL
+UNIQUE INDEX peripherals_device_pin_active_idx  ON (device_id, pin)  WHERE deleted_at IS NULL
+UNIQUE INDEX peripherals_port_id_active_idx     ON (port_id)         WHERE deleted_at IS NULL AND port_id IS NOT NULL
+```
+
+One row per physical peripheral attached to a device. `port_id` links to the model port that determines the GPIO pin; `pin` is copied from the port at insertion so it remains correct even if the port catalogue changes. Legacy rows created before `port_id` was added have `port_id = NULL`. Soft-deleted peripherals (`deleted_at IS NOT NULL`) are excluded from all list/get queries but their port slot is released for reuse.
+
 ## Relationships
 
 ```
+device_models ──< device_model_ports
+              └──< devices
 users ──< devices
       └──< provisioning_codes
       └──< refresh_tokens
       └──  accounts  (1:1 via user_id UNIQUE)
-devices ──< peripherals
+devices ──< peripherals ──> device_model_ports (via port_id, nullable)
         └──< triggers
 triggers ──< action_triggers ──> actions
 outbox_events  (standalone — no FK; device/trigger referenced via payload)
@@ -187,6 +252,10 @@ They run automatically on server startup via `platform.Migrate()`. Current migra
 | 020 | Create `actions` table |
 | 021 | Create `action_triggers` join table |
 | 022 | Migrate existing trigger rows to `actions` + `action_triggers`; drop `target_peripheral_id` and `action` columns from `triggers` |
+| 023–025 | (internal) |
+| 026 | Create `device_models` and `device_model_ports` tables; seed `fishhub-v1` |
+| 027 | Add `model_id` (NOT NULL) to `devices`; backfill existing rows to `fishhub-v1` |
+| 028 | Add `port_id` (nullable) to `peripherals`; add unique index `peripherals_port_id_active_idx` |
 
 To add a migration, create the next numbered `.up.sql` / `.down.sql` pair in `db/migrations/`. Migrations run on the next server startup.
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/apierr"
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
 	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
@@ -309,18 +310,25 @@ type LastReadingResponse struct {
 	Values    map[string]any `json:"values"`
 }
 
+type PortResponse struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Pin   int    `json:"pin"`
+}
+
 type PeripheralResponse struct {
-	ID          string               `json:"id"`
-	DeviceID    string               `json:"device_id"`
-	Name        string               `json:"name"`
-	Kind        string               `json:"kind"`
-	Pin         int                  `json:"pin"`
-	Category    string               `json:"category"`
-	ControlMode *string              `json:"control_mode"`
+	ID          string                      `json:"id"`
+	DeviceID    string                      `json:"device_id"`
+	Name        string                      `json:"name"`
+	Kind        string                      `json:"kind"`
+	Pin         int                         `json:"pin"`
+	Port        *PortResponse               `json:"port"`
+	Category    string                      `json:"category"`
+	ControlMode *string                     `json:"control_mode"`
 	Schedule    []peripheral.ScheduleWindow `json:"schedule"`
-	LastReading *LastReadingResponse `json:"last_reading"`
-	CreatedAt   string               `json:"created_at"`
-	UpdatedAt   string               `json:"updated_at"`
+	LastReading *LastReadingResponse        `json:"last_reading"`
+	CreatedAt   string                      `json:"created_at"`
+	UpdatedAt   string                      `json:"updated_at"`
 }
 
 func peripheralResponse(p peripheral.Peripheral) PeripheralResponse {
@@ -335,12 +343,17 @@ func peripheralResponse(p peripheral.Peripheral) PeripheralResponse {
 			Values:    p.LastReading.Values,
 		}
 	}
+	var port *PortResponse
+	if p.Port != nil {
+		port = &PortResponse{ID: p.Port.ID, Label: p.Port.Label, Pin: p.Port.Pin}
+	}
 	return PeripheralResponse{
 		ID:          p.ID,
 		DeviceID:    p.DeviceID,
 		Name:        p.Name,
 		Kind:        p.Kind,
 		Pin:         p.Pin,
+		Port:        port,
 		Category:    p.Category,
 		ControlMode: p.ControlMode,
 		Schedule:    schedule,
@@ -350,15 +363,56 @@ func peripheralResponse(p peripheral.Peripheral) PeripheralResponse {
 	}
 }
 
+// DeviceModelHandler handles GET /api/devices/{id}/model (session auth).
+type DeviceModelHandler struct {
+	Store devicemodel.Store
+}
+
+type portResponse struct {
+	ID    string `json:"id"`
+	Kind  string `json:"kind"`
+	Label string `json:"label"`
+	Pin   int    `json:"pin"`
+}
+
+type deviceModelResponse struct {
+	ID    string         `json:"id"`
+	Slug  string         `json:"slug"`
+	Name  string         `json:"name"`
+	Ports []portResponse `json:"ports"`
+}
+
+func (h *DeviceModelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	claims := auth.MustClaimsFromContext(r.Context())
+	deviceID := chi.URLParam(r, "id")
+
+	m, err := h.Store.GetByDeviceID(r.Context(), deviceID, claims.UserID)
+	if err != nil {
+		if errors.Is(err, devicemodel.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	ports := make([]portResponse, len(m.Ports))
+	for i, p := range m.Ports {
+		ports[i] = portResponse{ID: p.ID, Kind: p.Kind, Label: p.Label, Pin: p.Pin}
+	}
+	render.JSON(w, r, deviceModelResponse{ID: m.ID, Slug: m.Slug, Name: m.Name, Ports: ports})
+}
+
 // CreatePeripheralHandler handles POST /api/devices/{id}/peripherals (session auth).
 type CreatePeripheralHandler struct {
-	Service *peripheral.Service
+	Service    *peripheral.Service
+	ModelStore devicemodel.Store
 }
 
 type createPeripheralRequest struct {
 	Name     string `json:"name"`
 	Kind     string `json:"kind"`
-	Pin      int    `json:"pin"`
+	PortID   string `json:"port_id"`
 	Category string `json:"category"`
 }
 
@@ -370,8 +424,8 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		apierr.Write(w, http.StatusBadRequest, "invalid_request", "invalid request body")
 		return
 	}
-	if req.Name == "" || req.Kind == "" {
-		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name and kind are required")
+	if req.Name == "" || req.Kind == "" || req.PortID == "" {
+		apierr.Write(w, http.StatusBadRequest, "invalid_request", "name, kind, and port_id are required")
 		return
 	}
 	if req.Category == "" {
@@ -383,7 +437,34 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 
 	deviceID := chi.URLParam(r, "id")
-	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Category, req.Pin)
+
+	// Resolve and validate the port against the device model.
+	m, err := h.ModelStore.GetByDeviceID(r.Context(), deviceID, claims.UserID)
+	if err != nil {
+		if errors.Is(err, devicemodel.ErrNotFound) {
+			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	port, err := h.ModelStore.GetPort(r.Context(), req.PortID, m.ID)
+	if err != nil {
+		if errors.Is(err, devicemodel.ErrPortNotFound) {
+			apierr.Write(w, http.StatusBadRequest, "port_not_found", "port not found or does not belong to this device's model")
+			return
+		}
+		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	if port.Kind != req.Kind {
+		apierr.Write(w, http.StatusBadRequest, "port_kind_mismatch", "port kind does not match the requested peripheral kind")
+		return
+	}
+
+	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Category, port)
 	if err != nil {
 		if errors.Is(err, device.ErrNotFound) {
 			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")
@@ -393,8 +474,8 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			apierr.Write(w, http.StatusConflict, "peripheral_name_conflict", "a peripheral with that name already exists")
 			return
 		}
-		if errors.Is(err, peripheral.ErrPinInUse) {
-			apierr.Write(w, http.StatusConflict, "peripheral_pin_conflict", "pin already in use by another peripheral")
+		if errors.Is(err, peripheral.ErrPortInUse) {
+			apierr.Write(w, http.StatusConflict, "port_conflict", "port already in use by another peripheral")
 			return
 		}
 		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")
@@ -485,7 +566,6 @@ type PatchPeripheralHandler struct {
 
 type patchPeripheralRequest struct {
 	Name string `json:"name"`
-	Pin  int    `json:"pin"`
 }
 
 func (h *PatchPeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -503,7 +583,7 @@ func (h *PatchPeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	deviceID := chi.URLParam(r, "id")
 	peripheralID := chi.URLParam(r, "peripheralId")
-	p, err := h.Service.Update(r.Context(), deviceID, claims.UserID, peripheralID, req.Name, req.Pin)
+	p, err := h.Service.Update(r.Context(), deviceID, claims.UserID, peripheralID, req.Name)
 	if err != nil {
 		if errors.Is(err, peripheral.ErrNotFound) {
 			apierr.Write(w, http.StatusNotFound, "peripheral_not_found", "peripheral not found")
@@ -511,10 +591,6 @@ func (h *PatchPeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		}
 		if errors.Is(err, peripheral.ErrAlreadyExists) {
 			apierr.Write(w, http.StatusConflict, "peripheral_name_conflict", "a peripheral with that name already exists")
-			return
-		}
-		if errors.Is(err, peripheral.ErrPinInUse) {
-			apierr.Write(w, http.StatusConflict, "peripheral_pin_conflict", "pin already in use by another peripheral")
 			return
 		}
 		apierr.Write(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -314,7 +314,7 @@ func newActivateHandler(t *testing.T, store *stubProvisioningStore, signer *stub
 	t.Helper()
 	db := testutil.NewTestDB(t)
 	return &api.ActivateHandler{
-		Service: provisioning.NewActivationService(db, store, &stubOutboxStore{}, signer, &stubTimezoneReader{}, discardLogger),
+		Service: provisioning.NewActivationService(db, store, &stubOutboxStore{}, signer, &stubTimezoneReader{}, &stubModelIDResolver{}, discardLogger),
 	}
 }
 

--- a/internal/api/peripheral_handler_test.go
+++ b/internal/api/peripheral_handler_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/api"
-	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
 	"github.com/fishhub-oss/fishhub-server/internal/testutil"
 )
@@ -179,10 +179,14 @@ func TestCreatePeripheralHandler(t *testing.T) {
 	t.Run("already exists returns 409", func(t *testing.T) {
 		store := &stubPeripheralStore{createErr: peripheral.ErrAlreadyExists}
 		svc := newPeripheralService(t, store, &stubPublisher{})
-		h := &api.CreatePeripheralHandler{Service: svc}
+		modelStore := &stubDeviceModelStore{
+			model: devicemodel.DeviceModel{ID: "model-1"},
+			port:  devicemodel.Port{ID: "port-1", Kind: "relay", Label: "RELAY 1", Pin: 16},
+		}
+		h := &api.CreatePeripheralHandler{Service: svc, ModelStore: modelStore}
 
 		req := withChiParam(
-			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`)), "user-1"),
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","port_id":"port-1"}`)), "user-1"),
 			"id", "dev-1",
 		)
 		rec := httptest.NewRecorder()
@@ -191,12 +195,13 @@ func TestCreatePeripheralHandler(t *testing.T) {
 	})
 
 	t.Run("device not found returns 404", func(t *testing.T) {
-		store := &stubPeripheralStore{createErr: device.ErrNotFound}
+		store := &stubPeripheralStore{}
 		svc := newPeripheralService(t, store, &stubPublisher{})
-		h := &api.CreatePeripheralHandler{Service: svc}
+		modelStore := &stubDeviceModelStore{modelErr: devicemodel.ErrNotFound}
+		h := &api.CreatePeripheralHandler{Service: svc, ModelStore: modelStore}
 
 		req := withChiParam(
-			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","pin":5}`)), "user-1"),
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"light","kind":"relay","port_id":"port-1"}`)), "user-1"),
 			"id", "dev-x",
 		)
 		rec := httptest.NewRecorder()
@@ -210,12 +215,11 @@ func TestCreatePeripheralHandler(t *testing.T) {
 func TestPatchPeripheralHandler(t *testing.T) {
 	t.Run("returns 200 with updated peripheral", func(t *testing.T) {
 		p := newPeripheral("renamed")
-		p.Pin = 7
 		store := &stubPeripheralStore{updated: p}
 		svc := peripheral.NewService(nil, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &api.PatchPeripheralHandler{Service: svc}
 
-		body := `{"name":"renamed","pin":7}`
+		body := `{"name":"renamed"}`
 		req := withChiParams(
 			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body)), "user-1"),
 			map[string]string{"id": "dev-1", "peripheralId": "pid-1"},
@@ -233,9 +237,6 @@ func TestPatchPeripheralHandler(t *testing.T) {
 		if resp["name"] != "renamed" {
 			t.Errorf("unexpected name: %v", resp["name"])
 		}
-		if resp["pin"] != float64(7) {
-			t.Errorf("unexpected pin: %v", resp["pin"])
-		}
 	})
 
 	t.Run("peripheral not found returns 404", func(t *testing.T) {
@@ -244,7 +245,7 @@ func TestPatchPeripheralHandler(t *testing.T) {
 		h := &api.PatchPeripheralHandler{Service: svc}
 
 		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"name":"x","pin":1}`)), "user-1"),
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"name":"x"}`)), "user-1"),
 			map[string]string{"id": "dev-1", "peripheralId": "ghost"},
 		)
 		rec := httptest.NewRecorder()
@@ -258,7 +259,7 @@ func TestPatchPeripheralHandler(t *testing.T) {
 		h := &api.PatchPeripheralHandler{Service: svc}
 
 		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"name":"taken","pin":1}`)), "user-1"),
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"name":"taken"}`)), "user-1"),
 			map[string]string{"id": "dev-1", "peripheralId": "pid-1"},
 		)
 		rec := httptest.NewRecorder()
@@ -266,26 +267,12 @@ func TestPatchPeripheralHandler(t *testing.T) {
 		assertErrorCode(t, rec, http.StatusConflict, "peripheral_name_conflict")
 	})
 
-	t.Run("pin conflict returns 409", func(t *testing.T) {
-		store := &stubPeripheralStore{updateErr: peripheral.ErrPinInUse}
-		svc := peripheral.NewService(nil, store, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
-		h := &api.PatchPeripheralHandler{Service: svc}
-
-		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"name":"x","pin":5}`)), "user-1"),
-			map[string]string{"id": "dev-1", "peripheralId": "pid-1"},
-		)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		assertErrorCode(t, rec, http.StatusConflict, "peripheral_pin_conflict")
-	})
-
 	t.Run("missing name returns 400", func(t *testing.T) {
 		svc := peripheral.NewService(nil, &stubPeripheralStore{}, &stubOutboxStore{}, nil, &stubPublisher{}, discardLogger)
 		h := &api.PatchPeripheralHandler{Service: svc}
 
 		req := withChiParams(
-			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"pin":5}`)), "user-1"),
+			withClaims(httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{}`)), "user-1"),
 			map[string]string{"id": "dev-1", "peripheralId": "pid-1"},
 		)
 		rec := httptest.NewRecorder()

--- a/internal/api/stubs_test.go
+++ b/internal/api/stubs_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
@@ -94,7 +95,7 @@ func (s *stubProvisioningStore) ClaimCode(_ context.Context, _ string) (string, 
 	}
 	return s.claimedDeviceID, uid, s.claimErr
 }
-func (s *stubProvisioningStore) Activate(_ context.Context, _ *sql.Tx, _, _, _ string) error {
+func (s *stubProvisioningStore) Activate(_ context.Context, _ *sql.Tx, _, _, _, _ string) error {
 	return s.activateErr
 }
 
@@ -214,7 +215,7 @@ type stubPeripheralStore struct {
 	deleteErr      error
 }
 
-func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _, _ string, _ int) (peripheral.Peripheral, error) {
+func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _, _ string, _ devicemodel.Port) (peripheral.Peripheral, error) {
 	return s.created, s.createErr
 }
 func (s *stubPeripheralStore) ListPeripherals(_ context.Context, _, _ string) ([]peripheral.Peripheral, error) {
@@ -229,7 +230,7 @@ func (s *stubPeripheralStore) SetPeripheralSchedule(_ context.Context, _, _, _ s
 func (s *stubPeripheralStore) SetControlMode(_ context.Context, _ *sql.Tx, _, _, _, _ string) (peripheral.Peripheral, error) {
 	return s.controlModeP, s.controlModeErr
 }
-func (s *stubPeripheralStore) UpdatePeripheral(_ context.Context, _, _, _, _ string, _ int) (peripheral.Peripheral, error) {
+func (s *stubPeripheralStore) UpdatePeripheral(_ context.Context, _, _, _, _ string) (peripheral.Peripheral, error) {
 	return s.updated, s.updateErr
 }
 func (s *stubPeripheralStore) DeletePeripheral(_ context.Context, _ *sql.Tx, _, _, _ string) (peripheral.Peripheral, error) {
@@ -254,6 +255,41 @@ func newDevice(id string) device.Device {
 }
 
 var errSentinel = errors.New("store error")
+
+// ── ModelIDResolver ───────────────────────────────────────────────────────────
+
+type stubModelIDResolver struct{ id string }
+
+func (s *stubModelIDResolver) DefaultModelID(_ context.Context) (string, error) {
+	if s.id == "" {
+		return "model-uuid", nil
+	}
+	return s.id, nil
+}
+
+// ── DeviceModelStore ──────────────────────────────────────────────────────────
+
+type stubDeviceModelStore struct {
+	model        devicemodel.DeviceModel
+	modelErr     error
+	port         devicemodel.Port
+	portErr      error
+	defaultID    string
+	defaultIDErr error
+}
+
+func (s *stubDeviceModelStore) GetByDeviceID(_ context.Context, _, _ string) (devicemodel.DeviceModel, error) {
+	return s.model, s.modelErr
+}
+func (s *stubDeviceModelStore) GetPort(_ context.Context, _, _ string) (devicemodel.Port, error) {
+	return s.port, s.portErr
+}
+func (s *stubDeviceModelStore) DefaultModelID(_ context.Context) (string, error) {
+	if s.defaultID == "" {
+		return "model-uuid", s.defaultIDErr
+	}
+	return s.defaultID, s.defaultIDErr
+}
 
 // ── TriggerStore ──────────────────────────────────────────────────────────────
 

--- a/internal/api/trigger_handler_test.go
+++ b/internal/api/trigger_handler_test.go
@@ -173,7 +173,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 
 		// Insert a real device so the device-exists check passes.
 		var deviceID string
-		db.QueryRowContext(ctx, `INSERT INTO devices (user_id) VALUES ('00000000-0000-0000-0000-000000000001') RETURNING id`).Scan(&deviceID)
+		db.QueryRowContext(ctx, `INSERT INTO devices (user_id, model_id) VALUES ('00000000-0000-0000-0000-000000000001', (SELECT id FROM device_models WHERE slug = 'fishhub-v1')) RETURNING id`).Scan(&deviceID)
 
 		svc := trigger.NewService(db, &stubTriggerStore{}, &stubOutboxStore{}, discardLogger)
 		h := &api.CreateTriggerHandler{Service: svc}

--- a/internal/device/store_test.go
+++ b/internal/device/store_test.go
@@ -33,7 +33,7 @@ func TestListByUserID_integration(t *testing.T) {
 			t.Fatalf("setup claim: %v", err)
 		}
 		var d2 string
-		if err := db.QueryRowContext(ctx, `INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID).Scan(&d2); err != nil {
+		if err := db.QueryRowContext(ctx, `INSERT INTO devices (user_id, model_id) VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1')) RETURNING id`, userID).Scan(&d2); err != nil {
 			t.Fatalf("setup device 2: %v", err)
 		}
 
@@ -85,7 +85,7 @@ func TestGetActivationStatus_integration(t *testing.T) {
 		t.Helper()
 		var deviceID string
 		err := db.QueryRowContext(ctx,
-			`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+			`INSERT INTO devices (user_id, model_id) VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1')) RETURNING id`, userID,
 		).Scan(&deviceID)
 		if err != nil {
 			t.Fatalf("insert device: %v", err)
@@ -165,7 +165,7 @@ func TestFindByID_integration(t *testing.T) {
 
 	var deviceID string
 	if err := db.QueryRowContext(ctx,
-		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+		`INSERT INTO devices (user_id, model_id) VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1')) RETURNING id`, userID,
 	).Scan(&deviceID); err != nil {
 		t.Fatalf("insert device: %v", err)
 	}

--- a/internal/devicemodel/errors.go
+++ b/internal/devicemodel/errors.go
@@ -1,0 +1,8 @@
+package devicemodel
+
+import "errors"
+
+var (
+	ErrNotFound     = errors.New("device model not found")
+	ErrPortNotFound = errors.New("port not found")
+)

--- a/internal/devicemodel/model.go
+++ b/internal/devicemodel/model.go
@@ -1,0 +1,20 @@
+package devicemodel
+
+import "time"
+
+type Port struct {
+	ID        string
+	ModelID   string
+	Kind      string
+	Label     string
+	Pin       int
+	CreatedAt time.Time
+}
+
+type DeviceModel struct {
+	ID        string
+	Slug      string
+	Name      string
+	Ports     []Port
+	CreatedAt time.Time
+}

--- a/internal/devicemodel/store.go
+++ b/internal/devicemodel/store.go
@@ -1,0 +1,103 @@
+package devicemodel
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Store provides read access to device models and their ports.
+type Store interface {
+	// GetByDeviceID returns the model (with all ports) for a device owned by userID.
+	// Returns ErrNotFound if the device does not exist, is not owned by userID,
+	// or has no model assigned.
+	GetByDeviceID(ctx context.Context, deviceID, userID string) (DeviceModel, error)
+
+	// GetPort returns a single port by ID, verifying it belongs to the given model.
+	// Returns ErrPortNotFound if the port does not exist or does not belong to the model.
+	GetPort(ctx context.Context, portID, modelID string) (Port, error)
+
+	// DefaultModelID returns the ID of the 'fishhub-v1' model.
+	// Returns ErrNotFound if the seed has not run yet.
+	DefaultModelID(ctx context.Context) (string, error)
+}
+
+type postgresStore struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) Store {
+	return &postgresStore{db: db}
+}
+
+func (s *postgresStore) GetByDeviceID(ctx context.Context, deviceID, userID string) (DeviceModel, error) {
+	var m DeviceModel
+	err := s.db.QueryRowContext(ctx, `
+		SELECT dm.id, dm.slug, dm.name, dm.created_at
+		FROM device_models dm
+		JOIN devices d ON d.model_id = dm.id
+		WHERE d.id = $1
+		  AND d.user_id = $2
+		  AND d.deleted_at IS NULL
+	`, deviceID, userID).Scan(&m.ID, &m.Slug, &m.Name, &m.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return DeviceModel{}, ErrNotFound
+	}
+	if err != nil {
+		return DeviceModel{}, fmt.Errorf("get device model: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, model_id, kind, label, pin, created_at
+		FROM device_model_ports
+		WHERE model_id = $1
+		ORDER BY kind, label
+	`, m.ID)
+	if err != nil {
+		return DeviceModel{}, fmt.Errorf("get device model ports: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var p Port
+		if err := rows.Scan(&p.ID, &p.ModelID, &p.Kind, &p.Label, &p.Pin, &p.CreatedAt); err != nil {
+			return DeviceModel{}, fmt.Errorf("get device model ports: scan: %w", err)
+		}
+		m.Ports = append(m.Ports, p)
+	}
+	if err := rows.Err(); err != nil {
+		return DeviceModel{}, fmt.Errorf("get device model ports: iterate: %w", err)
+	}
+	return m, nil
+}
+
+func (s *postgresStore) GetPort(ctx context.Context, portID, modelID string) (Port, error) {
+	var p Port
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, model_id, kind, label, pin, created_at
+		FROM device_model_ports
+		WHERE id = $1 AND model_id = $2
+	`, portID, modelID).Scan(&p.ID, &p.ModelID, &p.Kind, &p.Label, &p.Pin, &p.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Port{}, ErrPortNotFound
+	}
+	if err != nil {
+		return Port{}, fmt.Errorf("get port: %w", err)
+	}
+	return p, nil
+}
+
+func (s *postgresStore) DefaultModelID(ctx context.Context) (string, error) {
+	var id string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id FROM device_models WHERE slug = 'fishhub-v1'`,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("default model id: %w", err)
+	}
+	return id, nil
+}

--- a/internal/peripheral/errors.go
+++ b/internal/peripheral/errors.go
@@ -3,9 +3,12 @@ package peripheral
 import "errors"
 
 var (
-	ErrNotAnActuator  = errors.New("peripheral is not an actuator")
-	ErrNotFound       = errors.New("peripheral not found")
-	ErrAlreadyExists  = errors.New("peripheral already exists")
-	ErrPinInUse       = errors.New("peripheral pin already in use")
-	ErrInvalidCommand = errors.New("command must be 'set' or 'schedule'")
+	ErrNotAnActuator    = errors.New("peripheral is not an actuator")
+	ErrNotFound         = errors.New("peripheral not found")
+	ErrAlreadyExists    = errors.New("peripheral already exists")
+	ErrPinInUse         = errors.New("peripheral pin already in use")
+	ErrInvalidCommand   = errors.New("command must be 'set' or 'schedule'")
+	ErrPortNotFound     = errors.New("port not found or does not belong to device model")
+	ErrPortKindMismatch = errors.New("port kind does not match peripheral kind")
+	ErrPortInUse        = errors.New("port already in use by another peripheral")
 )

--- a/internal/peripheral/model.go
+++ b/internal/peripheral/model.go
@@ -6,12 +6,20 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 )
 
+// Port is the resolved port information carried on a Peripheral after a join.
+type Port struct {
+	ID    string
+	Label string
+	Pin   int
+}
+
 type Peripheral struct {
 	ID          string
 	DeviceID    string
 	Name        string
 	Kind        string
 	Pin         int
+	Port        *Port   // nil for peripherals that pre-date the port model
 	Category    string  // "sensor" | "actuator"
 	ControlMode *string // nil for sensors; "automatic"|"manual" for actuators
 	Schedule    []ScheduleWindow

--- a/internal/peripheral/service.go
+++ b/internal/peripheral/service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/measurement"
 	"github.com/fishhub-oss/fishhub-server/internal/mqtt"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
@@ -58,16 +59,17 @@ func NewService(
 }
 
 // Register creates a new peripheral and enqueues a peripheral.push outbox event atomically.
-func (s *Service) Register(ctx context.Context, deviceID, userID, name, kind, category string, pin int) (Peripheral, error) {
+// port must already be validated (kind match, belongs to device model) by the caller.
+func (s *Service) Register(ctx context.Context, deviceID, userID, name, kind, category string, port devicemodel.Port) (Peripheral, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return Peripheral{}, fmt.Errorf("register peripheral: begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
-	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, category, pin)
+	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, category, port)
 	if err != nil {
-		if !errors.Is(err, ErrAlreadyExists) {
+		if !errors.Is(err, ErrAlreadyExists) && !errors.Is(err, ErrPortInUse) {
 			s.logger.Error("register peripheral: create", "device_id", deviceID, "name", name, "error", err)
 		}
 		return Peripheral{}, err
@@ -75,10 +77,10 @@ func (s *Service) Register(ctx context.Context, deviceID, userID, name, kind, ca
 
 	if err := s.outbox.Insert(ctx, tx, eventTypePeripheralPush, peripheralPushPayload{
 		DeviceID: deviceID,
-		Name:     fmt.Sprintf("%s-%d", kind, pin),
+		Name:     fmt.Sprintf("%s-%d", kind, port.Pin),
 		Op:       "create",
 		Kind:     kind,
-		Pin:      pin,
+		Pin:      port.Pin,
 	}, peripheralPushClaimTimeoutSeconds); err != nil {
 		s.logger.Error("register peripheral: enqueue push", "device_id", deviceID, "name", name, "error", err)
 		return Peripheral{}, fmt.Errorf("register peripheral: enqueue push: %w", err)
@@ -227,12 +229,11 @@ func (s *Service) SendCommand(ctx context.Context, deviceID, userID, peripheralI
 	return nil
 }
 
-// Update updates name and pin on a peripheral. No firmware notification is needed
-// because the firmware identifies peripherals by kind-pin namespace, not by name.
-func (s *Service) Update(ctx context.Context, deviceID, userID, peripheralID, name string, pin int) (Peripheral, error) {
-	p, err := s.store.UpdatePeripheral(ctx, deviceID, userID, peripheralID, name, pin)
+// Update updates the name of a peripheral. Port is immutable after creation.
+func (s *Service) Update(ctx context.Context, deviceID, userID, peripheralID, name string) (Peripheral, error) {
+	p, err := s.store.UpdatePeripheral(ctx, deviceID, userID, peripheralID, name)
 	if err != nil {
-		if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrAlreadyExists) && !errors.Is(err, ErrPinInUse) {
+		if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrAlreadyExists) {
 			s.logger.Error("update peripheral", "device_id", deviceID, "peripheral_id", peripheralID, "error", err)
 		}
 		return Peripheral{}, err

--- a/internal/peripheral/store.go
+++ b/internal/peripheral/store.go
@@ -9,16 +9,19 @@ import (
 	"strings"
 
 	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 )
 
 type Store interface {
 	// CreatePeripheral inserts a new peripheral for the device owned by userID.
+	// port must belong to the device's model and match kind; its pin is used for the peripheral.
 	// Returns device.ErrNotFound if the device does not exist or is not owned by userID.
 	// Returns ErrAlreadyExists if an active peripheral with the same name exists.
-	// Returns ErrPinInUse if an active peripheral with the same pin exists.
+	// Returns ErrPortInUse if an active peripheral already occupies the port.
 	// category must be "sensor" or "actuator"; actuators get control_mode defaulted to "automatic".
-	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, pin int) (Peripheral, error)
-	// ListPeripherals returns active (non-deleted) peripherals for the device owned by userID.
+	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, port devicemodel.Port) (Peripheral, error)
+	// ListPeripherals returns active (non-deleted) peripherals for the device owned by userID,
+	// each joined with its port (label, pin) when port_id is set.
 	// Returns an empty slice if the device does not exist or is not owned by userID.
 	ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error)
 	// GetPeripheral returns a single active peripheral by ID, scoped to the device and user.
@@ -31,11 +34,10 @@ type Store interface {
 	// Returns ErrNotFound if the peripheral does not exist or is not reachable by userID.
 	// Returns ErrNotAnActuator if the peripheral's category is not "actuator".
 	SetControlMode(ctx context.Context, tx *sql.Tx, deviceID, userID, peripheralID, mode string) (Peripheral, error)
-	// UpdatePeripheral updates name and pin on an active peripheral owned by userID.
+	// UpdatePeripheral updates name on an active peripheral owned by userID.
 	// Returns ErrNotFound if the peripheral does not exist or is not reachable by userID.
 	// Returns ErrAlreadyExists if another active peripheral on the device has the same name.
-	// Returns ErrPinInUse if another active peripheral on the device uses the same pin.
-	UpdatePeripheral(ctx context.Context, deviceID, userID, peripheralID, name string, pin int) (Peripheral, error)
+	UpdatePeripheral(ctx context.Context, deviceID, userID, peripheralID, name string) (Peripheral, error)
 	// DeletePeripheral soft-deletes the peripheral (sets deleted_at) and returns it.
 	// Returns ErrNotFound if the peripheral does not exist or is not reachable by userID.
 	DeletePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, peripheralID string) (Peripheral, error)
@@ -49,7 +51,7 @@ func NewStore(db *sql.DB) Store {
 	return &postgresStore{db: db}
 }
 
-func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, pin int) (Peripheral, error) {
+func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, port devicemodel.Port) (Peripheral, error) {
 	var exists bool
 	err := s.db.QueryRowContext(ctx,
 		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL)`,
@@ -65,11 +67,11 @@ func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, device
 	var p Peripheral
 	var controlMode sql.NullString
 	err = tx.QueryRowContext(ctx, `
-		INSERT INTO peripherals (device_id, name, kind, pin, category, control_mode)
-		VALUES ($1, $2, $3, $4, $5,
-			CASE WHEN $5 = 'actuator' THEN 'automatic' ELSE NULL END)
+		INSERT INTO peripherals (device_id, name, kind, pin, port_id, category, control_mode)
+		VALUES ($1, $2, $3, $4, $5, $6,
+			CASE WHEN $6 = 'actuator' THEN 'automatic' ELSE NULL END)
 		RETURNING id, device_id, name, kind, pin, category, control_mode, created_at, updated_at
-	`, deviceID, name, kind, pin, category).Scan(
+	`, deviceID, name, kind, port.Pin, port.ID, category).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
 		&p.Category, &controlMode, &p.CreatedAt, &p.UpdatedAt,
 	)
@@ -78,25 +80,28 @@ func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, device
 		case "peripherals_device_name_active_idx":
 			return Peripheral{}, ErrAlreadyExists
 		case "peripherals_device_pin_active_idx":
-			return Peripheral{}, ErrPinInUse
-		case "":
-		default:
-			return Peripheral{}, ErrAlreadyExists
+			// Port carries the pin, so a pin conflict is always a port conflict.
+			return Peripheral{}, ErrPortInUse
+		case "peripherals_port_id_active_idx":
+			return Peripheral{}, ErrPortInUse
 		}
 		return Peripheral{}, fmt.Errorf("create peripheral: insert: %w", err)
 	}
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
 	}
+	p.Port = &Port{ID: port.ID, Label: port.Label, Pin: port.Pin}
 	return p, nil
 }
 
 func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
-		       p.schedule, p.created_at, p.updated_at
+		       p.schedule, p.created_at, p.updated_at,
+		       dmp.id, dmp.label, dmp.pin
 		FROM peripherals p
 		JOIN devices d ON d.id = p.device_id
+		LEFT JOIN device_model_ports dmp ON dmp.id = p.port_id
 		WHERE p.device_id = $1
 		  AND d.user_id = $2
 		  AND p.deleted_at IS NULL
@@ -113,10 +118,13 @@ func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID st
 		var p Peripheral
 		var controlMode sql.NullString
 		var scheduleJSON []byte
+		var portID, portLabel sql.NullString
+		var portPin sql.NullInt64
 		if err := rows.Scan(
 			&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
 			&p.Category, &controlMode, &scheduleJSON,
 			&p.CreatedAt, &p.UpdatedAt,
+			&portID, &portLabel, &portPin,
 		); err != nil {
 			return nil, fmt.Errorf("list peripherals: scan: %w", err)
 		}
@@ -128,6 +136,9 @@ func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID st
 				return nil, fmt.Errorf("list peripherals: unmarshal schedule: %w", err)
 			}
 		}
+		if portID.Valid && portLabel.Valid && portPin.Valid {
+			p.Port = &Port{ID: portID.String, Label: portLabel.String, Pin: int(portPin.Int64)}
+		}
 		peripherals = append(peripherals, p)
 	}
 	return peripherals, rows.Err()
@@ -137,11 +148,15 @@ func (s *postgresStore) GetPeripheral(ctx context.Context, deviceID, userID, per
 	var p Peripheral
 	var controlMode sql.NullString
 	var scheduleJSON []byte
+	var portID, portLabel sql.NullString
+	var portPin sql.NullInt64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
-		       p.schedule, p.created_at, p.updated_at
+		       p.schedule, p.created_at, p.updated_at,
+		       dmp.id, dmp.label, dmp.pin
 		FROM peripherals p
 		JOIN devices d ON d.id = p.device_id
+		LEFT JOIN device_model_ports dmp ON dmp.id = p.port_id
 		WHERE p.device_id = $1
 		  AND d.user_id = $2
 		  AND p.id = $3
@@ -151,6 +166,7 @@ func (s *postgresStore) GetPeripheral(ctx context.Context, deviceID, userID, per
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
 		&p.Category, &controlMode, &scheduleJSON,
 		&p.CreatedAt, &p.UpdatedAt,
+		&portID, &portLabel, &portPin,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Peripheral{}, ErrNotFound
@@ -165,6 +181,9 @@ func (s *postgresStore) GetPeripheral(ctx context.Context, deviceID, userID, per
 		if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
 			return Peripheral{}, fmt.Errorf("get peripheral: unmarshal schedule: %w", err)
 		}
+	}
+	if portID.Valid && portLabel.Valid && portPin.Valid {
+		p.Port = &Port{ID: portID.String, Label: portLabel.String, Pin: int(portPin.Int64)}
 	}
 	return p, nil
 }
@@ -300,36 +319,40 @@ func (s *postgresStore) DeletePeripheral(ctx context.Context, tx *sql.Tx, device
 	return p, nil
 }
 
-func (s *postgresStore) UpdatePeripheral(ctx context.Context, deviceID, userID, peripheralID, name string, pin int) (Peripheral, error) {
+func (s *postgresStore) UpdatePeripheral(ctx context.Context, deviceID, userID, peripheralID, name string) (Peripheral, error) {
 	var p Peripheral
 	var controlMode sql.NullString
 	var scheduleJSON []byte
+	var portID sql.NullString
+	var portLabel sql.NullString
+	var portPin sql.NullInt64
 	err := s.db.QueryRowContext(ctx, `
 		UPDATE peripherals p
-		SET name = $1, pin = $2, updated_at = now()
+		SET name = $1, updated_at = now()
 		FROM devices d
 		WHERE p.device_id = d.id
-		  AND d.user_id   = $3
-		  AND p.device_id = $4
-		  AND p.id        = $5
+		  AND d.user_id   = $2
+		  AND p.device_id = $3
+		  AND p.id        = $4
 		  AND p.deleted_at IS NULL
 		  AND d.deleted_at IS NULL
 		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category,
-		          p.control_mode, p.schedule, p.created_at, p.updated_at
-	`, name, pin, userID, deviceID, peripheralID).Scan(
+		          p.control_mode, p.schedule, p.created_at, p.updated_at,
+		          p.port_id,
+		          (SELECT label FROM device_model_ports WHERE id = p.port_id),
+		          (SELECT pin   FROM device_model_ports WHERE id = p.port_id)
+	`, name, userID, deviceID, peripheralID).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
 		&p.Category, &controlMode, &scheduleJSON,
 		&p.CreatedAt, &p.UpdatedAt,
+		&portID, &portLabel, &portPin,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Peripheral{}, ErrNotFound
 	}
 	if err != nil {
-		switch uniqueViolationIndex(err) {
-		case "peripherals_device_name_active_idx":
+		if uniqueViolationIndex(err) == "peripherals_device_name_active_idx" {
 			return Peripheral{}, ErrAlreadyExists
-		case "peripherals_device_pin_active_idx":
-			return Peripheral{}, ErrPinInUse
 		}
 		return Peripheral{}, fmt.Errorf("update peripheral: %w", err)
 	}
@@ -340,6 +363,9 @@ func (s *postgresStore) UpdatePeripheral(ctx context.Context, deviceID, userID, 
 		if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
 			return Peripheral{}, fmt.Errorf("update peripheral: unmarshal schedule: %w", err)
 		}
+	}
+	if portID.Valid && portLabel.Valid && portPin.Valid {
+		p.Port = &Port{ID: portID.String, Label: portLabel.String, Pin: int(portPin.Int64)}
 	}
 	return p, nil
 }

--- a/internal/peripheral/store_integration_test.go
+++ b/internal/peripheral/store_integration_test.go
@@ -2,14 +2,31 @@ package peripheral_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
 	"github.com/fishhub-oss/fishhub-server/internal/device"
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/peripheral"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/testutil"
 )
+
+// portByLabel looks up a device_model_ports row by label for fishhub-v1.
+func portByLabel(t *testing.T, db *sql.DB, ctx context.Context, label string) devicemodel.Port {
+	t.Helper()
+	var p devicemodel.Port
+	if err := db.QueryRowContext(ctx, `
+		SELECT dmp.id, dm.id, dmp.kind, dmp.label, dmp.pin
+		FROM device_model_ports dmp
+		JOIN device_models dm ON dm.id = dmp.model_id
+		WHERE dm.slug = 'fishhub-v1' AND dmp.label = $1`, label,
+	).Scan(&p.ID, &p.ModelID, &p.Kind, &p.Label, &p.Pin); err != nil {
+		t.Fatalf("lookup port %q: %v", label, err)
+	}
+	return p
+}
 
 func TestPeripheralStore_integration(t *testing.T) {
 	db := testutil.NewTestDB(t)
@@ -17,9 +34,16 @@ func TestPeripheralStore_integration(t *testing.T) {
 	ctx := context.Background()
 	userID := platform.SeedUserID()
 
+	// Look up ports used across the test.
+	relayPort := portByLabel(t, db, ctx, "RELAY 1") // kind=relay, pin=16
+	tempPort := portByLabel(t, db, ctx, "TEMP")     // kind=ds18b20, pin=4
+	relay2Port := portByLabel(t, db, ctx, "RELAY 2") // kind=relay, pin=17
+
 	var deviceID string
 	if err := db.QueryRowContext(ctx,
-		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+		`INSERT INTO devices (user_id, model_id)
+		 VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1'))
+		 RETURNING id`, userID,
 	).Scan(&deviceID); err != nil {
 		t.Fatalf("insert device: %v", err)
 	}
@@ -30,7 +54,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("begin tx for light: %v", err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", 5)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", relayPort)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("create light: %v", err)
@@ -45,7 +69,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("begin tx for temp: %v", err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "temp", "ds18b20", "sensor", 4)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "temp", "ds18b20", "sensor", tempPort)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("create temp: %v", err)
@@ -64,7 +88,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if p.ID == "" {
 			t.Error("expected non-empty ID")
 		}
-		if p.Name != "light" || p.Kind != "relay" || p.Pin != 5 {
+		if p.Name != "light" || p.Kind != "relay" || p.Pin != relayPort.Pin {
 			t.Errorf("unexpected peripheral: %+v", p)
 		}
 		if p.Category != "actuator" {
@@ -72,6 +96,9 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		if p.ControlMode == nil || *p.ControlMode != "automatic" {
 			t.Errorf("expected control_mode=automatic, got %v", p.ControlMode)
+		}
+		if p.Port == nil || p.Port.Label != relayPort.Label || p.Port.Pin != relayPort.Pin {
+			t.Errorf("expected port %+v, got %+v", relayPort, p.Port)
 		}
 	})
 
@@ -106,6 +133,9 @@ func TestPeripheralStore_integration(t *testing.T) {
 				if p.ControlMode == nil || *p.ControlMode != "automatic" {
 					t.Errorf("expected automatic control_mode, got %v", p.ControlMode)
 				}
+				if p.Port == nil || p.Port.Label != relayPort.Label {
+					t.Errorf("expected port label %q, got %+v", relayPort.Label, p.Port)
+				}
 			}
 		}
 		if !found {
@@ -120,22 +150,22 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", 6)
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", relay2Port)
 		if !errors.Is(err, peripheral.ErrAlreadyExists) {
 			t.Errorf("expected ErrAlreadyExists, got %v", err)
 		}
 	})
 
-	t.Run("create with duplicate pin returns ErrPinInUse", func(t *testing.T) {
+	t.Run("create with duplicate port returns ErrPortInUse", func(t *testing.T) {
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", "actuator", 5)
-		if !errors.Is(err, peripheral.ErrPinInUse) {
-			t.Errorf("expected ErrPinInUse, got %v", err)
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", "actuator", relayPort)
+		if !errors.Is(err, peripheral.ErrPortInUse) {
+			t.Errorf("expected ErrPortInUse, got %v", err)
 		}
 	})
 
@@ -146,7 +176,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", "actuator", 7)
+		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", "actuator", relay2Port)
 		if !errors.Is(err, device.ErrNotFound) {
 			t.Errorf("expected device.ErrNotFound, got %v", err)
 		}
@@ -244,8 +274,8 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if deleted.Kind != "relay" || deleted.Pin != 5 {
-			t.Errorf("expected kind=relay pin=5, got kind=%s pin=%d", deleted.Kind, deleted.Pin)
+		if deleted.Kind != "relay" || deleted.Pin != relayPort.Pin {
+			t.Errorf("expected kind=relay pin=%d, got kind=%s pin=%d", relayPort.Pin, deleted.Kind, deleted.Pin)
 		}
 		if err := tx.Commit(); err != nil {
 			t.Fatal(err)
@@ -280,7 +310,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", 5)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", relayPort)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("re-create after delete: %v", err)

--- a/internal/provisioning/activation.go
+++ b/internal/provisioning/activation.go
@@ -17,6 +17,12 @@ type TimezoneReader interface {
 	GetTimezone(ctx context.Context, userID string) (string, error)
 }
 
+// ModelIDResolver returns the default device model ID to assign to new devices.
+// Implemented by a bridge in main.go.
+type ModelIDResolver interface {
+	DefaultModelID(ctx context.Context) (string, error)
+}
+
 // ActivationResult holds what the device receives immediately after activation.
 // MQTT credentials are not included — the device polls GET /devices/{id}/status
 // until they are ready.
@@ -28,12 +34,13 @@ type ActivationResult struct {
 // ActivationService orchestrates device activation: claim code → store credentials
 // + enqueue HiveMQ provisioning atomically → sign JWT.
 type ActivationService struct {
-	db             *sql.DB
-	store          Store
-	outboxStore    outbox.Store
-	signer         devicejwt.Signer
-	timezoneReader TimezoneReader
-	logger         *slog.Logger
+	db              *sql.DB
+	store           Store
+	outboxStore     outbox.Store
+	signer          devicejwt.Signer
+	timezoneReader  TimezoneReader
+	modelIDResolver ModelIDResolver
+	logger          *slog.Logger
 }
 
 func NewActivationService(
@@ -42,18 +49,20 @@ func NewActivationService(
 	outboxStore outbox.Store,
 	signer devicejwt.Signer,
 	timezoneReader TimezoneReader,
+	modelIDResolver ModelIDResolver,
 	logger *slog.Logger,
 ) *ActivationService {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &ActivationService{
-		db:             db,
-		store:          store,
-		outboxStore:    outboxStore,
-		signer:         signer,
-		timezoneReader: timezoneReader,
-		logger:         logger,
+		db:              db,
+		store:           store,
+		outboxStore:     outboxStore,
+		signer:          signer,
+		timezoneReader:  timezoneReader,
+		modelIDResolver: modelIDResolver,
+		logger:          logger,
 	}
 }
 
@@ -87,6 +96,12 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 	}
 	mqttPassword := hex.EncodeToString(mqttPasswordBytes)
 
+	modelID, err := s.modelIDResolver.DefaultModelID(ctx)
+	if err != nil {
+		s.logger.Error("activate: resolve default model", "device_id", deviceID, "error", err)
+		return ActivationResult{}, fmt.Errorf("resolve default model: %w", err)
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		s.logger.Error("activate: begin tx", "device_id", deviceID, "error", err)
@@ -94,7 +109,7 @@ func (s *ActivationService) Activate(ctx context.Context, code string) (Activati
 	}
 	defer tx.Rollback()
 
-	if err := s.store.Activate(ctx, tx, deviceID, mqttUsername, mqttPassword); err != nil {
+	if err := s.store.Activate(ctx, tx, deviceID, mqttUsername, mqttPassword, modelID); err != nil {
 		s.logger.Error("activate: store credentials", "device_id", deviceID, "error", err)
 		return ActivationResult{}, fmt.Errorf("activate device: %w", err)
 	}

--- a/internal/provisioning/activation_test.go
+++ b/internal/provisioning/activation_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/outbox"
 	"github.com/fishhub-oss/fishhub-server/internal/platform"
 	"github.com/fishhub-oss/fishhub-server/internal/provisioning"
@@ -38,7 +39,7 @@ func (s *stubProvisioningStore) ClaimCode(_ context.Context, _ string) (string, 
 	}
 	return s.claimedDeviceID, uid, s.claimErr
 }
-func (s *stubProvisioningStore) Activate(_ context.Context, _ *sql.Tx, _, _, _ string) error {
+func (s *stubProvisioningStore) Activate(_ context.Context, _ *sql.Tx, _, _, _, _ string) error {
 	return s.activateErr
 }
 
@@ -73,10 +74,19 @@ func (s *stubTimezoneReader) GetTimezone(_ context.Context, _ string) (string, e
 	return "UTC", nil
 }
 
+type stubModelIDResolver struct{ id string }
+
+func (s *stubModelIDResolver) DefaultModelID(_ context.Context) (string, error) {
+	if s.id == "" {
+		return "model-uuid", nil
+	}
+	return s.id, nil
+}
+
 func newActivationSvc(t *testing.T, store provisioning.Store, outboxStore outbox.Store, signer *stubSigner) *provisioning.ActivationService {
 	t.Helper()
 	db := testutil.NewTestDB(t)
-	return provisioning.NewActivationService(db, store, outboxStore, signer, &stubTimezoneReader{}, discardLogger)
+	return provisioning.NewActivationService(db, store, outboxStore, signer, &stubTimezoneReader{}, &stubModelIDResolver{}, discardLogger)
 }
 
 func TestActivationService_HappyPath(t *testing.T) {
@@ -92,7 +102,7 @@ func TestActivationService_HappyPath(t *testing.T) {
 		t.Fatalf("setup: get code: %v", err)
 	}
 
-	svc := provisioning.NewActivationService(db, provStore, outboxStore, &stubSigner{token: "jwt-tok"}, &stubTimezoneReader{}, discardLogger)
+	svc := provisioning.NewActivationService(db, provStore, outboxStore, &stubSigner{token: "jwt-tok"}, &stubTimezoneReader{}, devicemodel.NewStore(db), discardLogger)
 
 	result, err := svc.Activate(ctx, code)
 	if err != nil {
@@ -157,7 +167,7 @@ func TestActivationService_SignerError(t *testing.T) {
 	}
 
 	signErr := errors.New("signing key not configured")
-	svc := provisioning.NewActivationService(db, provStore, outboxStore, &stubSigner{err: signErr}, &stubTimezoneReader{}, discardLogger)
+	svc := provisioning.NewActivationService(db, provStore, outboxStore, &stubSigner{err: signErr}, &stubTimezoneReader{}, devicemodel.NewStore(db), discardLogger)
 
 	_, err = svc.Activate(ctx, code)
 	if !errors.Is(err, signErr) {

--- a/internal/provisioning/store.go
+++ b/internal/provisioning/store.go
@@ -15,8 +15,8 @@ type Store interface {
 	// ClaimCode marks the code used, creates a new device row, and returns the device ID and user ID.
 	// Returns ErrCodeNotFound if the code is unknown, ErrCodeAlreadyUsed if already claimed.
 	ClaimCode(ctx context.Context, code string) (deviceID, userID string, err error)
-	// Activate stores MQTT credentials on the device row within the provided transaction.
-	Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error
+	// Activate stores MQTT credentials and model_id on the device row within the provided transaction.
+	Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword, modelID string) error
 }
 
 type postgresStore struct {
@@ -105,7 +105,9 @@ func (s *postgresStore) ClaimCode(ctx context.Context, code string) (string, str
 
 	var deviceID string
 	if err := tx.QueryRowContext(ctx, `
-		INSERT INTO devices (user_id) VALUES ($1) RETURNING id
+		INSERT INTO devices (user_id, model_id)
+		VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1'))
+		RETURNING id
 	`, userID).Scan(&deviceID); err != nil {
 		return "", "", fmt.Errorf("insert device: %w", err)
 	}
@@ -122,10 +124,10 @@ func (s *postgresStore) ClaimCode(ctx context.Context, code string) (string, str
 	return deviceID, userID, nil
 }
 
-func (s *postgresStore) Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword string) error {
+func (s *postgresStore) Activate(ctx context.Context, tx *sql.Tx, deviceID, mqttUsername, mqttPassword, modelID string) error {
 	_, err := tx.ExecContext(ctx, `
-		UPDATE devices SET mqtt_username = $2, mqtt_password = $3 WHERE id = $1
-	`, deviceID, mqttUsername, mqttPassword)
+		UPDATE devices SET mqtt_username = $2, mqtt_password = $3, model_id = $4 WHERE id = $1
+	`, deviceID, mqttUsername, mqttPassword, modelID)
 	return err
 }
 

--- a/internal/provisioning/store_integration_test.go
+++ b/internal/provisioning/store_integration_test.go
@@ -135,7 +135,12 @@ func TestActivate_integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("begin tx: %v", err)
 		}
-		if err := store.Activate(ctx, tx, deviceID, "mqtt-user", "mqtt-pass"); err != nil {
+		var modelID string
+		if err := db.QueryRowContext(ctx, `SELECT id FROM device_models WHERE slug = 'fishhub-v1'`).Scan(&modelID); err != nil {
+			tx.Rollback()
+			t.Fatalf("resolve model: %v", err)
+		}
+		if err := store.Activate(ctx, tx, deviceID, "mqtt-user", "mqtt-pass", modelID); err != nil {
 			tx.Rollback()
 			t.Fatalf("activate: %v", err)
 		}

--- a/internal/trigger/store_integration_test.go
+++ b/internal/trigger/store_integration_test.go
@@ -21,7 +21,7 @@ func TestTriggerStore_integration(t *testing.T) {
 	// Insert a device.
 	var deviceID string
 	if err := db.QueryRowContext(ctx,
-		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+		`INSERT INTO devices (user_id, model_id) VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1')) RETURNING id`, userID,
 	).Scan(&deviceID); err != nil {
 		t.Fatalf("insert device: %v", err)
 	}

--- a/internal/trigger_events/store_integration_test.go
+++ b/internal/trigger_events/store_integration_test.go
@@ -18,7 +18,7 @@ func TestTriggerEventsStore_integration(t *testing.T) {
 
 	var deviceID string
 	if err := db.QueryRowContext(ctx,
-		`INSERT INTO devices (user_id) VALUES ($1) RETURNING id`, userID,
+		`INSERT INTO devices (user_id, model_id) VALUES ($1, (SELECT id FROM device_models WHERE slug = 'fishhub-v1')) RETURNING id`, userID,
 	).Scan(&deviceID); err != nil {
 		t.Fatalf("insert device: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fishhub-oss/fishhub-server/internal/auth"
 	"github.com/fishhub-oss/fishhub-server/internal/device"
 	"github.com/fishhub-oss/fishhub-server/internal/devicejwt"
+	"github.com/fishhub-oss/fishhub-server/internal/devicemodel"
 	"github.com/fishhub-oss/fishhub-server/internal/emqx"
 	"github.com/fishhub-oss/fishhub-server/internal/hivemq"
 	"github.com/fishhub-oss/fishhub-server/internal/jwtutil"
@@ -354,6 +355,7 @@ func main() {
 	// ── Stores & services ─────────────────────────────────────────────────────
 	deviceStore := device.NewStore(db)
 	peripheralStore := peripheral.NewStore(db)
+	deviceModelStore := devicemodel.NewStore(db)
 	triggerStore := trigger.NewStore(db)
 	provisioningStore := provisioning.NewStore(db)
 	outboxStore := outbox.NewPostgresStore(db)
@@ -363,7 +365,7 @@ func main() {
 	triggerSvc := trigger.NewService(db, triggerStore, outboxStore, logger)
 	provisioningSvc := provisioning.NewService(provisioningStore, logger)
 	activationSvc := provisioning.NewActivationService(db, provisioningStore, outboxStore, deviceSigner,
-		accountTimezoneReaderBridge{accountStore}, logger)
+		accountTimezoneReaderBridge{accountStore}, deviceModelStore, logger)
 
 	// ── MQTT readings subscription ────────────────────────────────────────────
 	readingsMQTTHandler := measurement.NewReadingsMQTTHandler(deviceStore, readingsSvc, logger)
@@ -452,7 +454,8 @@ func main() {
 		r.Patch("/api/devices/{id}", (&api.PatchDeviceHandler{Service: deviceSvc}).ServeHTTP)
 		r.Delete("/api/devices/{id}", (&api.DeleteDeviceHandler{Service: deviceSvc}).ServeHTTP)
 		r.Get("/api/devices/{id}/readings", (&api.ReadingsQueryHandler{Service: readingsSvc}).List)
-		r.Post("/api/devices/{id}/peripherals", (&api.CreatePeripheralHandler{Service: peripheralSvc}).ServeHTTP)
+		r.Get("/api/devices/{id}/model", (&api.DeviceModelHandler{Store: deviceModelStore}).ServeHTTP)
+		r.Post("/api/devices/{id}/peripherals", (&api.CreatePeripheralHandler{Service: peripheralSvc, ModelStore: deviceModelStore}).ServeHTTP)
 		r.Get("/api/devices/{id}/peripherals", (&api.ListPeripheralsHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Put("/api/devices/{id}/peripherals/{peripheralId}/schedule", (&api.SetPeripheralScheduleHandler{Service: peripheralSvc}).ServeHTTP)
 		r.Patch("/api/devices/{id}/peripherals/{peripheralId}", (&api.PatchPeripheralHandler{Service: peripheralSvc}).ServeHTTP)


### PR DESCRIPTION
## Summary

- Introduces `device_models` and `device_model_ports` tables (migrations 026–028) with a seeded `fishhub-v1` model (9 ports: TEMP, RELAY 1–4, ANALOG 1–4)
- `devices.model_id` is now NOT NULL (backfilled to `fishhub-v1` for existing rows); `peripherals.port_id` is nullable for backward compatibility
- Peripherals are registered via `port_id` instead of raw `pin`; the handler validates port exists, belongs to the device's model, and kind matches before calling the service
- Adds `GET /api/devices/{id}/model` returning the model and its ports
- `GET /api/devices/{id}/peripherals` and individual peripheral responses now include a `port` object (id, label, pin)
- `PATCH /api/devices/{id}/peripherals/{id}` drops the `pin` field (pin is immutable once set via port)
- All tests updated to use `port_id` and `model_id`; `ErrPinInUse` now maps to `ErrPortInUse` since port determines pin

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: `POST /api/devices/{id}/peripherals` with valid `port_id` creates peripheral
- [ ] Manual: duplicate `port_id` returns 409 `port_conflict`
- [ ] Manual: mismatched `kind` returns 400 `port_kind_mismatch`
- [ ] Manual: `GET /api/devices/{id}/model` returns model + ports JSON
- [ ] Manual: peripheral list/get includes `port` field

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)