### PR TITLE
Store and echo purpose field on peripheral

### DIFF
--- a/db/migrations/029_peripherals_add_purpose.down.sql
+++ b/db/migrations/029_peripherals_add_purpose.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE peripherals DROP COLUMN purpose;

--- a/db/migrations/029_peripherals_add_purpose.up.sql
+++ b/db/migrations/029_peripherals_add_purpose.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE peripherals ADD COLUMN purpose VARCHAR(64);

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -325,6 +325,7 @@ type PeripheralResponse struct {
 	Port        *PortResponse               `json:"port"`
 	Category    string                      `json:"category"`
 	ControlMode *string                     `json:"control_mode"`
+	Purpose     *string                     `json:"purpose"`
 	Schedule    []peripheral.ScheduleWindow `json:"schedule"`
 	LastReading *LastReadingResponse        `json:"last_reading"`
 	CreatedAt   string                      `json:"created_at"`
@@ -356,6 +357,7 @@ func peripheralResponse(p peripheral.Peripheral) PeripheralResponse {
 		Port:        port,
 		Category:    p.Category,
 		ControlMode: p.ControlMode,
+		Purpose:     p.Purpose,
 		Schedule:    schedule,
 		LastReading: lastReading,
 		CreatedAt:   p.CreatedAt.UTC().Format(time.RFC3339),
@@ -410,10 +412,11 @@ type CreatePeripheralHandler struct {
 }
 
 type createPeripheralRequest struct {
-	Name     string `json:"name"`
-	Kind     string `json:"kind"`
-	PortID   string `json:"port_id"`
-	Category string `json:"category"`
+	Name     string  `json:"name"`
+	Kind     string  `json:"kind"`
+	PortID   string  `json:"port_id"`
+	Category string  `json:"category"`
+	Purpose  *string `json:"purpose"`
 }
 
 func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -464,7 +467,7 @@ func (h *CreatePeripheralHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Category, port)
+	p, err := h.Service.Register(r.Context(), deviceID, claims.UserID, req.Name, req.Kind, req.Category, req.Purpose, port)
 	if err != nil {
 		if errors.Is(err, device.ErrNotFound) {
 			apierr.Write(w, http.StatusNotFound, "device_not_found", "device not found")

--- a/internal/api/peripheral_handler_test.go
+++ b/internal/api/peripheral_handler_test.go
@@ -30,6 +30,8 @@ func newPeripheral(name string) peripheral.Peripheral {
 	}
 }
 
+func strPtr(s string) *string { return &s }
+
 func newPeripheralService(t *testing.T, store *stubPeripheralStore, pub *stubPublisher) *peripheral.Service {
 	t.Helper()
 	return peripheral.NewService(testutil.NewTestDB(t), store, &stubOutboxStore{}, nil, pub, discardLogger)
@@ -207,6 +209,38 @@ func TestCreatePeripheralHandler(t *testing.T) {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 		assertErrorCode(t, rec, http.StatusNotFound, "device_not_found")
+	})
+
+	t.Run("purpose is stored and echoed in response", func(t *testing.T) {
+		p := newPeripheral("heater")
+		purpose := "heater"
+		p.Purpose = &purpose
+		store := &stubPeripheralStore{created: p}
+		svc := newPeripheralService(t, store, &stubPublisher{})
+		modelStore := &stubDeviceModelStore{
+			model: devicemodel.DeviceModel{ID: "model-1"},
+			port:  devicemodel.Port{ID: "port-1", Kind: "relay", Label: "RELAY 1", Pin: 16},
+		}
+		h := &api.CreatePeripheralHandler{Service: svc, ModelStore: modelStore}
+
+		body := `{"name":"heater","kind":"relay","port_id":"port-1","purpose":"heater"}`
+		req := withChiParam(
+			withClaims(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), "user-1"),
+			"id", "dev-1",
+		)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["purpose"] != "heater" {
+			t.Errorf("expected purpose=heater, got %v", resp["purpose"])
+		}
 	})
 }
 

--- a/internal/api/stubs_test.go
+++ b/internal/api/stubs_test.go
@@ -215,7 +215,7 @@ type stubPeripheralStore struct {
 	deleteErr      error
 }
 
-func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _, _ string, _ devicemodel.Port) (peripheral.Peripheral, error) {
+func (s *stubPeripheralStore) CreatePeripheral(_ context.Context, _ *sql.Tx, _, _, _, _, _ string, _ *string, _ devicemodel.Port) (peripheral.Peripheral, error) {
 	return s.created, s.createErr
 }
 func (s *stubPeripheralStore) ListPeripherals(_ context.Context, _, _ string) ([]peripheral.Peripheral, error) {

--- a/internal/peripheral/model.go
+++ b/internal/peripheral/model.go
@@ -22,6 +22,7 @@ type Peripheral struct {
 	Port        *Port   // nil for peripherals that pre-date the port model
 	Category    string  // "sensor" | "actuator"
 	ControlMode *string // nil for sensors; "automatic"|"manual" for actuators
+	Purpose     *string
 	Schedule    []ScheduleWindow
 	LastReading *measurement.Point
 	CreatedAt   time.Time

--- a/internal/peripheral/service.go
+++ b/internal/peripheral/service.go
@@ -20,11 +20,12 @@ const eventTypePeripheralPush = "peripheral.push"
 const peripheralPushClaimTimeoutSeconds = 30
 
 type peripheralPushPayload struct {
-	DeviceID string `json:"device_id"`
-	Name     string `json:"name"`
-	Op       string `json:"op"`
-	Kind     string `json:"kind,omitempty"`
-	Pin      int    `json:"pin,omitempty"`
+	DeviceID string  `json:"device_id"`
+	Name     string  `json:"name"`
+	Op       string  `json:"op"`
+	Kind     string  `json:"kind,omitempty"`
+	Pin      int     `json:"pin,omitempty"`
+	Purpose  *string `json:"purpose,omitempty"`
 }
 
 // Service orchestrates peripheral registration, listing, schedule updates, and deletion.
@@ -60,14 +61,14 @@ func NewService(
 
 // Register creates a new peripheral and enqueues a peripheral.push outbox event atomically.
 // port must already be validated (kind match, belongs to device model) by the caller.
-func (s *Service) Register(ctx context.Context, deviceID, userID, name, kind, category string, port devicemodel.Port) (Peripheral, error) {
+func (s *Service) Register(ctx context.Context, deviceID, userID, name, kind, category string, purpose *string, port devicemodel.Port) (Peripheral, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return Peripheral{}, fmt.Errorf("register peripheral: begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
-	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, category, port)
+	p, err := s.store.CreatePeripheral(ctx, tx, deviceID, userID, name, kind, category, purpose, port)
 	if err != nil {
 		if !errors.Is(err, ErrAlreadyExists) && !errors.Is(err, ErrPortInUse) {
 			s.logger.Error("register peripheral: create", "device_id", deviceID, "name", name, "error", err)
@@ -81,6 +82,7 @@ func (s *Service) Register(ctx context.Context, deviceID, userID, name, kind, ca
 		Op:       "create",
 		Kind:     kind,
 		Pin:      port.Pin,
+		Purpose:  purpose,
 	}, peripheralPushClaimTimeoutSeconds); err != nil {
 		s.logger.Error("register peripheral: enqueue push", "device_id", deviceID, "name", name, "error", err)
 		return Peripheral{}, fmt.Errorf("register peripheral: enqueue push: %w", err)

--- a/internal/peripheral/store.go
+++ b/internal/peripheral/store.go
@@ -19,7 +19,7 @@ type Store interface {
 	// Returns ErrAlreadyExists if an active peripheral with the same name exists.
 	// Returns ErrPortInUse if an active peripheral already occupies the port.
 	// category must be "sensor" or "actuator"; actuators get control_mode defaulted to "automatic".
-	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, port devicemodel.Port) (Peripheral, error)
+	CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, purpose *string, port devicemodel.Port) (Peripheral, error)
 	// ListPeripherals returns active (non-deleted) peripherals for the device owned by userID,
 	// each joined with its port (label, pin) when port_id is set.
 	// Returns an empty slice if the device does not exist or is not owned by userID.
@@ -51,7 +51,7 @@ func NewStore(db *sql.DB) Store {
 	return &postgresStore{db: db}
 }
 
-func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, port devicemodel.Port) (Peripheral, error) {
+func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, name, kind, category string, purpose *string, port devicemodel.Port) (Peripheral, error) {
 	var exists bool
 	err := s.db.QueryRowContext(ctx,
 		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL)`,
@@ -66,14 +66,16 @@ func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, device
 
 	var p Peripheral
 	var controlMode sql.NullString
+	var purposeOut sql.NullString
 	err = tx.QueryRowContext(ctx, `
-		INSERT INTO peripherals (device_id, name, kind, pin, port_id, category, control_mode)
+		INSERT INTO peripherals (device_id, name, kind, pin, port_id, category, control_mode, purpose)
 		VALUES ($1, $2, $3, $4, $5, $6,
-			CASE WHEN $6 = 'actuator' THEN 'automatic' ELSE NULL END)
-		RETURNING id, device_id, name, kind, pin, category, control_mode, created_at, updated_at
-	`, deviceID, name, kind, port.Pin, port.ID, category).Scan(
+			CASE WHEN $6 = 'actuator' THEN 'automatic' ELSE NULL END,
+			$7)
+		RETURNING id, device_id, name, kind, pin, category, control_mode, purpose, created_at, updated_at
+	`, deviceID, name, kind, port.Pin, port.ID, category, purpose).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-		&p.Category, &controlMode, &p.CreatedAt, &p.UpdatedAt,
+		&p.Category, &controlMode, &purposeOut, &p.CreatedAt, &p.UpdatedAt,
 	)
 	if err != nil {
 		switch uniqueViolationIndex(err) {
@@ -90,6 +92,9 @@ func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, device
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
 	}
+	if purposeOut.Valid {
+		p.Purpose = &purposeOut.String
+	}
 	p.Port = &Port{ID: port.ID, Label: port.Label, Pin: port.Pin}
 	return p, nil
 }
@@ -97,7 +102,7 @@ func (s *postgresStore) CreatePeripheral(ctx context.Context, tx *sql.Tx, device
 func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID string) ([]Peripheral, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
-		       p.schedule, p.created_at, p.updated_at,
+		       p.purpose, p.schedule, p.created_at, p.updated_at,
 		       dmp.id, dmp.label, dmp.pin
 		FROM peripherals p
 		JOIN devices d ON d.id = p.device_id
@@ -117,12 +122,13 @@ func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID st
 	for rows.Next() {
 		var p Peripheral
 		var controlMode sql.NullString
+		var purposeOut sql.NullString
 		var scheduleJSON []byte
 		var portID, portLabel sql.NullString
 		var portPin sql.NullInt64
 		if err := rows.Scan(
 			&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-			&p.Category, &controlMode, &scheduleJSON,
+			&p.Category, &controlMode, &purposeOut, &scheduleJSON,
 			&p.CreatedAt, &p.UpdatedAt,
 			&portID, &portLabel, &portPin,
 		); err != nil {
@@ -130,6 +136,9 @@ func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID st
 		}
 		if controlMode.Valid {
 			p.ControlMode = &controlMode.String
+		}
+		if purposeOut.Valid {
+			p.Purpose = &purposeOut.String
 		}
 		if scheduleJSON != nil {
 			if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
@@ -147,12 +156,13 @@ func (s *postgresStore) ListPeripherals(ctx context.Context, deviceID, userID st
 func (s *postgresStore) GetPeripheral(ctx context.Context, deviceID, userID, peripheralID string) (Peripheral, error) {
 	var p Peripheral
 	var controlMode sql.NullString
+	var purposeOut sql.NullString
 	var scheduleJSON []byte
 	var portID, portLabel sql.NullString
 	var portPin sql.NullInt64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
-		       p.schedule, p.created_at, p.updated_at,
+		       p.purpose, p.schedule, p.created_at, p.updated_at,
 		       dmp.id, dmp.label, dmp.pin
 		FROM peripherals p
 		JOIN devices d ON d.id = p.device_id
@@ -164,7 +174,7 @@ func (s *postgresStore) GetPeripheral(ctx context.Context, deviceID, userID, per
 		  AND d.deleted_at IS NULL
 	`, deviceID, userID, peripheralID).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-		&p.Category, &controlMode, &scheduleJSON,
+		&p.Category, &controlMode, &purposeOut, &scheduleJSON,
 		&p.CreatedAt, &p.UpdatedAt,
 		&portID, &portLabel, &portPin,
 	)
@@ -176,6 +186,9 @@ func (s *postgresStore) GetPeripheral(ctx context.Context, deviceID, userID, per
 	}
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
+	}
+	if purposeOut.Valid {
+		p.Purpose = &purposeOut.String
 	}
 	if scheduleJSON != nil {
 		if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
@@ -196,6 +209,7 @@ func (s *postgresStore) SetPeripheralSchedule(ctx context.Context, deviceID, use
 
 	var p Peripheral
 	var controlMode sql.NullString
+	var purposeOut sql.NullString
 	var scheduleOut []byte
 	err = s.db.QueryRowContext(ctx, `
 		UPDATE peripherals p
@@ -208,10 +222,10 @@ func (s *postgresStore) SetPeripheralSchedule(ctx context.Context, deviceID, use
 		  AND p.deleted_at IS NULL
 		  AND d.deleted_at IS NULL
 		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
-		          p.schedule, p.created_at, p.updated_at
+		          p.purpose, p.schedule, p.created_at, p.updated_at
 	`, scheduleJSON, userID, deviceID, peripheralID).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-		&p.Category, &controlMode, &scheduleOut,
+		&p.Category, &controlMode, &purposeOut, &scheduleOut,
 		&p.CreatedAt, &p.UpdatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -223,6 +237,9 @@ func (s *postgresStore) SetPeripheralSchedule(ctx context.Context, deviceID, use
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
 	}
+	if purposeOut.Valid {
+		p.Purpose = &purposeOut.String
+	}
 	if err := json.Unmarshal(scheduleOut, &p.Schedule); err != nil {
 		return Peripheral{}, fmt.Errorf("set peripheral schedule: unmarshal: %w", err)
 	}
@@ -232,6 +249,7 @@ func (s *postgresStore) SetPeripheralSchedule(ctx context.Context, deviceID, use
 func (s *postgresStore) SetControlMode(ctx context.Context, tx *sql.Tx, deviceID, userID, peripheralID, mode string) (Peripheral, error) {
 	var p Peripheral
 	var controlMode sql.NullString
+	var purposeOut sql.NullString
 	var scheduleJSON []byte
 	err := tx.QueryRowContext(ctx, `
 		UPDATE peripherals p
@@ -245,10 +263,10 @@ func (s *postgresStore) SetControlMode(ctx context.Context, tx *sql.Tx, deviceID
 		  AND p.deleted_at IS NULL
 		  AND d.deleted_at IS NULL
 		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode,
-		          p.schedule, p.created_at, p.updated_at
+		          p.purpose, p.schedule, p.created_at, p.updated_at
 	`, mode, userID, deviceID, peripheralID).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-		&p.Category, &controlMode, &scheduleJSON,
+		&p.Category, &controlMode, &purposeOut, &scheduleJSON,
 		&p.CreatedAt, &p.UpdatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -277,6 +295,9 @@ func (s *postgresStore) SetControlMode(ctx context.Context, tx *sql.Tx, deviceID
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
 	}
+	if purposeOut.Valid {
+		p.Purpose = &purposeOut.String
+	}
 	if scheduleJSON != nil {
 		if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {
 			return Peripheral{}, fmt.Errorf("set control mode: unmarshal schedule: %w", err)
@@ -288,6 +309,7 @@ func (s *postgresStore) SetControlMode(ctx context.Context, tx *sql.Tx, deviceID
 func (s *postgresStore) DeletePeripheral(ctx context.Context, tx *sql.Tx, deviceID, userID, peripheralID string) (Peripheral, error) {
 	var p Peripheral
 	var controlMode sql.NullString
+	var purposeOut sql.NullString
 	var schedule []byte
 	err := tx.QueryRowContext(ctx, `
 		UPDATE peripherals p
@@ -299,10 +321,10 @@ func (s *postgresStore) DeletePeripheral(ctx context.Context, tx *sql.Tx, device
 		  AND p.id = $3
 		  AND p.deleted_at IS NULL
 		  AND d.deleted_at IS NULL
-		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode, p.schedule, p.created_at, p.updated_at
+		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category, p.control_mode, p.purpose, p.schedule, p.created_at, p.updated_at
 	`, userID, deviceID, peripheralID).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-		&p.Category, &controlMode, &schedule, &p.CreatedAt, &p.UpdatedAt,
+		&p.Category, &controlMode, &purposeOut, &schedule, &p.CreatedAt, &p.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return Peripheral{}, ErrNotFound
@@ -313,6 +335,9 @@ func (s *postgresStore) DeletePeripheral(ctx context.Context, tx *sql.Tx, device
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
 	}
+	if purposeOut.Valid {
+		p.Purpose = &purposeOut.String
+	}
 	if err := json.Unmarshal(schedule, &p.Schedule); err != nil {
 		p.Schedule = []ScheduleWindow{}
 	}
@@ -322,6 +347,7 @@ func (s *postgresStore) DeletePeripheral(ctx context.Context, tx *sql.Tx, device
 func (s *postgresStore) UpdatePeripheral(ctx context.Context, deviceID, userID, peripheralID, name string) (Peripheral, error) {
 	var p Peripheral
 	var controlMode sql.NullString
+	var purposeOut sql.NullString
 	var scheduleJSON []byte
 	var portID sql.NullString
 	var portLabel sql.NullString
@@ -337,13 +363,13 @@ func (s *postgresStore) UpdatePeripheral(ctx context.Context, deviceID, userID, 
 		  AND p.deleted_at IS NULL
 		  AND d.deleted_at IS NULL
 		RETURNING p.id, p.device_id, p.name, p.kind, p.pin, p.category,
-		          p.control_mode, p.schedule, p.created_at, p.updated_at,
+		          p.control_mode, p.purpose, p.schedule, p.created_at, p.updated_at,
 		          p.port_id,
 		          (SELECT label FROM device_model_ports WHERE id = p.port_id),
 		          (SELECT pin   FROM device_model_ports WHERE id = p.port_id)
 	`, name, userID, deviceID, peripheralID).Scan(
 		&p.ID, &p.DeviceID, &p.Name, &p.Kind, &p.Pin,
-		&p.Category, &controlMode, &scheduleJSON,
+		&p.Category, &controlMode, &purposeOut, &scheduleJSON,
 		&p.CreatedAt, &p.UpdatedAt,
 		&portID, &portLabel, &portPin,
 	)
@@ -358,6 +384,9 @@ func (s *postgresStore) UpdatePeripheral(ctx context.Context, deviceID, userID, 
 	}
 	if controlMode.Valid {
 		p.ControlMode = &controlMode.String
+	}
+	if purposeOut.Valid {
+		p.Purpose = &purposeOut.String
 	}
 	if scheduleJSON != nil {
 		if err := json.Unmarshal(scheduleJSON, &p.Schedule); err != nil {

--- a/internal/peripheral/store_integration_test.go
+++ b/internal/peripheral/store_integration_test.go
@@ -54,7 +54,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("begin tx for light: %v", err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", relayPort)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", nil, relayPort)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("create light: %v", err)
@@ -69,7 +69,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("begin tx for temp: %v", err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "temp", "ds18b20", "sensor", tempPort)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "temp", "ds18b20", "sensor", nil, tempPort)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("create temp: %v", err)
@@ -150,7 +150,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", relay2Port)
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", nil, relay2Port)
 		if !errors.Is(err, peripheral.ErrAlreadyExists) {
 			t.Errorf("expected ErrAlreadyExists, got %v", err)
 		}
@@ -163,7 +163,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", "actuator", relayPort)
+		_, err = store.CreatePeripheral(ctx, tx, deviceID, userID, "pump", "relay", "actuator", nil, relayPort)
 		if !errors.Is(err, peripheral.ErrPortInUse) {
 			t.Errorf("expected ErrPortInUse, got %v", err)
 		}
@@ -176,7 +176,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		}
 		defer tx.Rollback()
 
-		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", "actuator", relay2Port)
+		_, err = store.CreatePeripheral(ctx, tx, "00000000-0000-0000-0000-000000000099", userID, "pump", "relay", "actuator", nil, relay2Port)
 		if !errors.Is(err, device.ErrNotFound) {
 			t.Errorf("expected device.ErrNotFound, got %v", err)
 		}
@@ -310,7 +310,7 @@ func TestPeripheralStore_integration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", relayPort)
+		p, err := store.CreatePeripheral(ctx, tx, deviceID, userID, "light", "relay", "actuator", nil, relayPort)
 		if err != nil {
 			tx.Rollback()
 			t.Fatalf("re-create after delete: %v", err)


### PR DESCRIPTION
## Summary

- Adds migration 029: `ALTER TABLE peripherals ADD COLUMN purpose VARCHAR(64)`
- Accepts optional `purpose` in `POST /api/devices/{id}/peripherals` request body
- Persists and returns `purpose` in all peripheral API responses (list, create, patch, set-schedule, set-control-mode)
- No server-side logic switches on the value — the UI decides what to do with it

## Test plan

- [ ] `TestCreatePeripheralHandler/purpose_is_stored_and_echoed_in_response` — new unit test verifies the field flows through handler → service → response
- [ ] Integration tests (`store_integration_test.go`) updated to pass `nil` purpose where not relevant; all pass
- [ ] `go test ./internal/api/... ./internal/peripheral/...` — green

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)