### PR TITLE
perf: speed up QueryLastReadings with tiered top-N scan

### DIFF
--- a/internal/measurement/influx_test.go
+++ b/internal/measurement/influx_test.go
@@ -200,6 +200,121 @@ func TestWriteAndQueryStringField_Integration(t *testing.T) {
 	}
 }
 
+func TestQueryLastReadings_Integration(t *testing.T) {
+	host := startInfluxDB(t)
+	createDatabase(t, host)
+
+	client, err := measurement.NewInfluxClient(host, testToken, testDatabase)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	ctx := context.Background()
+	const device = "last-readings-device"
+
+	// Timestamps relative to now so the 30-min recent window covers them.
+	now := time.Now().UTC().Truncate(time.Second)
+	writeAt := func(ts time.Time, fields map[string]any) {
+		t.Helper()
+		if err := client.WriteReading(ctx, measurement.Reading{
+			DeviceID:     device,
+			UserID:       "test-user",
+			Timestamp:    ts,
+			Measurements: fields,
+		}); err != nil {
+			t.Fatalf("write reading: %v", err)
+		}
+	}
+
+	// temperature written twice — newer value must win.
+	writeAt(now.Add(-10*time.Minute), map[string]any{"temperature": float64(20.0)})
+	writeAt(now.Add(-5*time.Minute), map[string]any{"ph": float64(7.2)})
+	writeAt(now.Add(-2*time.Minute), map[string]any{"temperature": float64(23.4)})
+
+	p, err := client.QueryLastReadings(ctx, device)
+	if err != nil {
+		t.Fatalf("query last readings: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected a point, got nil")
+	}
+	if p.Values["temperature"] != float64(23.4) {
+		t.Errorf("temperature: want 23.4 (latest), got %v", p.Values["temperature"])
+	}
+	if p.Values["ph"] != float64(7.2) {
+		t.Errorf("ph: want 7.2, got %v", p.Values["ph"])
+	}
+	// Timestamp is the newest row's timestamp.
+	if !p.Timestamp.Equal(now.Add(-2 * time.Minute)) {
+		t.Errorf("timestamp: want %v, got %v", now.Add(-2*time.Minute), p.Timestamp)
+	}
+}
+
+func TestQueryLastReadings_WideFallback_Integration(t *testing.T) {
+	host := startInfluxDB(t)
+	createDatabase(t, host)
+
+	client, err := measurement.NewInfluxClient(host, testToken, testDatabase)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	ctx := context.Background()
+	const device = "fallback-device"
+
+	// Only data is older than the 30-min recent window but within the 7-day window —
+	// must be found via the wide-window fallback pass.
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := client.WriteReading(ctx, measurement.Reading{
+		DeviceID:     device,
+		UserID:       "test-user",
+		Timestamp:    now.Add(-2 * time.Hour),
+		Measurements: map[string]any{"temperature": float64(18.5)},
+	}); err != nil {
+		t.Fatalf("write reading: %v", err)
+	}
+
+	p, err := client.QueryLastReadings(ctx, device)
+	if err != nil {
+		t.Fatalf("query last readings: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected a point from the wide-window fallback, got nil")
+	}
+	if p.Values["temperature"] != float64(18.5) {
+		t.Errorf("temperature: want 18.5, got %v", p.Values["temperature"])
+	}
+}
+
+func TestQueryLastReadings_NoData_Integration(t *testing.T) {
+	host := startInfluxDB(t)
+	createDatabase(t, host)
+
+	client, err := measurement.NewInfluxClient(host, testToken, testDatabase)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	ctx := context.Background()
+
+	// Seed the sensors table with an unrelated device so the table exists — mirrors
+	// production, where the table is always present and "no data" means no rows for
+	// this particular device (not a missing table).
+	if err := client.WriteReading(ctx, measurement.Reading{
+		DeviceID:     "some-other-device",
+		UserID:       "test-user",
+		Timestamp:    time.Now().UTC(),
+		Measurements: map[string]any{"temperature": float64(21.0)},
+	}); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	p, err := client.QueryLastReadings(ctx, "device-with-no-data")
+	if err != nil {
+		t.Fatalf("query last readings: %v", err)
+	}
+	if p != nil {
+		t.Errorf("expected nil for device with no data, got %+v", p)
+	}
+}
+
 func TestQueryReadings_Integration(t *testing.T) {
 	host := startInfluxDB(t)
 	createDatabase(t, host)

--- a/internal/measurement/store_influx.go
+++ b/internal/measurement/store_influx.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	influxdb3 "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
-	"github.com/apache/arrow-go/v18/arrow"
 )
 
 var reservedColumns = map[string]bool{"time": true, "device_id": true, "user_id": true}
@@ -42,69 +41,73 @@ func (c *influxDBClient) WriteReading(ctx context.Context, r Reading) error {
 }
 
 // QueryLastReadings returns a single Point containing the last known non-null
-// value for every field the device has ever written. Returns nil if the device has no data.
+// value for every field the device has written recently. Returns nil if the device
+// has no data within the widest lookback window.
 //
-// Two-step approach required by InfluxDB 3's schema-on-write model:
-//  1. SELECT * LIMIT 1 to discover which field columns actually exist.
-//  2. LAST_VALUE(field IGNORE NULLS) OVER () to get the latest value per field
-//     independently (different peripherals write at different timestamps).
+// Tiered lookback: the device deep-sleeps ~5 min between cycles, so the latest
+// reading is almost always within minutes. We try a short recent window first and
+// only widen to a long window when it comes back empty (a peripheral that has been
+// silent). Each pass is a single time-ordered top-N scan reduced in Go — far cheaper
+// than an unbounded LAST_VALUE(...) OVER () window function over the whole partition.
 func (c *influxDBClient) QueryLastReadings(ctx context.Context, deviceID string) (*Point, error) {
-	// Lookback window: covers any peripheral that has written at least once in the last 30 days.
-	// Bounding the scan is critical for performance — unbounded window functions scan all history.
-	const lookback = 7 * 24 * time.Hour
+	for _, lookback := range []time.Duration{30 * time.Minute, 7 * 24 * time.Hour} {
+		p, err := c.queryLastWithin(ctx, deviceID, lookback)
+		if err != nil {
+			return nil, err
+		}
+		if p != nil {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+
+// queryLastWithin scans the most recent rows within lookback, newest first, and
+// keeps the first non-null value seen per field. This reproduces
+// LAST_VALUE(field IGNORE NULLS) for every field independently: because rows are
+// ordered time-descending, the first non-null value encountered for a field is its
+// latest value. maxRows bounds the scan so a device that writes each peripheral on a
+// separate cycle still terminates; in the common case (all measurements written in one
+// point per cycle) the newest row already carries every field.
+func (c *influxDBClient) queryLastWithin(ctx context.Context, deviceID string, lookback time.Duration) (*Point, error) {
+	const maxRows = 200
 	since := time.Now().UTC().Add(-lookback).Format(time.RFC3339)
 
-	discoverSQL := fmt.Sprintf(
-		`SELECT * FROM sensors WHERE device_id = '%s' AND time >= '%s' ORDER BY time DESC LIMIT 1`,
-		deviceID, since,
+	sql := fmt.Sprintf(
+		`SELECT * FROM sensors WHERE device_id = '%s' AND time >= '%s' ORDER BY time DESC LIMIT %d`,
+		deviceID, since, maxRows,
 	)
-	iter, err := c.client.Query(ctx, discoverSQL)
-	if err != nil {
-		return nil, fmt.Errorf("influx query last readings (discover): %w", err)
-	}
-
-	var fields []string
-	for iter.Next() {
-		for k := range iter.Value() {
-			if !reservedColumns[k] {
-				fields = append(fields, k)
-			}
-		}
-		break
-	}
-	if len(fields) == 0 {
-		return nil, nil
-	}
-
-	selectCols := ""
-	for _, f := range fields {
-		selectCols += fmt.Sprintf(`, LAST_VALUE("%s" IGNORE NULLS) OVER () AS "%s"`, f, f)
-	}
-	lastSQL := fmt.Sprintf(
-		`SELECT MAX(time) OVER () AS time%s FROM sensors WHERE device_id = '%s' AND time >= '%s' LIMIT 1`,
-		selectCols,
-		deviceID,
-		since,
-	)
-	iter2, err := c.client.Query(ctx, lastSQL)
+	iter, err := c.client.Query(ctx, sql)
 	if err != nil {
 		return nil, fmt.Errorf("influx query last readings: %w", err)
 	}
 
+	var rows []map[string]any
+	for iter.Next() {
+		rows = append(rows, iter.Value())
+	}
+	return reduceLatest(rows), nil
+}
+
+// reduceLatest folds rows ordered newest-first into a single Point holding the
+// first non-null value seen for each field — equivalent to LAST_VALUE(field IGNORE
+// NULLS) per field, since the first non-null encountered in time-descending order is
+// the latest. The Point timestamp is the newest row's timestamp. Returns nil when no
+// field values are present.
+func reduceLatest(rows []map[string]any) *Point {
 	p := &Point{Values: make(map[string]any)}
-	for iter2.Next() {
-		row := iter2.Value()
-		// MAX(time) OVER () returns arrow.Timestamp (nanoseconds), not time.Time.
-		// The client only maps the literal "time" column to time.Time automatically.
-		switch tv := row["time"].(type) {
-		case time.Time:
-			p.Timestamp = tv.UTC()
-		case arrow.Timestamp:
-			p.Timestamp = tv.ToTime(arrow.Nanosecond).UTC()
+	for _, row := range rows {
+		if p.Timestamp.IsZero() {
+			if t, ok := row["time"].(time.Time); ok {
+				p.Timestamp = t.UTC()
+			}
 		}
 		for k, v := range row {
 			if reservedColumns[k] {
 				continue
+			}
+			if _, seen := p.Values[k]; seen {
+				continue // already captured a newer (non-null) value for this field
 			}
 			switch val := v.(type) {
 			case float64:
@@ -119,12 +122,11 @@ func (c *influxDBClient) QueryLastReadings(ctx context.Context, deviceID string)
 				p.Values[k] = val
 			}
 		}
-		break
 	}
 	if len(p.Values) == 0 {
-		return nil, nil
+		return nil
 	}
-	return p, nil
+	return p
 }
 
 func (c *influxDBClient) QueryReadings(ctx context.Context, q Query) ([]Point, error) {

--- a/internal/measurement/store_influx_internal_test.go
+++ b/internal/measurement/store_influx_internal_test.go
@@ -1,0 +1,117 @@
+package measurement
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReduceLatest(t *testing.T) {
+	t1 := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC) // newest
+	t2 := time.Date(2026, 6, 12, 9, 55, 0, 0, time.UTC)
+	t3 := time.Date(2026, 6, 12, 9, 50, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		rows       []map[string]any
+		wantTime   time.Time
+		wantValues map[string]any
+		wantNil    bool
+	}{
+		{
+			name:    "no rows",
+			rows:    nil,
+			wantNil: true,
+		},
+		{
+			name: "only reserved columns",
+			rows: []map[string]any{
+				{"time": t1, "device_id": "d", "user_id": "u"},
+			},
+			wantNil: true,
+		},
+		{
+			name: "single row, single field",
+			rows: []map[string]any{
+				{"time": t1, "device_id": "d", "user_id": "u", "ds18b20-4/temperature": float64(23.4)},
+			},
+			wantTime:   t1,
+			wantValues: map[string]any{"ds18b20-4/temperature": float64(23.4)},
+		},
+		{
+			name: "newest non-null per field wins",
+			rows: []map[string]any{
+				// newest first
+				{"time": t1, "ds18b20-4/temperature": float64(23.4)},
+				{"time": t2, "ds18b20-4/temperature": float64(20.0)},
+			},
+			wantTime:   t1,
+			wantValues: map[string]any{"ds18b20-4/temperature": float64(23.4)},
+		},
+		{
+			name: "fields spread across rows are all captured",
+			rows: []map[string]any{
+				{"time": t1, "ds18b20-4/temperature": float64(23.4)},
+				{"time": t2, "analog-32/ph": float64(7.2)},
+				{"time": t3, "ds18b20-4/temperature": float64(20.0), "analog-32/ph": float64(7.0)},
+			},
+			wantTime: t1,
+			wantValues: map[string]any{
+				"ds18b20-4/temperature": float64(23.4), // from t1, not the older t3
+				"analog-32/ph":          float64(7.2),  // from t2, not the older t3
+			},
+		},
+		{
+			name: "null gap: latest non-null is taken from an older row",
+			rows: []map[string]any{
+				// newest row has the field present but nil (sparse columnar write)
+				{"time": t1, "ds18b20-4/temperature": nil},
+				{"time": t2, "ds18b20-4/temperature": float64(21.1)},
+			},
+			wantTime:   t1, // timestamp is still the newest row
+			wantValues: map[string]any{"ds18b20-4/temperature": float64(21.1)},
+		},
+		{
+			name: "bool coerced to 1/0",
+			rows: []map[string]any{
+				{"time": t1, "relay-16/state": true, "relay-17/state": false},
+			},
+			wantTime:   t1,
+			wantValues: map[string]any{"relay-16/state": 1, "relay-17/state": 0},
+		},
+		{
+			name: "string field preserved",
+			rows: []map[string]any{
+				{"time": t1, "light-26/source": "schedule"},
+			},
+			wantTime:   t1,
+			wantValues: map[string]any{"light-26/source": "schedule"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reduceLatest(tt.rows)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected a Point, got nil")
+			}
+			if !got.Timestamp.Equal(tt.wantTime) {
+				t.Errorf("timestamp: want %v, got %v", tt.wantTime, got.Timestamp)
+			}
+			if len(got.Values) != len(tt.wantValues) {
+				t.Errorf("values: want %d entries %v, got %d entries %v",
+					len(tt.wantValues), tt.wantValues, len(got.Values), got.Values)
+			}
+			for k, want := range tt.wantValues {
+				if got.Values[k] != want {
+					t.Errorf("values[%q]: want %v, got %v", k, want, got.Values[k])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What & why

`GET /api/devices/{id}/peripherals` embeds each peripheral's latest reading via `measurement.QueryLastReadings`, which was the slow part of the request. The old implementation:

- made **two sequential InfluxDB round-trips** — a discover query (`SELECT * … LIMIT 1`) only to learn which field columns exist, then the real query;
- used **unbounded `LAST_VALUE(field IGNORE NULLS) OVER ()` window functions, one per field**, forcing a full sort/scan of the entire 7-day partition before `LIMIT 1` discarded almost all of it;
- **scanned 7 days** even though the latest reading is almost always seconds old.

## Change

- Single time-ordered top-N scan (`ORDER BY time DESC LIMIT N`) reduced in Go: keep the first non-null value seen per field — equivalent to `LAST_VALUE(… IGNORE NULLS)` since rows arrive newest-first.
- **Tiered lookback**: a short 30-min window first (deep-sleep is 5 min, so the latest reading is almost always recent), widening to 7 days only when the recent window is empty.
- Reduction extracted into `reduceLatest` for white-box unit testing.
- Dropped the now-unused `arrow` import.

No interface, handler, or response-shape changes — `Querier.QueryLastReadings` keeps its signature, so the API and peripheral layers are untouched. Caching was intentionally left out of scope.

## Tests

- White-box unit test for `reduceLatest` (8 cases: newest-non-null-per-field, fields spread across rows, null gaps, bool/string coercion, empty).
- Integration tests: recent-window hit, wide-window fallback, no-rows-for-device → nil.
- `measurement`, `api`, `peripheral` suites pass; `gofmt` clean.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)